### PR TITLE
Intent system + daily reading ritual (PRD #15)

### DIFF
--- a/apps/site/src/demo/DemoNewTabApp.tsx
+++ b/apps/site/src/demo/DemoNewTabApp.tsx
@@ -103,6 +103,10 @@ function mergeSettings(raw?: Partial<UserSettings>): UserSettings {
       raw.recommendationSource === "random" || raw.recommendationSource === "pinned"
         ? raw.recommendationSource
         : DEFAULT_DEMO_SETTINGS.recommendationSource,
+    dailyQueueSize:
+      typeof raw.dailyQueueSize === "number" && raw.dailyQueueSize >= 3 && raw.dailyQueueSize <= 10
+        ? raw.dailyQueueSize
+        : DEFAULT_DEMO_SETTINGS.dailyQueueSize,
   };
 }
 

--- a/apps/site/src/demo/fixtures.ts
+++ b/apps/site/src/demo/fixtures.ts
@@ -20,6 +20,7 @@ export const DEFAULT_DEMO_SETTINGS: UserSettings = {
   backgroundMode: "images",
   searchEngine: "google",
   recommendationSource: "random",
+  dailyQueueSize: 5,
 };
 
 interface BookmarkSeed {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,8 +21,6 @@ import {
   type ReturnSurface,
 } from "./lib/reader-navigation";
 import { resolveReaderRouteBookmarks } from "./lib/reader-route";
-import type { ReadingTab } from "./lib/reading-list";
-import { LS_READING_TAB } from "./lib/storage-keys";
 import { NewTabHome } from "./components/NewTabHome";
 import { BookmarkReader } from "./components/BookmarkReader";
 import { BookmarksList } from "./components/BookmarksList";
@@ -99,14 +97,6 @@ interface ExternalReaderState {
 }
 
 type AppView = "home" | "reading";
-
-function readStoredReadingTab(): ReadingTab {
-  const stored = localStorage.getItem(LS_READING_TAB);
-  if (stored === "unread" || stored === "continue" || stored === "read") {
-    return stored;
-  }
-  return "unread";
-}
 
 function openBookmarkInCurrentTab(tweetId: string, returnSurface: ReturnSurface) {
   window.location.assign(getReaderUrl(tweetId, undefined, returnSurface));
@@ -222,7 +212,6 @@ function NewTabRouteApp() {
     getNewTabView() === "reading" ? "reading" : "home"
   );
   const [settingsOpen, setSettingsOpen] = useState(false);
-  const [readingTab, setReadingTab] = useState<ReadingTab>(() => readStoredReadingTab());
   const [toast, setToast] = useState<ToastState | null>(null);
   const [isResetting, setIsResetting] = useState(false);
 
@@ -234,15 +223,6 @@ function NewTabRouteApp() {
     displayBookmarks,
     `${activeAccountId || "__none__"}:${displayBookmarks.length}:${offlineMode ? "offline" : "online"}`,
   );
-
-  const restoreReadingTab = useCallback(() => {
-    setReadingTab(readStoredReadingTab());
-  }, []);
-
-  const handleReadingTabChange = useCallback((tab: ReadingTab) => {
-    setReadingTab(tab);
-    localStorage.setItem(LS_READING_TAB, tab);
-  }, []);
 
   const notifySyncBlocked = useCallback((reason?: string, retryAfterMs?: number) => {
     const code = reason as SyncBlockedReason | undefined;
@@ -320,13 +300,12 @@ function NewTabRouteApp() {
     } catch {
     } finally {
       refreshContinueReading();
-      restoreReadingTab();
       setView("home");
       setSettingsOpen(false);
       setIsResetting(false);
       window.location.reload();
     }
-  }, [actions, isResetting, refreshContinueReading, restoreReadingTab]);
+  }, [actions, isResetting, refreshContinueReading]);
 
   useEffect(() => {
     actions.setReaderActive(false);
@@ -417,8 +396,6 @@ function NewTabRouteApp() {
       <BookmarksList
         continueReadingItems={continueReading}
         unreadBookmarks={allUnread}
-        activeTab={readingTab}
-        onTabChange={handleReadingTabChange}
         onOpenBookmark={openBookmarkFromReading}
         getBookmarkHref={getReadingBookmarkHref}
         onSync={handleSync}
@@ -441,10 +418,7 @@ function NewTabRouteApp() {
         getBookmarkHref={getHomeBookmarkHref}
         recommendationSource={settings.recommendationSource}
         onOpenSettings={() => setSettingsOpen(true)}
-        onOpenReading={() => {
-          restoreReadingTab();
-          setView("reading");
-        }}
+        onOpenReading={() => setView("reading")}
         isResetting={isResetting}
       />
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import {
   markReadingProgressUncompleted,
   getTweetDetailCache,
   getAllReadingProgress,
+  appendReadLogEntry,
 } from "./db";
 import { pickRelatedBookmarks } from "./lib/related";
 import { resetLocalData } from "./lib/reset";
@@ -672,6 +673,13 @@ function ReaderRouteApp() {
     });
   }, [actions, displayBookmark, localBookmark, localBookmarkSnapshot]);
 
+  const handleMarkAsRead = useCallback((tweetId: string) => {
+    void markReadingProgressCompleted(tweetId);
+    if (displayBookmark && displayBookmark.tweetId === tweetId) {
+      void appendReadLogEntry(displayBookmark.id);
+    }
+  }, [displayBookmark]);
+
   const bookmarkAction = !offlineMode && displayBookmark?.bookmarked
     ? {
       label:
@@ -711,7 +719,7 @@ function ReaderRouteApp() {
               : undefined
           }
           bookmarkAction={bookmarkAction}
-          onMarkAsRead={markReadingProgressCompleted}
+          onMarkAsRead={handleMarkAsRead}
           onMarkAsUnread={markReadingProgressUncompleted}
           loadDetail={
             externalReader?.status === "ready" && externalReader.bookmark

--- a/src/components/BookmarkReader.tsx
+++ b/src/components/BookmarkReader.tsx
@@ -7,18 +7,21 @@ import {
   SunIcon,
   MoonIcon,
 } from "@phosphor-icons/react";
-import type { Bookmark, Highlight, SelectionRange, ThreadTweet } from "../types";
+import type { Bookmark, BookmarkIntent, Highlight, SelectionRange, ThreadTweet } from "../types";
 import { cn } from "../lib/cn";
 import {
   useReaderAvailabilityState,
   useRuntimeActions,
 } from "../stores/selectors";
+import { setIntent } from "../db/intent-repo";
+import { runtimeStore } from "../stores/runtime-store";
 
 import { resolveTweetKind } from "./reader/utils";
 import { TweetContent } from "./reader/TweetContent";
 import { SelectionToolbar } from "./reader/SelectionToolbar";
 import { HighlightPopover } from "./reader/HighlightPopover";
 import { NotePopover } from "./reader/NotePopover";
+import { IntentTray } from "./reader/IntentTray";
 import { useReadingProgress } from "../hooks/useReadingProgress";
 import { useTheme } from "../hooks/useTheme";
 import { useHighlights } from "../hooks/useHighlights";
@@ -137,6 +140,7 @@ export function BookmarkReader({
     });
 
   const [notePanelState, setNotePanelState] = useState<NotePanelState | null>(null);
+  const [showIntentTray, setShowIntentTray] = useState(false);
 
   useEffect(() => {
     const container = articleRef.current;
@@ -193,8 +197,24 @@ export function BookmarkReader({
     } else {
       onMarkAsRead?.(bookmark.tweetId);
       setReadOverride(true);
+      setShowIntentTray(true);
     }
   }, [effectiveMarkedRead, onMarkAsRead, onMarkAsUnread, bookmark.tweetId]);
+
+  const handleIntentSelect = useCallback(
+    (intent: BookmarkIntent) => {
+      const now = new Date().toISOString();
+      runtimeStore.setState((state) => ({
+        bookmarks: state.bookmarks.map((b) =>
+          b.id === bookmark.id
+            ? { ...b, intent, intentSource: "manual" as const, intentAssignedAt: now }
+            : b,
+        ),
+      }));
+      void setIntent(bookmark.id, { intent, intentSource: "manual" });
+    },
+    [bookmark.id],
+  );
 
   const displayBookmark = useMemo(() => {
     if (!resolvedBookmark) return bookmark;
@@ -214,6 +234,7 @@ export function BookmarkReader({
   );
 
   useHotkeys("escape", (event) => {
+    if (showIntentTray) return;
     const target = event.target;
     if (target instanceof HTMLElement && target.closest("input, textarea, [contenteditable]")) {
       return;
@@ -221,7 +242,7 @@ export function BookmarkReader({
     onBack();
   }, {
     preventDefault: true,
-  }, [onBack]);
+  }, [onBack, showIntentTray]);
 
   useHotkeys("j, ArrowRight", () => {
     if (!nextHref) return;
@@ -427,6 +448,13 @@ export function BookmarkReader({
             }
             setNotePanelState(null);
           }}
+        />
+      )}
+
+      {showIntentTray && (
+        <IntentTray
+          onSelect={handleIntentSelect}
+          onDismiss={() => setShowIntentTray(false)}
         />
       )}
     </div>

--- a/src/components/BookmarksList.tsx
+++ b/src/components/BookmarksList.tsx
@@ -5,20 +5,27 @@ import { useHotkeys } from "react-hotkeys-hook";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   ArrowLeftIcon,
+  CaretDownIcon,
+  CaretRightIcon,
   CircleNotchIcon,
   DownloadSimpleIcon,
-  List,
+  FireSimpleIcon,
+  ListIcon,
   MagnifyingGlassIcon,
-  SquaresFour,
+  QueueIcon,
+  SquaresFourIcon,
 } from "@phosphor-icons/react";
 import type { Bookmark, BookmarkIntent } from "../types";
 import { setIntent } from "../db/intent-repo";
 import type { ContinueReadingItem } from "../hooks/useContinueReading";
+import { useDailyQueue } from "../hooks/useDailyQueue";
+import { useSettings } from "../hooks/useSettings";
+import { useStreak } from "../hooks/useStreak";
 import { useBookmarkSearch } from "../hooks/useBookmarkSearch";
-import { pickTitle, inferKindBadge } from "../lib/bookmark-utils";
+import { pickTitle, inferKindBadge, estimateReadingMinutes } from "../lib/bookmark-utils";
 import { cn } from "../lib/cn";
 import type { ReadingTab } from "../lib/reading-list";
-import { sortIndexToTimestamp } from "../lib/time";
+import { sortIndexToTimestamp, timeAgo } from "../lib/time";
 import { getAllBookmarks } from "../db";
 import { articleToMarkdown } from "../lib/export/article-to-markdown";
 import { downloadMarkdownFile } from "../lib/export/article-download";
@@ -74,7 +81,7 @@ const INTENT_DOT_STYLES: Record<BookmarkIntent, string> = {
 
 type IntentFilter = BookmarkIntent | "all";
 type FormatFilter = "all" | "threads" | "articles";
-type ViewMode = "browse" | "list";
+type ViewMode = "queue" | "browse" | "list";
 
 function getBookmarkTimestamp(bookmark: Bookmark): number | null {
   try {
@@ -95,6 +102,267 @@ const INTENT_PILL_CONFIG: { value: IntentFilter; label: string; countKey?: Bookm
   { value: "act_on", label: "act on", countKey: "act_on" },
 ];
 
+interface QueueViewProps {
+  queue: import("../types").DailyQueue | null;
+  queueBookmarks: Bookmark[];
+  loading: boolean;
+  streak: import("../lib/streak-tracker").StreakResult;
+  intentCounts: Record<BookmarkIntent, number>;
+  collapsedSections: Record<string, boolean>;
+  toggleSection: (section: string) => void;
+  getBookmarkHref: (bookmark: Bookmark) => string;
+  handleSetIntent: (bookmarkId: string, intent: BookmarkIntent, event: React.MouseEvent) => void;
+}
+
+function QueueRow({
+  bookmark,
+  getBookmarkHref,
+  handleSetIntent,
+}: {
+  bookmark: Bookmark;
+  getBookmarkHref: (bookmark: Bookmark) => string;
+  handleSetIntent: (bookmarkId: string, intent: BookmarkIntent, event: React.MouseEvent) => void;
+}) {
+  const age = timeAgo(bookmark.createdAt);
+  const minutes = estimateReadingMinutes(bookmark);
+  const kind = inferKindBadge(bookmark);
+
+  return (
+    <a
+      href={getBookmarkHref(bookmark)}
+      className="group/row relative flex w-full items-center gap-3 py-3 px-3 text-left no-underline transition-colors duration-150 hover:bg-surface-hover"
+    >
+      <div
+        className={cn(
+          "absolute left-0 top-1/2 h-8 w-[3px] -translate-y-1/2 rounded-r-sm",
+          INTENT_BORDER_COLORS[bookmark.intent ?? "unsorted"],
+        )}
+      />
+      <img
+        src={bookmark.author.profileImageUrl}
+        alt={`@${bookmark.author.screenName}`}
+        className="size-9 shrink-0 rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.1)]"
+      />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium leading-snug text-foreground">
+          {pickTitle(bookmark)}
+        </p>
+        <p className="mt-1 truncate text-xs text-muted/50">
+          <span>@{bookmark.author.screenName}</span>
+          <span className="text-muted/40"> &middot; {kind}</span>
+          <span className="text-muted/40"> &middot; {minutes} min</span>
+        </p>
+      </div>
+      <span className="shrink-0 text-2xs tabular-nums text-muted/40">
+        {age}
+      </span>
+      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/row:opacity-100">
+        {INTENT_LABELS.map(({ intent, label }) => (
+          <button
+            key={intent}
+            type="button"
+            onClick={(e) => handleSetIntent(bookmark.id, intent, e)}
+            className={cn(
+              "flex size-6 items-center justify-center rounded-full transition-[transform,opacity] hover:scale-125",
+              bookmark.intent === intent
+                ? "opacity-100"
+                : "opacity-60 hover:opacity-100",
+            )}
+            aria-label={`File as ${label}`}
+            title={label}
+          >
+            <span
+              className={cn(
+                "block size-2 rounded-full",
+                INTENT_DOT_STYLES[intent],
+                bookmark.intent === intent && "ring-1 ring-foreground/20",
+              )}
+            />
+          </button>
+        ))}
+      </div>
+    </a>
+  );
+}
+
+function QueueSection({
+  title,
+  dotClass,
+  count,
+  collapsed,
+  onToggle,
+  children,
+}: {
+  title: string;
+  dotClass: string;
+  count: number;
+  collapsed: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mb-4">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="mb-1 flex w-full items-center gap-2 py-1.5 text-left"
+      >
+        {collapsed ? (
+          <CaretRightIcon className="size-3 text-muted/50" />
+        ) : (
+          <CaretDownIcon className="size-3 text-muted/50" />
+        )}
+        <span className={cn("size-2 rounded-full", dotClass)} />
+        <span className="text-2xs font-medium uppercase tracking-extra-wide text-muted/40">
+          {title}
+        </span>
+        <span className="text-2xs tabular-nums text-muted/30">{count}</span>
+      </button>
+      {!collapsed && (
+        <div className="divide-y divide-border/30 overflow-hidden rounded-lg border border-border/50">
+          {children}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function QueueView({
+  queue,
+  queueBookmarks,
+  loading,
+  streak,
+  intentCounts,
+  collapsedSections,
+  toggleSection,
+  getBookmarkHref,
+  handleSetIntent,
+}: QueueViewProps) {
+  const completedCount = queue?.completedIds.length ?? 0;
+  const totalCount = queue?.bookmarkIds.length ?? 0;
+  const remaining = totalCount - completedCount;
+
+  const waitingForYou = queueBookmarks.filter(
+    (b) => (b.intent ?? "unsorted") === "read_soon",
+  );
+  const actOnItems = queueBookmarks.filter(
+    (b) => (b.intent ?? "unsorted") === "act_on",
+  );
+  const referenceCount = intentCounts.reference;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <CircleNotchIcon className="size-5 animate-spin text-muted/40" />
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-6 flex items-center justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h2 className="text-2xs font-medium uppercase tracking-extra-wide text-muted/40">
+              Today
+            </h2>
+            {totalCount > 0 && (
+              <span className="text-2xs tabular-nums text-muted/30">
+                {completedCount} / {totalCount}
+              </span>
+            )}
+          </div>
+          {remaining > 0 && (
+            <p className="mt-0.5 text-xs text-muted/50">
+              {remaining} more to finish
+            </p>
+          )}
+        </div>
+        <div
+          className={cn(
+            "flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium",
+            streak.earnedToday
+              ? "bg-accent-surface text-accent"
+              : "bg-surface-alt text-muted/60",
+          )}
+        >
+          <FireSimpleIcon
+            weight={streak.earnedToday ? "fill" : "regular"}
+            className="size-3.5"
+          />
+          <span className="tabular-nums">{streak.current} days</span>
+          {streak.earnedToday && (
+            <span className="text-accent/70">+1 today</span>
+          )}
+        </div>
+      </div>
+
+      {waitingForYou.length > 0 && (
+        <QueueSection
+          title="waiting for you"
+          dotClass="bg-accent"
+          count={waitingForYou.length}
+          collapsed={collapsedSections["waiting"] ?? false}
+          onToggle={() => toggleSection("waiting")}
+        >
+          {waitingForYou.map((bookmark) => (
+            <div key={bookmark.tweetId}>
+              <QueueRow
+                bookmark={bookmark}
+                getBookmarkHref={getBookmarkHref}
+                handleSetIntent={handleSetIntent}
+              />
+            </div>
+          ))}
+        </QueueSection>
+      )}
+
+      {actOnItems.length > 0 && (
+        <QueueSection
+          title="act on"
+          dotClass="bg-accent-700 dark:bg-accent-400"
+          count={actOnItems.length}
+          collapsed={collapsedSections["act_on"] ?? false}
+          onToggle={() => toggleSection("act_on")}
+        >
+          {actOnItems.map((bookmark) => (
+            <div key={bookmark.tweetId}>
+              <QueueRow
+                bookmark={bookmark}
+                getBookmarkHref={getBookmarkHref}
+                handleSetIntent={handleSetIntent}
+              />
+            </div>
+          ))}
+        </QueueSection>
+      )}
+
+      <QueueSection
+        title="reference library"
+        dotClass="bg-muted/50"
+        count={referenceCount}
+        collapsed={collapsedSections["reference"] ?? true}
+        onToggle={() => toggleSection("reference")}
+      >
+        <div className="px-3 py-3 text-xs text-muted/50">
+          {referenceCount} items filed as reference
+        </div>
+      </QueueSection>
+
+      {totalCount === 0 && (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <p className="text-balance text-lg text-muted">
+            No queue for today
+          </p>
+          <p className="mt-2 text-sm text-muted/60">
+            Items filed as Read soon or Act on will appear here
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function BookmarksList({
   continueReadingItems,
   unreadBookmarks,
@@ -108,8 +376,10 @@ export function BookmarksList({
   const runtimeOfflineMode = useIsOffline();
   const actions = useRuntimeActions();
   const offlineMode = offlineModeOverride ?? runtimeOfflineMode;
+  const { settings } = useSettings();
+  const streak = useStreak();
 
-  const [viewMode, setViewMode] = useState<ViewMode>("browse");
+  const [viewMode, setViewMode] = useState<ViewMode>("queue");
   const [intentFilter, setIntentFilter] = useState<IntentFilter>("all");
   const [formatFilter, setFormatFilter] = useState<FormatFilter>("all");
   const [focusedIndex, setFocusedIndex] = useState(-1);
@@ -136,6 +406,17 @@ export function BookmarksList({
     }
     return merged;
   }, [continueReadingItems, unreadBookmarks]);
+
+  const { queue, queueBookmarks, loading: queueLoading } = useDailyQueue(
+    allBookmarks,
+    settings.dailyQueueSize,
+  );
+
+  const [collapsedSections, setCollapsedSections] = useState<Record<string, boolean>>({});
+
+  const toggleSection = useCallback((section: string) => {
+    setCollapsedSections((prev) => ({ ...prev, [section]: !prev[section] }));
+  }, []);
 
   const { query, setQuery, results, isSearching } =
     useBookmarkSearch(allBookmarks);
@@ -468,6 +749,17 @@ export function BookmarksList({
               className="flex gap-0.5 rounded-md border border-border/70 p-0.5"
             >
               <Toggle
+                value="queue"
+                className={cn(
+                  "flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium transition-colors",
+                  "text-muted hover:text-foreground",
+                  "data-[pressed]:bg-surface-alt data-[pressed]:text-foreground",
+                )}
+              >
+                <QueueIcon className="size-3.5" />
+                Queue
+              </Toggle>
+              <Toggle
                 value="browse"
                 className={cn(
                   "flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium transition-colors",
@@ -475,7 +767,7 @@ export function BookmarksList({
                   "data-[pressed]:bg-surface-alt data-[pressed]:text-foreground",
                 )}
               >
-                <SquaresFour className="size-3.5" />
+                <SquaresFourIcon className="size-3.5" />
                 Browse
               </Toggle>
               <Toggle
@@ -486,7 +778,7 @@ export function BookmarksList({
                   "data-[pressed]:bg-surface-alt data-[pressed]:text-foreground",
                 )}
               >
-                <List className="size-3.5" />
+                <ListIcon className="size-3.5" />
                 List
               </Toggle>
             </ToggleGroup>
@@ -609,7 +901,19 @@ export function BookmarksList({
 
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
         <main className={cn(containerWidthClass, "mx-auto px-6 pb-16 pt-4")}>
-          {viewMode === "browse" ? (
+          {viewMode === "queue" ? (
+            <QueueView
+              queue={queue}
+              queueBookmarks={queueBookmarks}
+              loading={queueLoading}
+              streak={streak}
+              intentCounts={intentCounts}
+              collapsedSections={collapsedSections}
+              toggleSection={toggleSection}
+              getBookmarkHref={getBookmarkHref}
+              handleSetIntent={handleSetIntent}
+            />
+          ) : viewMode === "browse" ? (
             <>
               {!isFiltering && recentlySaved.length > 0 && (
                 <section className="mb-6">

--- a/src/components/BookmarksList.tsx
+++ b/src/components/BookmarksList.tsx
@@ -10,7 +10,8 @@ import {
   MagnifyingGlassIcon,
   PushPinIcon,
 } from "@phosphor-icons/react";
-import type { Bookmark } from "../types";
+import type { Bookmark, BookmarkIntent } from "../types";
+import { setIntent } from "../db/intent-repo";
 import type { ContinueReadingItem } from "../hooks/useContinueReading";
 import { useBookmarkSearch } from "../hooks/useBookmarkSearch";
 import { pickTitle, inferKindBadge } from "../lib/bookmark-utils";
@@ -43,6 +44,7 @@ import {
   useSyncButtonState,
   type SyncButtonState,
 } from "../stores/selectors";
+import { runtimeStore } from "../stores/runtime-store";
 import { Badge } from "./ui/Badge";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
@@ -97,6 +99,26 @@ function getBookmarkTimestamp(bookmark: Bookmark): number | null {
     return null;
   }
 }
+
+const INTENT_BORDER_COLORS: Record<BookmarkIntent, string> = {
+  read_soon: "bg-accent",
+  reference: "bg-muted/30",
+  act_on: "bg-accent-700 dark:bg-accent-400",
+  unsorted: "bg-transparent",
+};
+
+const INTENT_LABELS: { intent: BookmarkIntent; label: string }[] = [
+  { intent: "read_soon", label: "Read soon" },
+  { intent: "reference", label: "Reference" },
+  { intent: "act_on", label: "Act on" },
+];
+
+const INTENT_DOT_STYLES: Record<BookmarkIntent, string> = {
+  read_soon: "bg-accent",
+  reference: "bg-muted/50",
+  act_on: "bg-accent-700 dark:bg-accent-400",
+  unsorted: "",
+};
 
 export function BookmarksList({
   continueReadingItems,
@@ -537,6 +559,23 @@ export function BookmarksList({
     }
   }, []);
 
+  const handleSetIntent = useCallback(
+    (bookmarkId: string, intent: BookmarkIntent, event: React.MouseEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      const now = new Date().toISOString();
+      runtimeStore.setState((state) => ({
+        bookmarks: state.bookmarks.map((b) =>
+          b.id === bookmarkId
+            ? { ...b, intent, intentSource: "manual" as const, intentAssignedAt: now }
+            : b,
+        ),
+      }));
+      void setIntent(bookmarkId, { intent, intentSource: "manual" });
+    },
+    [],
+  );
+
   const hasItems = visibleBookmarks.length > 0;
 
   const renderEmptyState = () => {
@@ -854,13 +893,19 @@ export function BookmarksList({
                     <a
                       href={getBookmarkHref(bookmark)}
                       className={cn(
-                        "group/row flex w-full items-center gap-3 py-3 px-3 text-left no-underline transition-colors duration-150",
+                        "group/row relative flex w-full items-center gap-3 py-3 px-3 text-left no-underline transition-colors duration-150",
                         virtualItem.index % 2 === 0
                           ? "bg-surface-alt hover:bg-surface-hover"
                           : "hover:bg-surface-hover",
                         isFocused && "ring-1 ring-accent/20",
                       )}
                     >
+                      <div
+                        className={cn(
+                          "absolute left-0 top-1/2 h-8 w-[3px] -translate-y-1/2 rounded-r-sm",
+                          INTENT_BORDER_COLORS[bookmark.intent ?? "unsorted"],
+                        )}
+                      />
                       <img
                         src={bookmark.author.profileImageUrl}
                         alt={`@${bookmark.author.screenName}`}
@@ -934,6 +979,29 @@ export function BookmarksList({
                             </span>
                           )}
                         </p>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/row:opacity-100">
+                        {INTENT_LABELS.map(({ intent, label }) => (
+                          <button
+                            key={intent}
+                            type="button"
+                            onClick={(e) => handleSetIntent(bookmark.id, intent, e)}
+                            className={cn(
+                              "flex size-6 items-center justify-center rounded-full transition-[transform,opacity] hover:scale-125",
+                              bookmark.intent === intent ? "opacity-100" : "opacity-60 hover:opacity-100",
+                            )}
+                            aria-label={`File as ${label}`}
+                            title={label}
+                          >
+                            <span
+                              className={cn(
+                                "block size-2 rounded-full",
+                                INTENT_DOT_STYLES[intent],
+                                bookmark.intent === intent && "ring-1 ring-foreground/20",
+                              )}
+                            />
+                          </button>
+                        ))}
                       </div>
                       {activeTab === "unread" && (
                         <button

--- a/src/components/BookmarksList.tsx
+++ b/src/components/BookmarksList.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Tabs } from "@base-ui/react/tabs";
+import { ToggleGroup } from "@base-ui/react/toggle-group";
+import { Toggle } from "@base-ui/react/toggle";
 import { useHotkeys } from "react-hotkeys-hook";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import {
   ArrowLeftIcon,
-  ArrowsDownUpIcon,
   CircleNotchIcon,
   DownloadSimpleIcon,
+  List,
   MagnifyingGlassIcon,
-  PushPinIcon,
+  SquaresFour,
 } from "@phosphor-icons/react";
 import type { Bookmark, BookmarkIntent } from "../types";
 import { setIntent } from "../db/intent-repo";
@@ -16,40 +17,21 @@ import type { ContinueReadingItem } from "../hooks/useContinueReading";
 import { useBookmarkSearch } from "../hooks/useBookmarkSearch";
 import { pickTitle, inferKindBadge } from "../lib/bookmark-utils";
 import { cn } from "../lib/cn";
-import { NEW_BADGE_CUTOFF_MS } from "../lib/constants";
-import {
-  getPinnedTweetIds,
-  getPinnedTweetIdsOrdered,
-  togglePin,
-  subscribeToPinChanges,
-} from "../lib/pins";
-import {
-  readStoredReadingSortPreferences,
-  sortContinueReadingItems,
-  sortUnreadBookmarks,
-  writeStoredReadingSortPreferences,
-  type ReadingSort,
-  type ReadingSortPreferences,
-  type ReadingTab,
-} from "../lib/reading-list";
-import { sortIndexToTimestamp, timeAgo } from "../lib/time";
-import { getAllBookmarks, getHighlightCountsByTweetIds, type HighlightCounts } from "../db";
+import type { ReadingTab } from "../lib/reading-list";
+import { sortIndexToTimestamp } from "../lib/time";
+import { getAllBookmarks } from "../db";
 import { articleToMarkdown } from "../lib/export/article-to-markdown";
 import { downloadMarkdownFile } from "../lib/export/article-download";
 import { resolveReaderExportArticle } from "../lib/export/tweet-export";
-import { subscribeToReaderActivity } from "../lib/reader-activity";
 import {
   useIsOffline,
   useRuntimeActions,
-  useSyncButtonState,
   type SyncButtonState,
 } from "../stores/selectors";
 import { runtimeStore } from "../stores/runtime-store";
-import { Badge } from "./ui/Badge";
 import { Button } from "./ui/Button";
 import { Input } from "./ui/Input";
 import { OfflineBanner } from "./ui/OfflineBanner";
-import { Select, type SelectOption } from "./ui/Select";
 import { Toast } from "./ui/Toast";
 
 export type { ReadingTab } from "../lib/reading-list";
@@ -57,8 +39,8 @@ export type { ReadingTab } from "../lib/reading-list";
 interface Props {
   continueReadingItems: ContinueReadingItem[];
   unreadBookmarks: Bookmark[];
-  activeTab: ReadingTab;
-  onTabChange: (tab: ReadingTab) => void;
+  activeTab?: ReadingTab;
+  onTabChange?: (tab: ReadingTab) => void;
   onOpenBookmark: (bookmark: Bookmark) => void;
   getBookmarkHref: (bookmark: Bookmark) => string;
   onSync: () => void;
@@ -68,37 +50,7 @@ interface Props {
   onLogin?: () => void;
 }
 
-interface BookmarkRow {
-  bookmark: Bookmark;
-  subtitle?: string;
-}
-
-const SORT_OPTIONS: SelectOption[] = [
-  { value: "recent", label: "Recent" },
-  { value: "oldest", label: "Oldest" },
-  { value: "annotated", label: "Annotated" },
-];
-
 const ITEM_HEIGHT = 64;
-
-function isReadingSort(value: string): value is ReadingSort {
-  return value === "recent" || value === "oldest" || value === "annotated";
-}
-
-function getCounts(
-  counts: ReadonlyMap<string, HighlightCounts>,
-  tweetId: string,
-): HighlightCounts | null {
-  return counts.get(tweetId) ?? null;
-}
-
-function getBookmarkTimestamp(bookmark: Bookmark): number | null {
-  try {
-    return sortIndexToTimestamp(bookmark.sortIndex);
-  } catch {
-    return null;
-  }
-}
 
 const INTENT_BORDER_COLORS: Record<BookmarkIntent, string> = {
   read_soon: "bg-accent",
@@ -120,54 +72,52 @@ const INTENT_DOT_STYLES: Record<BookmarkIntent, string> = {
   unsorted: "",
 };
 
+type IntentFilter = BookmarkIntent | "all";
+type FormatFilter = "all" | "threads" | "articles";
+type ViewMode = "browse" | "list";
+
+function getBookmarkTimestamp(bookmark: Bookmark): number | null {
+  try {
+    return sortIndexToTimestamp(bookmark.sortIndex);
+  } catch {
+    return null;
+  }
+}
+
+function formatOldestDate(date: Date): string {
+  return date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+const INTENT_PILL_CONFIG: { value: IntentFilter; label: string; countKey?: BookmarkIntent }[] = [
+  { value: "all", label: "all" },
+  { value: "read_soon", label: "read soon", countKey: "read_soon" },
+  { value: "reference", label: "reference", countKey: "reference" },
+  { value: "act_on", label: "act on", countKey: "act_on" },
+];
+
 export function BookmarksList({
   continueReadingItems,
   unreadBookmarks,
-  activeTab,
-  onTabChange,
   onOpenBookmark,
   getBookmarkHref,
-  onSync,
   onBack,
-  syncButtonStateOverride,
   offlineModeOverride,
   onLogin,
 }: Props) {
   const containerWidthClass = "max-w-3xl";
-  const runtimeSyncButton = useSyncButtonState();
   const runtimeOfflineMode = useIsOffline();
   const actions = useRuntimeActions();
-  const syncButton = syncButtonStateOverride ?? runtimeSyncButton;
   const offlineMode = offlineModeOverride ?? runtimeOfflineMode;
+
+  const [viewMode, setViewMode] = useState<ViewMode>("browse");
+  const [intentFilter, setIntentFilter] = useState<IntentFilter>("all");
+  const [formatFilter, setFormatFilter] = useState<FormatFilter>("all");
   const [focusedIndex, setFocusedIndex] = useState(-1);
-  const [sortPreferences, setSortPreferences] =
-    useState<ReadingSortPreferences>(() => readStoredReadingSortPreferences());
-  const [pinnedIds, setPinnedIds] = useState(() => getPinnedTweetIds());
-  const [pinnedOrder, setPinnedOrder] = useState(() =>
-    getPinnedTweetIdsOrdered(),
-  );
   const [toastMessage, setToastMessage] = useState<string | null>(null);
-  const [showUnpinButtons, setShowUnpinButtons] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
   const searchInputRef = useRef<HTMLInputElement>(null);
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const pinnedCardRefs = useRef<Map<number, HTMLAnchorElement>>(new Map());
-
-  useEffect(() => {
-    setFocusedIndex(-1);
-  }, [activeTab]);
-
-  useEffect(() => {
-    return subscribeToPinChanges(() => {
-      setPinnedIds(getPinnedTweetIds());
-      setPinnedOrder(getPinnedTweetIdsOrdered());
-    });
-  }, []);
-
-  useEffect(() => {
-    if (!showUnpinButtons) return;
-    const timer = setTimeout(() => setShowUnpinButtons(false), 3000);
-    return () => clearTimeout(timer);
-  }, [showUnpinButtons]);
 
   const allBookmarks = useMemo(() => {
     const seen = new Set<string>();
@@ -190,10 +140,90 @@ export function BookmarksList({
   const { query, setQuery, results, isSearching } =
     useBookmarkSearch(allBookmarks);
 
-  const matchingIds = useMemo(() => {
-    if (!isSearching) return null;
-    return new Set(results.map((bookmark) => bookmark.tweetId));
-  }, [isSearching, results]);
+  const intentCounts = useMemo(() => {
+    const counts: Record<BookmarkIntent, number> = {
+      read_soon: 0,
+      reference: 0,
+      act_on: 0,
+      unsorted: 0,
+    };
+    for (const b of allBookmarks) {
+      counts[b.intent ?? "unsorted"]++;
+    }
+    return counts;
+  }, [allBookmarks]);
+
+  const formatCounts = useMemo(() => {
+    let threads = 0;
+    let articles = 0;
+    for (const b of allBookmarks) {
+      if (b.tweetKind === "thread" || b.isThread) threads++;
+      if (b.tweetKind === "article") articles++;
+    }
+    return { threads, articles };
+  }, [allBookmarks]);
+
+  const filteredBookmarks = useMemo(() => {
+    let list = isSearching ? results : allBookmarks;
+    if (intentFilter !== "all") {
+      list = list.filter((b) => (b.intent ?? "unsorted") === intentFilter);
+    }
+    if (formatFilter === "threads") {
+      list = list.filter((b) => b.tweetKind === "thread" || b.isThread);
+    } else if (formatFilter === "articles") {
+      list = list.filter((b) => b.tweetKind === "article");
+    }
+    return [...list].sort((a, b) => {
+      const tsA = getBookmarkTimestamp(a) ?? 0;
+      const tsB = getBookmarkTimestamp(b) ?? 0;
+      return tsB - tsA;
+    });
+  }, [allBookmarks, results, isSearching, intentFilter, formatFilter]);
+
+  const recentlySaved = useMemo(() => {
+    const sorted = [...allBookmarks].sort((a, b) => {
+      const tsA = getBookmarkTimestamp(a) ?? 0;
+      const tsB = getBookmarkTimestamp(b) ?? 0;
+      return tsB - tsA;
+    });
+    return sorted.slice(0, 5);
+  }, [allBookmarks]);
+
+  const fromAYearAgo = useMemo(() => {
+    const now = new Date();
+    const oneYearAgo = new Date(
+      now.getFullYear() - 1,
+      now.getMonth(),
+      now.getDate(),
+    );
+    const windowMs = 3 * 24 * 60 * 60 * 1000;
+    const windowStart = oneYearAgo.getTime() - windowMs;
+    const windowEnd = oneYearAgo.getTime() + windowMs;
+    return allBookmarks.filter((b) => {
+      return b.createdAt >= windowStart && b.createdAt <= windowEnd;
+    });
+  }, [allBookmarks]);
+
+  const oldestDate = useMemo(() => {
+    let oldest = Infinity;
+    for (const b of allBookmarks) {
+      const ts = getBookmarkTimestamp(b);
+      if (ts !== null && ts < oldest) oldest = ts;
+    }
+    if (!Number.isFinite(oldest)) return null;
+    return new Date(oldest);
+  }, [allBookmarks]);
+
+  useEffect(() => {
+    setFocusedIndex(-1);
+  }, [intentFilter, formatFilter, viewMode]);
+
+  const virtualizer = useVirtualizer({
+    count: filteredBookmarks.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => ITEM_HEIGHT,
+    overscan: 10,
+  });
 
   useHotkeys(
     "/",
@@ -203,208 +233,13 @@ export function BookmarksList({
     { preventDefault: true },
   );
 
-  const { inProgress, completed } = useMemo(() => {
-    const nextInProgress: ContinueReadingItem[] = [];
-    const nextCompleted: ContinueReadingItem[] = [];
-    for (const item of continueReadingItems) {
-      if (item.progress.completed) {
-        nextCompleted.push(item);
-      } else {
-        nextInProgress.push(item);
-      }
-    }
-    return { inProgress: nextInProgress, completed: nextCompleted };
-  }, [continueReadingItems]);
-
-  const newBookmarkIds = useMemo(() => {
-    const cutoff = Date.now() - NEW_BADGE_CUTOFF_MS;
-    const ids = new Set<string>();
-    const merged = [
-      ...unreadBookmarks,
-      ...continueReadingItems.map((item) => item.bookmark),
-    ];
-    for (const bookmark of merged) {
-      const timestamp = getBookmarkTimestamp(bookmark);
-      if (
-        timestamp !== null &&
-        bookmark.sortIndex !== bookmark.tweetId &&
-        timestamp >= cutoff
-      ) {
-        ids.add(bookmark.tweetId);
-      }
-    }
-    return ids;
-  }, [unreadBookmarks, continueReadingItems]);
-
-  const [highlightCounts, setHighlightCounts] = useState<
-    Map<string, HighlightCounts>
-  >(new Map());
-
-  const visibleTweetIds = useMemo(() => {
-    if (activeTab === "continue") {
-      return continueReadingItems
-        .filter((item) => !item.progress.completed)
-        .map((item) => item.bookmark.tweetId);
-    }
-    if (activeTab === "read") {
-      return continueReadingItems
-        .filter((item) => item.progress.completed)
-        .map((item) => item.bookmark.tweetId);
-    }
-    return unreadBookmarks.map((bookmark) => bookmark.tweetId);
-  }, [activeTab, continueReadingItems, unreadBookmarks]);
-
-  const refreshHighlightCounts = useCallback(() => {
-    const tweetIds = visibleTweetIds;
-    if (tweetIds.length === 0) {
-      setHighlightCounts(new Map());
-      return;
-    }
-
-    let cancelled = false;
-    getHighlightCountsByTweetIds(tweetIds)
-      .then((counts) => {
-        if (!cancelled) setHighlightCounts(counts);
-      })
-      .catch(() => {
-        if (!cancelled) setHighlightCounts(new Map());
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [visibleTweetIds]);
-
-  useEffect(() => {
-    return refreshHighlightCounts();
-  }, [refreshHighlightCounts]);
-
-  useEffect(() => {
-    return subscribeToReaderActivity(() => {
-      refreshHighlightCounts();
-    });
-  }, [refreshHighlightCounts]);
-
-  const { filteredUnread, filteredInProgress, filteredCompleted } =
-    useMemo(() => {
-      if (!matchingIds) {
-        return {
-          filteredUnread: unreadBookmarks,
-          filteredInProgress: inProgress,
-          filteredCompleted: completed,
-        };
-      }
-      return {
-        filteredUnread: unreadBookmarks.filter((b) =>
-          matchingIds.has(b.tweetId),
-        ),
-        filteredInProgress: inProgress.filter((item) =>
-          matchingIds.has(item.bookmark.tweetId),
-        ),
-        filteredCompleted: completed.filter((item) =>
-          matchingIds.has(item.bookmark.tweetId),
-        ),
-      };
-    }, [unreadBookmarks, inProgress, completed, matchingIds]);
-
-  const sortedUnread = useMemo(
-    () =>
-      sortUnreadBookmarks(
-        filteredUnread,
-        sortPreferences.unread,
-        highlightCounts,
-      ),
-    [filteredUnread, sortPreferences.unread, highlightCounts],
+  useHotkeys(
+    "mod+k",
+    () => {
+      searchInputRef.current?.focus();
+    },
+    { preventDefault: true },
   );
-
-  const sortedInProgress = useMemo(
-    () =>
-      sortContinueReadingItems(
-        filteredInProgress,
-        sortPreferences.continue,
-        highlightCounts,
-      ),
-    [filteredInProgress, sortPreferences.continue, highlightCounts],
-  );
-
-  const sortedCompleted = useMemo(
-    () =>
-      sortContinueReadingItems(
-        filteredCompleted,
-        sortPreferences.read,
-        highlightCounts,
-      ),
-    [filteredCompleted, sortPreferences.read, highlightCounts],
-  );
-
-  const activeSort = sortPreferences[activeTab];
-
-  const bookmarkRows: BookmarkRow[] = useMemo(() => {
-    if (activeTab === "continue") {
-      return sortedInProgress.map(({ bookmark, progress }) => ({
-        bookmark,
-        subtitle: `Last read ${timeAgo(progress.lastReadAt)}`,
-      }));
-    }
-    if (activeTab === "read") {
-      return sortedCompleted.map(({ bookmark, progress }) => ({
-        bookmark,
-        subtitle: `Finished ${timeAgo(progress.lastReadAt)}`,
-      }));
-    }
-    return sortedUnread.map((bookmark) => ({ bookmark }));
-  }, [activeTab, sortedUnread, sortedInProgress, sortedCompleted]);
-
-  const pinnedBookmarks = useMemo(() => {
-    if (pinnedIds.size === 0) return [];
-    const rowByTweetId = new Map<string, BookmarkRow>();
-    for (const row of bookmarkRows) {
-      rowByTweetId.set(row.bookmark.tweetId, row);
-    }
-    const result: BookmarkRow[] = [];
-    for (const id of pinnedOrder) {
-      const row = rowByTweetId.get(id);
-      if (row) result.push(row);
-    }
-    return result;
-  }, [bookmarkRows, pinnedIds, pinnedOrder]);
-
-  const pinnedCount = pinnedBookmarks.length;
-  const visiblePinnedCount = activeTab === "unread" ? pinnedCount : 0;
-
-  const unpinnedRows = useMemo(
-    () => activeTab === "unread"
-      ? bookmarkRows.filter((r) => !pinnedIds.has(r.bookmark.tweetId))
-      : bookmarkRows,
-    [activeTab, bookmarkRows, pinnedIds],
-  );
-
-  const visibleBookmarks = useMemo(() => {
-    const unpinned = unpinnedRows.map((r) => r.bookmark);
-    if (activeTab !== "unread") return unpinned;
-    const pinned = pinnedBookmarks.map((r) => r.bookmark);
-    return [...pinned, ...unpinned];
-  }, [activeTab, pinnedBookmarks, unpinnedRows]);
-
-  const virtualizer = useVirtualizer({
-    count: unpinnedRows.length,
-    getScrollElement: () => scrollContainerRef.current,
-    estimateSize: () => ITEM_HEIGHT,
-    overscan: 10,
-  });
-
-  useEffect(() => {
-    if (focusedIndex < 0) return;
-    if (focusedIndex < visiblePinnedCount) {
-      const el = pinnedCardRefs.current.get(focusedIndex);
-      if (el) el.scrollIntoView({ block: "nearest" });
-    } else {
-      const unpinnedIndex = focusedIndex - visiblePinnedCount;
-      if (unpinnedIndex < unpinnedRows.length) {
-        virtualizer.scrollToIndex(unpinnedIndex, { align: "auto" });
-      }
-    }
-  }, [focusedIndex, visiblePinnedCount, unpinnedRows.length, virtualizer]);
 
   const ignoreListHotkeys = useCallback((event: KeyboardEvent) => {
     const target = event.target;
@@ -416,27 +251,15 @@ export function BookmarksList({
     );
   }, []);
 
-  const handleSortChange = useCallback(
-    (nextSort: string) => {
-      if (!isReadingSort(nextSort)) return;
-      setSortPreferences((current) => {
-        const next = { ...current, [activeTab]: nextSort };
-        writeStoredReadingSortPreferences(next);
-        return next;
-      });
-    },
-    [activeTab],
-  );
-
   useHotkeys(
     "j, ArrowDown",
     () => {
       setFocusedIndex((prev) =>
-        prev < visibleBookmarks.length - 1 ? prev + 1 : prev,
+        prev < filteredBookmarks.length - 1 ? prev + 1 : prev,
       );
     },
     { preventDefault: true, ignoreEventWhen: ignoreListHotkeys },
-    [visibleBookmarks.length],
+    [filteredBookmarks.length],
   );
 
   useHotkeys(
@@ -450,12 +273,12 @@ export function BookmarksList({
   useHotkeys(
     "enter, space",
     () => {
-      if (focusedIndex >= 0 && focusedIndex < visibleBookmarks.length) {
-        onOpenBookmark(visibleBookmarks[focusedIndex]);
+      if (focusedIndex >= 0 && focusedIndex < filteredBookmarks.length) {
+        onOpenBookmark(filteredBookmarks[focusedIndex]);
       }
     },
     { preventDefault: true, ignoreEventWhen: ignoreListHotkeys },
-    [focusedIndex, visibleBookmarks, onOpenBookmark],
+    [focusedIndex, filteredBookmarks, onOpenBookmark],
   );
 
   useHotkeys(
@@ -465,61 +288,11 @@ export function BookmarksList({
     [onBack],
   );
 
-  const tabOrder: ReadingTab[] = ["unread", "continue", "read"];
-
-  useHotkeys(
-    "tab",
-    () => {
-      const idx = tabOrder.indexOf(activeTab);
-      onTabChange(tabOrder[(idx + 1) % tabOrder.length]);
-    },
-    { preventDefault: true, ignoreEventWhen: ignoreListHotkeys },
-    [activeTab, onTabChange],
-  );
-
-  useHotkeys(
-    "ArrowRight",
-    () => {
-      const idx = tabOrder.indexOf(activeTab);
-      if (idx < tabOrder.length - 1) onTabChange(tabOrder[idx + 1]);
-    },
-    { preventDefault: true, ignoreEventWhen: ignoreListHotkeys },
-    [activeTab, onTabChange],
-  );
-
-  useHotkeys(
-    "ArrowLeft",
-    () => {
-      const idx = tabOrder.indexOf(activeTab);
-      if (idx > 0) onTabChange(tabOrder[idx - 1]);
-    },
-    { preventDefault: true, ignoreEventWhen: ignoreListHotkeys },
-    [activeTab, onTabChange],
-  );
-
-  const showSyncControls = syncButton.visible;
-
-  const unreadIdSet = useMemo(
-    () => new Set(unreadBookmarks.map((b) => b.tweetId)),
-    [unreadBookmarks],
-  );
-
-  const handleTogglePin = useCallback(
-    (tweetId: string, event: React.MouseEvent) => {
-      event.preventDefault();
-      event.stopPropagation();
-      const result = togglePin(tweetId, unreadIdSet);
-      setPinnedIds(result.ids);
-      setPinnedOrder(getPinnedTweetIdsOrdered());
-      if (result.hitCap) {
-        setToastMessage("You can pin up to 6 bookmarks.");
-        setShowUnpinButtons(true);
-      }
-    },
-    [unreadIdSet],
-  );
-
-  const [isExporting, setIsExporting] = useState(false);
+  useEffect(() => {
+    if (focusedIndex >= 0 && focusedIndex < filteredBookmarks.length) {
+      virtualizer.scrollToIndex(focusedIndex, { align: "auto" });
+    }
+  }, [focusedIndex, filteredBookmarks.length, virtualizer]);
 
   const handleExportAll = useCallback(async () => {
     setIsExporting(true);
@@ -553,7 +326,6 @@ export function BookmarksList({
       downloadMarkdownFile(body, `bookmarks-${localDate}.md`);
     } catch (err) {
       console.error("Failed to export bookmarks", err);
-      alert("Failed to export bookmarks. Check the console for details.");
     } finally {
       setIsExporting(false);
     }
@@ -567,7 +339,12 @@ export function BookmarksList({
       runtimeStore.setState((state) => ({
         bookmarks: state.bookmarks.map((b) =>
           b.id === bookmarkId
-            ? { ...b, intent, intentSource: "manual" as const, intentAssignedAt: now }
+            ? {
+                ...b,
+                intent,
+                intentSource: "manual" as const,
+                intentAssignedAt: now,
+              }
             : b,
         ),
       }));
@@ -576,97 +353,164 @@ export function BookmarksList({
     [],
   );
 
-  const hasItems = visibleBookmarks.length > 0;
+  const handleViewModeChange = useCallback((values: string[]) => {
+    if (values.length > 0) {
+      setViewMode(values[0] as ViewMode);
+    }
+  }, []);
 
-  const renderEmptyState = () => {
-    if (activeTab === "unread") {
-      return (
-        <div className="flex flex-col items-center justify-center py-20 text-center">
-          <p className="text-lg text-muted text-balance">
-            All caught up! No unread bookmarks.
-          </p>
-          {showSyncControls && (
-            <Button
-              variant="ghost"
-              onClick={onSync}
-              disabled={syncButton.disabled}
-              className="mt-4"
-            >
-              Sync new bookmarks
-            </Button>
+  const isFiltering =
+    intentFilter !== "all" || formatFilter !== "all" || isSearching;
+  const hasItems = filteredBookmarks.length > 0;
+
+  const renderRow = useCallback(
+    (
+      bookmark: Bookmark,
+      index: number,
+      isFocused: boolean,
+    ) => (
+      <a
+        href={getBookmarkHref(bookmark)}
+        className={cn(
+          "group/row relative flex w-full items-center gap-3 py-3 px-3 text-left no-underline transition-colors duration-150",
+          index % 2 === 0
+            ? "bg-surface-alt hover:bg-surface-hover"
+            : "hover:bg-surface-hover",
+          isFocused && "ring-1 ring-accent/20",
+        )}
+      >
+        <div
+          className={cn(
+            "absolute left-0 top-1/2 h-8 w-[3px] -translate-y-1/2 rounded-r-sm",
+            INTENT_BORDER_COLORS[bookmark.intent ?? "unsorted"],
           )}
-        </div>
-      );
-    }
-    if (activeTab === "continue") {
-      return (
-        <div className="flex flex-col items-center justify-center py-20 text-center">
-          <p className="text-lg text-muted text-balance">
-            No reading in progress. Pick something to read.
+        />
+        <img
+          src={bookmark.author.profileImageUrl}
+          alt={`@${bookmark.author.screenName}`}
+          className="size-9 shrink-0 rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.1)]"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium leading-snug text-foreground">
+            {pickTitle(bookmark)}
           </p>
-          <Button
-            variant="ghost"
-            onClick={() => onTabChange("unread")}
-            className="mt-4"
-          >
-            Start reading
-          </Button>
+          <p className="mt-1 truncate text-xs text-muted/50">
+            <a
+              href={`https://x.com/${bookmark.author.screenName}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors hover:text-foreground"
+              onClick={(e) => e.stopPropagation()}
+            >
+              @{bookmark.author.screenName}
+            </a>
+            <span className="text-muted/40">
+              {" "}
+              &middot; {inferKindBadge(bookmark)}
+            </span>
+          </p>
         </div>
-      );
-    }
-    return (
-      <div className="flex flex-col items-center justify-center py-20 text-center">
-        <p className="text-lg text-muted text-balance">
-          Nothing finished yet. Keep reading!
-        </p>
-        <Button
-          variant="ghost"
-          onClick={() => onTabChange("continue")}
-          className="mt-4"
-        >
-          Continue reading
-        </Button>
-      </div>
-    );
-  };
+        <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/row:opacity-100">
+          {INTENT_LABELS.map(({ intent, label }) => (
+            <button
+              key={intent}
+              type="button"
+              onClick={(e) => handleSetIntent(bookmark.id, intent, e)}
+              className={cn(
+                "flex size-6 items-center justify-center rounded-full transition-[transform,opacity] hover:scale-125",
+                bookmark.intent === intent
+                  ? "opacity-100"
+                  : "opacity-60 hover:opacity-100",
+              )}
+              aria-label={`File as ${label}`}
+              title={label}
+            >
+              <span
+                className={cn(
+                  "block size-2 rounded-full",
+                  INTENT_DOT_STYLES[intent],
+                  bookmark.intent === intent && "ring-1 ring-foreground/20",
+                )}
+              />
+            </button>
+          ))}
+        </div>
+      </a>
+    ),
+    [getBookmarkHref, handleSetIntent],
+  );
 
   return (
     <div className="flex h-dvh flex-col bg-surface">
       <div className="sticky top-0 z-10 shrink-0 border-b border-border bg-surface/80 backdrop-blur-md">
-        <div
-          className={cn(
-            "mx-auto flex items-center gap-3 px-6 py-2.5",
-            containerWidthClass,
-          )}
-        >
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onBack}
-            aria-label="Back to home"
-            title="Back"
-          >
-            <ArrowLeftIcon className="size-5" />
-          </Button>
-          <span className="text-lg font-semibold text-foreground">Reading</span>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => { void handleExportAll(); }}
-            disabled={isExporting}
-            aria-label="Export all bookmarks"
-            title={isExporting ? "Exporting…" : "Export all as Markdown"}
-            aria-busy={isExporting}
-            className="ml-auto shrink-0"
-          >
-            {isExporting ? (
-              <CircleNotchIcon className="size-5 animate-spin" />
-            ) : (
-              <DownloadSimpleIcon className="size-5" />
-            )}
-          </Button>
-          <div className="relative mr-1 w-40 shrink-0 transition-transform duration-150 ease-out focus-within:-translate-y-px sm:w-52 md:w-60">
-            <MagnifyingGlassIcon className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted/65" />
+        <div className={cn("mx-auto px-6 pt-4 pb-4", containerWidthClass)}>
+          <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onBack}
+              aria-label="Back to home"
+              title="Back"
+            >
+              <ArrowLeftIcon className="size-5" />
+            </Button>
+            <div className="min-w-0 flex-1">
+              <h1 className="font-serif text-xl text-foreground">
+                Your library
+              </h1>
+              <p className="text-xs italic text-muted">
+                a quiet record of what&apos;s caught your attention
+              </p>
+            </div>
+            <ToggleGroup
+              value={[viewMode]}
+              onValueChange={handleViewModeChange}
+              className="flex gap-0.5 rounded-md border border-border/70 p-0.5"
+            >
+              <Toggle
+                value="browse"
+                className={cn(
+                  "flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium transition-colors",
+                  "text-muted hover:text-foreground",
+                  "data-[pressed]:bg-surface-alt data-[pressed]:text-foreground",
+                )}
+              >
+                <SquaresFour className="size-3.5" />
+                Browse
+              </Toggle>
+              <Toggle
+                value="list"
+                className={cn(
+                  "flex items-center gap-1.5 rounded px-2.5 py-1 text-xs font-medium transition-colors",
+                  "text-muted hover:text-foreground",
+                  "data-[pressed]:bg-surface-alt data-[pressed]:text-foreground",
+                )}
+              >
+                <List className="size-3.5" />
+                List
+              </Toggle>
+            </ToggleGroup>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => {
+                void handleExportAll();
+              }}
+              disabled={isExporting}
+              aria-label="Export all bookmarks"
+              title={isExporting ? "Exporting…" : "Export all as Markdown"}
+              aria-busy={isExporting}
+            >
+              {isExporting ? (
+                <CircleNotchIcon className="size-5 animate-spin" />
+              ) : (
+                <DownloadSimpleIcon className="size-5" />
+              )}
+            </Button>
+          </div>
+
+          <div className="relative mt-3">
+            <MagnifyingGlassIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted/65" />
             <Input
               ref={searchInputRef}
               type="text"
@@ -678,373 +522,174 @@ export function BookmarksList({
                   searchInputRef.current?.blur();
                 }
               }}
-              aria-label="Filter bookmarks"
-              placeholder="Search bookmarks..."
-              className="h-8 border-border/70 bg-surface/45 pl-8 pr-2 text-xs-plus placeholder:text-muted/50 transition-[border-color,background-color] duration-150 ease-out focus:border-foreground/20 focus:bg-surface/55"
+              aria-label="Search your library"
+              placeholder="Search your library..."
+              className="h-9 border-border/70 bg-surface/45 pl-9 pr-12 text-sm placeholder:text-muted/50 transition-[border-color,background-color] duration-150 ease-out focus:border-foreground/20 focus:bg-surface/55"
             />
+            <kbd className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2">
+              ⌘K
+            </kbd>
+          </div>
+
+          <p className="mt-2 text-xs text-muted/60">
+            {allBookmarks.length} saved
+            {oldestDate && <> &middot; oldest from {formatOldestDate(oldestDate)}</>}
+            &nbsp;&middot; never leaves this browser
+          </p>
+
+          <div className="mt-3 flex flex-wrap items-center gap-1.5">
+            {INTENT_PILL_CONFIG.map(({ value, label, countKey }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() =>
+                  setIntentFilter((prev) =>
+                    value === "all"
+                      ? "all"
+                      : prev === value
+                        ? "all"
+                        : value,
+                  )
+                }
+                className={cn(
+                  "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                  intentFilter === value
+                    ? "bg-foreground text-surface"
+                    : "bg-surface-alt text-muted hover:text-foreground",
+                )}
+              >
+                {label}
+                {countKey && (
+                  <span className="ml-1 tabular-nums">
+                    {intentCounts[countKey]}
+                  </span>
+                )}
+              </button>
+            ))}
+
+            <span className="mx-1 h-4 w-px bg-border/50" />
+
+            <button
+              type="button"
+              onClick={() =>
+                setFormatFilter((prev) =>
+                  prev === "threads" ? "all" : "threads",
+                )
+              }
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                formatFilter === "threads"
+                  ? "bg-foreground text-surface"
+                  : "bg-surface-alt text-muted hover:text-foreground",
+              )}
+            >
+              threads{" "}
+              <span className="tabular-nums">{formatCounts.threads}</span>
+            </button>
+            <button
+              type="button"
+              onClick={() =>
+                setFormatFilter((prev) =>
+                  prev === "articles" ? "all" : "articles",
+                )
+              }
+              className={cn(
+                "rounded-full px-3 py-1 text-xs font-medium transition-colors",
+                formatFilter === "articles"
+                  ? "bg-foreground text-surface"
+                  : "bg-surface-alt text-muted hover:text-foreground",
+              )}
+            >
+              articles{" "}
+              <span className="tabular-nums">{formatCounts.articles}</span>
+            </button>
           </div>
         </div>
-
-        <Tabs.Root
-          value={activeTab}
-          onValueChange={(value) => onTabChange(value as ReadingTab)}
-          className={cn("mx-auto px-6", containerWidthClass)}
-        >
-          <Tabs.List className="relative flex">
-            <Tabs.Tab
-              value="unread"
-              className={cn(
-                "px-4 py-2.5 text-sm font-medium transition-colors outline-none select-none",
-                "text-muted hover:text-foreground data-active:text-foreground",
-              )}
-            >
-              Unread
-              {sortedUnread.length > 0 && (
-                <span className="ml-1.5 inline-flex items-center justify-center rounded px-1.5 text-xs tabular-nums bg-muted/10 text-muted">
-                  {sortedUnread.length}
-                </span>
-              )}
-            </Tabs.Tab>
-            <Tabs.Tab
-              value="continue"
-              className={cn(
-                "px-4 py-2.5 text-sm font-medium transition-colors outline-none select-none",
-                "text-muted hover:text-foreground data-active:text-foreground",
-              )}
-            >
-              Reading
-              {sortedInProgress.length > 0 && (
-                <span className="ml-1.5 inline-flex items-center justify-center rounded px-1.5 text-xs tabular-nums bg-accent-surface text-accent">
-                  {sortedInProgress.length}
-                </span>
-              )}
-            </Tabs.Tab>
-            <Tabs.Tab
-              value="read"
-              className={cn(
-                "px-4 py-2.5 text-sm font-medium transition-colors outline-none select-none",
-                "text-muted hover:text-foreground data-active:text-foreground",
-              )}
-            >
-              Read
-              {sortedCompleted.length > 0 && (
-                <span className="ml-1.5 inline-flex items-center justify-center rounded px-1.5 text-xs tabular-nums bg-success/10 text-success">
-                  {sortedCompleted.length}
-                </span>
-              )}
-            </Tabs.Tab>
-            <Tabs.Indicator className="absolute bottom-0 h-0.5 w-[var(--active-tab-width)] translate-x-[var(--active-tab-left)] rounded-full bg-accent transition-[width,translate] duration-200 ease-tab" />
-          </Tabs.List>
-        </Tabs.Root>
       </div>
 
       <div ref={scrollContainerRef} className="flex-1 overflow-y-auto">
         <main className={cn(containerWidthClass, "mx-auto px-6 pb-16 pt-4")}>
-          {hasItems && (
-            <div className="mb-4 flex justify-end">
-              <Select
-                value={activeSort}
-                onValueChange={handleSortChange}
-                options={SORT_OPTIONS}
-                ariaLabel="Sort bookmarks"
-                size="sm"
-                leadingIcon={
-                  <ArrowsDownUpIcon weight="bold" className="size-3.5" />
-                }
-                className="w-36 shrink-0 border-border/70 bg-surface/45 hover:bg-surface/55"
-                popupClassName="w-[7.5rem]"
-              />
-            </div>
-          )}
-
-          {activeTab === "unread" && pinnedCount > 0 && (
-            <div className="mb-2">
-              <span className="text-2xs font-medium uppercase tracking-extra-wide text-muted/40">
-                Pinned
-              </span>
-            </div>
-          )}
-          {activeTab === "unread" && pinnedCount > 0 && (
-            <div className="mb-4 grid grid-cols-3 gap-3">
-              {pinnedBookmarks.map((row, idx) => {
-                const { bookmark } = row;
-                const isFocused = focusedIndex === idx;
-                const counts = getCounts(highlightCounts, bookmark.tweetId);
-                const hasAnnotations =
-                  (counts?.highlights ?? 0) > 0 || (counts?.notes ?? 0) > 0;
-
-                return (
-                  <a
-                    key={bookmark.tweetId}
-                    ref={(el) => {
-                      if (el) pinnedCardRefs.current.set(idx, el);
-                      else pinnedCardRefs.current.delete(idx);
-                    }}
-                    href={getBookmarkHref(bookmark)}
-                    className={cn(
-                      "group/card relative flex min-w-0 flex-col gap-2 overflow-hidden rounded-lg rounded-tr-5 bg-surface-card p-3 shadow-[inset_0_0_0_1px] shadow-border/60 no-underline transition-[background-color] duration-200",
-                      "before:pointer-events-none before:absolute before:top-0 before:right-0 before:z-[3] before:size-6 before:-translate-y-1/2 before:translate-x-1/2 before:rotate-45 before:bg-surface before:shadow-[0_1px_0_0] before:shadow-border before:transition-all before:duration-180 before:content-['']",
-                      "after:pointer-events-none after:absolute after:top-0 after:right-0 after:z-[2] after:h-[22px] after:w-[22px] after:-translate-y-1.5 after:translate-x-1.5 after:rounded-bl-md after:border after:border-border after:bg-surface after:shadow-xs after:transition-all after:duration-180 after:content-['']",
-                      "hover:rounded-tr-[35px] hover:bg-surface-hover hover:before:size-10 hover:after:h-[34px] hover:after:w-[34px] hover:after:shadow-lg hover:after:shadow-black/5",
-                      isFocused && "bg-surface-hover ring-1 ring-accent/30",
-                    )}
-                  >
-                    <div className="absolute top-3 left-0 h-5 w-[3px] rounded-r-sm bg-accent" />
-                    <div className="relative flex items-center gap-2">
-                      <img
-                        src={bookmark.author.profileImageUrl}
-                        alt={`@${bookmark.author.screenName}`}
-                        className="size-5 shrink-0 cursor-pointer rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.1)]"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          e.preventDefault();
-                          window.open(
-                            `https://x.com/${bookmark.author.screenName}`,
-                            "_blank",
-                            "noopener,noreferrer",
-                          );
-                        }}
-                      />
-                      <a
-                        href={`https://x.com/${bookmark.author.screenName}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="truncate text-xs text-muted/70 transition-colors hover:text-foreground"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        @{bookmark.author.screenName}
-                      </a>
-                    </div>
-                    <p className="line-clamp-2 text-xs leading-relaxed text-foreground">
-                      {pickTitle(bookmark)}
-                    </p>
-                    {hasAnnotations && (
-                      <p className="truncate text-2xs text-muted/40">
-                        {(counts?.highlights ?? 0) > 0 && (
-                          <span className="text-accent/60">
-                            {counts!.highlights}{" "}
-                            {counts!.highlights === 1
-                              ? "Highlight"
-                              : "Highlights"}
-                          </span>
-                        )}
-                        {(counts?.highlights ?? 0) > 0 &&
-                          (counts?.notes ?? 0) > 0 && <span> &middot; </span>}
-                        {(counts?.notes ?? 0) > 0 && (
-                          <span
-                            style={{ color: "var(--note-pill-fg)" }}
-                            className="opacity-60"
-                          >
-                            {counts!.notes}{" "}
-                            {counts!.notes === 1 ? "Note" : "Notes"}
-                          </span>
-                        )}
-                      </p>
-                    )}
-                    <button
-                      type="button"
-                      onClick={(e) => handleTogglePin(bookmark.tweetId, e)}
-                      className={cn(
-                        "absolute bottom-0.5 right-0.5 z-[4] flex size-10 items-center justify-center rounded text-accent transition-opacity hover:text-accent/80",
-                        showUnpinButtons ? "opacity-100" : "opacity-0 group-hover/card:opacity-100",
-                      )}
-                      aria-label="Unpin bookmark"
-                      title="Unpin"
-                    >
-                      <PushPinIcon weight="fill" className="size-3" />
-                    </button>
-                  </a>
-                );
-              })}
-            </div>
-          )}
-          {activeTab === "unread" && pinnedCount > 0 && unpinnedRows.length > 0 && (
-            <div className="mb-4 border-t border-dashed border-border/50" />
-          )}
-
-          {hasItems ? (
-            <div
-              style={{
-                height: virtualizer.getTotalSize(),
-                width: "100%",
-                position: "relative",
-              }}
-            >
-              {virtualizer.getVirtualItems().map((virtualItem) => {
-                const row = unpinnedRows[virtualItem.index];
-                const { bookmark } = row;
-                const counts = getCounts(highlightCounts, bookmark.tweetId);
-                const isFocused =
-                  focusedIndex === virtualItem.index + visiblePinnedCount;
-
-                return (
-                  <div
-                    key={bookmark.tweetId}
-                    ref={virtualizer.measureElement}
-                    data-index={virtualItem.index}
-                    style={{
-                      position: "absolute",
-                      top: 0,
-                      left: 0,
-                      width: "100%",
-                      transform: `translateY(${virtualItem.start}px)`,
-                    }}
-                  >
-                    <a
-                      href={getBookmarkHref(bookmark)}
-                      className={cn(
-                        "group/row relative flex w-full items-center gap-3 py-3 px-3 text-left no-underline transition-colors duration-150",
-                        virtualItem.index % 2 === 0
-                          ? "bg-surface-alt hover:bg-surface-hover"
-                          : "hover:bg-surface-hover",
-                        isFocused && "ring-1 ring-accent/20",
-                      )}
-                    >
-                      <div
-                        className={cn(
-                          "absolute left-0 top-1/2 h-8 w-[3px] -translate-y-1/2 rounded-r-sm",
-                          INTENT_BORDER_COLORS[bookmark.intent ?? "unsorted"],
-                        )}
-                      />
-                      <img
-                        src={bookmark.author.profileImageUrl}
-                        alt={`@${bookmark.author.screenName}`}
-                        className="size-9 shrink-0 cursor-pointer rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.1)]"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          e.preventDefault();
-                          window.open(
-                            `https://x.com/${bookmark.author.screenName}`,
-                            "_blank",
-                            "noopener,noreferrer",
-                          );
-                        }}
-                      />
-                      <div className="min-w-0 flex-1">
-                        <p className="truncate text-sm font-medium text-foreground leading-snug">
-                          {pickTitle(bookmark)}
-                          {newBookmarkIds.has(bookmark.tweetId) && (
-                            <Badge
-                              variant="accent"
-                              className="ml-2 align-middle"
-                            >
-                              New
-                            </Badge>
-                          )}
-                        </p>
-                        <p className="mt-1 truncate text-xs text-muted/50">
-                          <a
-                            href={`https://x.com/${bookmark.author.screenName}`}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="transition-colors hover:text-foreground"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            @{bookmark.author.screenName}
-                          </a>
-                          {row.subtitle ? (
-                            <span className="text-muted/40">
-                              {" "}
-                              &middot; {row.subtitle}
-                            </span>
-                          ) : (
-                            <span className="text-muted/40">
-                              {" "}
-                              &middot; {inferKindBadge(bookmark)}
-                            </span>
-                          )}
-                          {(counts?.highlights ?? 0) > 0 && (
-                            <span className="text-muted/40">
-                              {" "}
-                              &middot;{" "}
-                              <span className="text-accent/60">
-                                {counts!.highlights}{" "}
-                                {counts!.highlights === 1
-                                  ? "Highlight"
-                                  : "Highlights"}
-                              </span>
-                            </span>
-                          )}
-                          {(counts?.notes ?? 0) > 0 && (
-                            <span className="text-muted/40">
-                              {" "}
-                              &middot;{" "}
-                              <span
-                                style={{ color: "var(--note-pill-fg)" }}
-                                className="opacity-60"
-                              >
-                                {counts!.notes}{" "}
-                                {counts!.notes === 1 ? "Note" : "Notes"}
-                              </span>
-                            </span>
-                          )}
-                        </p>
+          {viewMode === "browse" ? (
+            <>
+              {!isFiltering && recentlySaved.length > 0 && (
+                <section className="mb-6">
+                  <h2 className="mb-2 text-2xs font-medium uppercase tracking-extra-wide text-muted/40">
+                    Recently saved
+                  </h2>
+                  <div className="divide-y divide-border/30 overflow-hidden rounded-lg border border-border/50">
+                    {recentlySaved.map((bookmark, idx) => (
+                      <div key={bookmark.tweetId}>
+                        {renderRow(bookmark, idx, false)}
                       </div>
-                      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover/row:opacity-100">
-                        {INTENT_LABELS.map(({ intent, label }) => (
-                          <button
-                            key={intent}
-                            type="button"
-                            onClick={(e) => handleSetIntent(bookmark.id, intent, e)}
-                            className={cn(
-                              "flex size-6 items-center justify-center rounded-full transition-[transform,opacity] hover:scale-125",
-                              bookmark.intent === intent ? "opacity-100" : "opacity-60 hover:opacity-100",
-                            )}
-                            aria-label={`File as ${label}`}
-                            title={label}
-                          >
-                            <span
-                              className={cn(
-                                "block size-2 rounded-full",
-                                INTENT_DOT_STYLES[intent],
-                                bookmark.intent === intent && "ring-1 ring-foreground/20",
-                              )}
-                            />
-                          </button>
-                        ))}
-                      </div>
-                      {activeTab === "unread" && (
-                        <button
-                          type="button"
-                          onClick={(e) => handleTogglePin(bookmark.tweetId, e)}
-                          className={cn(
-                            "flex size-10 shrink-0 items-center justify-center rounded transition-[color,opacity]",
-                            pinnedIds.has(bookmark.tweetId)
-                              ? "text-accent opacity-100 hover:text-accent/80"
-                              : "text-muted/40 opacity-0 group-hover/row:opacity-100 hover:text-muted",
-                          )}
-                          aria-label={
-                            pinnedIds.has(bookmark.tweetId)
-                              ? "Unpin bookmark"
-                              : "Pin bookmark"
-                          }
-                          title={
-                            pinnedIds.has(bookmark.tweetId) ? "Unpin" : "Pin"
-                          }
-                        >
-                          <PushPinIcon
-                            weight={
-                              pinnedIds.has(bookmark.tweetId) ? "fill" : "regular"
-                            }
-                            className="size-3.5"
-                          />
-                        </button>
-                      )}
-                      {activeTab !== "unread" && pinnedIds.has(bookmark.tweetId) && (
-                        <div
-                          className="flex size-10 shrink-0 items-center justify-center text-accent opacity-60"
-                          title="Pinned"
-                        >
-                          <PushPinIcon weight="fill" className="size-3.5" />
-                        </div>
-                      )}
-                    </a>
+                    ))}
                   </div>
-                );
-              })}
-            </div>
+                </section>
+              )}
+
+              {!isFiltering && fromAYearAgo.length > 0 && (
+                <section className="mb-6">
+                  <h2 className="mb-2 text-2xs font-medium uppercase tracking-extra-wide text-muted/40">
+                    From a year ago
+                  </h2>
+                  <div className="divide-y divide-border/30 overflow-hidden rounded-lg border border-border/50">
+                    {fromAYearAgo.map((bookmark, idx) => (
+                      <div key={bookmark.tweetId}>
+                        {renderRow(bookmark, idx, false)}
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {hasItems ? (
+                <div
+                  style={{
+                    height: virtualizer.getTotalSize(),
+                    width: "100%",
+                    position: "relative",
+                  }}
+                >
+                  {virtualizer.getVirtualItems().map((virtualItem) => {
+                    const bookmark = filteredBookmarks[virtualItem.index];
+                    const isFocused = focusedIndex === virtualItem.index;
+
+                    return (
+                      <div
+                        key={bookmark.tweetId}
+                        ref={virtualizer.measureElement}
+                        data-index={virtualItem.index}
+                        style={{
+                          position: "absolute",
+                          top: 0,
+                          left: 0,
+                          width: "100%",
+                          transform: `translateY(${virtualItem.start}px)`,
+                        }}
+                      >
+                        {renderRow(bookmark, virtualItem.index, isFocused)}
+                      </div>
+                    );
+                  })}
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-20 text-center">
+                  <p className="text-balance text-lg text-muted">
+                    {isSearching
+                      ? "No bookmarks match your search."
+                      : "No bookmarks yet."}
+                  </p>
+                </div>
+              )}
+            </>
           ) : (
-            renderEmptyState()
+            <div className="flex flex-col items-center justify-center py-20 text-center">
+              <p className="text-balance text-lg text-muted">
+                List view coming soon
+              </p>
+              <p className="mt-2 text-sm text-muted/60">
+                Time-grouped archive with bulk select
+              </p>
+            </div>
           )}
 
           {offlineMode && (

--- a/src/components/NewTabHome.tsx
+++ b/src/components/NewTabHome.tsx
@@ -47,6 +47,7 @@ import {
 } from "../stores/selectors";
 
 import { CLOCK_UPDATE_MS } from "../lib/constants";
+import { useStreak } from "../hooks/useStreak";
 
 interface Props {
   bookmarks: Bookmark[];
@@ -108,6 +109,7 @@ export function NewTabHome({
   const [mountSeed] = useState(() => Math.random());
   const searchRef = useRef<HTMLInputElement>(null);
   const prevWallpaperUrlRef = useRef<string | null>(null);
+  const streak = useStreak();
   const { wallpaperUrl, wallpaperCredit, gradientCss } =
     useWallpaper(backgroundMode);
   const { sites: topSites } = useTopSites(topSitesLimit, showTopSites);
@@ -477,7 +479,26 @@ export function NewTabHome({
       <div className="totem-grain pointer-events-none absolute inset-0" />
 
       <header className="relative z-20 flex w-full items-center justify-between px-6 pt-5 sm:px-8">
-        <TotemLogo className="size-8" />
+        <div className="flex items-center gap-3">
+          <TotemLogo className="size-8" />
+          {streak.current > 0 && (
+            <span
+              className={cn(
+                "inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xxs font-semibold tracking-wide transition-colors duration-150 ease-hover",
+                streak.earnedToday
+                  ? "bg-accent-500/20 text-accent-400"
+                  : "bg-white/10 text-on-bg-muted",
+              )}
+              title={`${streak.current} day streak${streak.earnedToday ? " — earned today" : ""}`}
+            >
+              <span aria-hidden>🔥</span>
+              {streak.current} {streak.current === 1 ? "day" : "days"}
+              {streak.earnedToday && (
+                <span className="text-accent-300"> · +1 today</span>
+              )}
+            </span>
+          )}
+        </div>
         <div className="flex items-center gap-2">
           {syncButton.visible && (
             <Button

--- a/src/components/NewTabHome.tsx
+++ b/src/components/NewTabHome.tsx
@@ -14,6 +14,7 @@ import { SearchEnginePicker } from "./SearchEnginePicker";
 import type {
   BackgroundMode,
   Bookmark,
+  BookmarkIntent,
   RecommendationSource,
   SearchEngineId,
 } from "../types";
@@ -25,6 +26,7 @@ import {
   pickTitle,
   pickExcerpt,
   estimateReadingMinutes,
+  inferKindBadge,
 } from "../lib/bookmark-utils";
 import { cn } from "../lib/cn";
 import { Button } from "./ui/Button";
@@ -48,6 +50,8 @@ import {
 
 import { CLOCK_UPDATE_MS } from "../lib/constants";
 import { useStreak } from "../hooks/useStreak";
+import { useDailyQueue } from "../hooks/useDailyQueue";
+import { useSettings } from "../hooks/useSettings";
 
 interface Props {
   bookmarks: Bookmark[];
@@ -70,6 +74,24 @@ interface Props {
   syncButtonStateOverride?: SyncButtonState;
   offlineModeOverride?: boolean;
   onLogin?: () => void;
+}
+
+const INTENT_BADGE_STYLES: Record<BookmarkIntent, { label: string; className: string } | null> = {
+  read_soon: { label: "Read soon", className: "bg-accent/15 text-accent" },
+  reference: { label: "Reference", className: "bg-home-fg-muted/15 text-home-fg-muted" },
+  act_on: { label: "Act on", className: "bg-accent-700/15 text-accent-700 dark:bg-accent-400/15 dark:text-accent-400" },
+  unsorted: null,
+};
+
+function formatSaveAge(createdAt: number): string {
+  const hours = Math.floor((Date.now() - createdAt) / 3_600_000);
+  if (hours < 1) return "just now";
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
 }
 
 interface DecoratedBookmark {
@@ -110,6 +132,15 @@ export function NewTabHome({
   const searchRef = useRef<HTMLInputElement>(null);
   const prevWallpaperUrlRef = useRef<string | null>(null);
   const streak = useStreak();
+  const { settings } = useSettings();
+  const {
+    queue,
+    queueBookmarks,
+    loading: queueLoading,
+    markCompleted,
+    markSkipped,
+  } = useDailyQueue(bookmarks, settings.dailyQueueSize);
+  const [queuePosition, setQueuePosition] = useState(0);
   const { wallpaperUrl, wallpaperCredit, gradientCss } =
     useWallpaper(backgroundMode);
   const { sites: topSites } = useTopSites(topSitesLimit, showTopSites);
@@ -155,7 +186,43 @@ export function NewTabHome({
     const index = Math.floor(mountSeed * pool.length);
     return pool[index];
   }, [items, unreadItems, mountSeed, recommendationSource]);
-  const runtimeFooterState = useFooterState(Boolean(currentItem), isResetting);
+
+  const remainingQueueIds = useMemo(() => {
+    if (!queue) return [];
+    return queue.bookmarkIds.filter(
+      (id) => !queue.completedIds.includes(id) && !queue.skippedIds.includes(id),
+    );
+  }, [queue]);
+
+  const hasActiveQueue = queueBookmarks.length > 0 && !queueLoading && remainingQueueIds.length > 0;
+
+  useEffect(() => {
+    if (!queue || queueBookmarks.length === 0) return;
+    const firstRemaining = queue.bookmarkIds.findIndex(
+      (id) => !queue.completedIds.includes(id) && !queue.skippedIds.includes(id),
+    );
+    if (firstRemaining >= 0) {
+      setQueuePosition(firstRemaining);
+    }
+  }, [queue?.completedIds.length, queue?.skippedIds.length, queue?.bookmarkIds, queueBookmarks.length, queue]);
+
+  const currentQueueItem: DecoratedBookmark | null = useMemo(() => {
+    const bookmark = queueBookmarks[queuePosition] ?? null;
+    if (!bookmark) return null;
+    return {
+      bookmark,
+      title: pickTitle(bookmark),
+      excerpt: pickExcerpt(bookmark),
+      minutes: detailedTweetIds.has(bookmark.tweetId)
+        ? estimateReadingMinutes(bookmark)
+        : null,
+      isRead: openedTweetIds.has(bookmark.tweetId),
+    };
+  }, [queueBookmarks, queuePosition, detailedTweetIds, openedTweetIds]);
+
+  const displayItem = hasActiveQueue ? currentQueueItem : currentItem;
+
+  const runtimeFooterState = useFooterState(Boolean(displayItem), isResetting);
   const syncButton = syncButtonStateOverride ?? runtimeSyncButton;
   const offlineMode = offlineModeOverride ?? runtimeOfflineMode;
   const footerState = footerStateOverride ?? runtimeFooterState;
@@ -183,40 +250,59 @@ export function NewTabHome({
 
   const surpriseMe = useCallback(() => {
     if (items.length === 0) return;
-    const pool = unreadItems.length > 0 ? unreadItems : items;
+    const readSoonPool = items.filter((item) => item.bookmark.intent === "read_soon");
+    const pool = readSoonPool.length > 0 ? readSoonPool : unreadItems.length > 0 ? unreadItems : items;
     const pick = pool[Math.floor(Math.random() * pool.length)];
     openItem(pick);
   }, [items, unreadItems, openItem]);
+
+  const handleReadNow = useCallback(() => {
+    if (!currentQueueItem) return;
+    markCompleted(currentQueueItem.bookmark.id);
+    onOpenBookmark(currentQueueItem.bookmark);
+  }, [currentQueueItem, markCompleted, onOpenBookmark]);
+
+  const handleSkip = useCallback(() => {
+    if (!currentQueueItem) return;
+    markSkipped(currentQueueItem.bookmark.id);
+  }, [currentQueueItem, markSkipped]);
 
   useHotkeys("/", () => searchRef.current?.focus(), {
     preventDefault: true,
   });
 
   useHotkeys(
+    "r",
+    () => { if (hasActiveQueue) handleReadNow(); },
+    { preventDefault: true },
+    [hasActiveQueue, handleReadNow],
+  );
+
+  useHotkeys(
     "space",
-    () => openItem(currentItem ?? null),
-    {
-      preventDefault: true,
+    () => {
+      if (hasActiveQueue) handleReadNow();
+      else openItem(currentItem ?? null);
     },
-    [currentItem, openItem],
+    { preventDefault: true },
+    [hasActiveQueue, handleReadNow, currentItem, openItem],
   );
 
   useHotkeys(
     "l",
     () => onOpenReading(),
-    {
-      preventDefault: true,
-    },
+    { preventDefault: true },
     [onOpenReading],
   );
 
   useHotkeys(
     "s",
-    () => surpriseMe(),
-    {
-      preventDefault: true,
+    () => {
+      if (hasActiveQueue) handleSkip();
+      else surpriseMe();
     },
-    [surpriseMe],
+    { preventDefault: true },
+    [hasActiveQueue, handleSkip, surpriseMe],
   );
 
   const showCardButtons = footerState === "bookmark_card";
@@ -289,16 +375,32 @@ export function NewTabHome({
             </Button>
           </article>
         );
-      case "bookmark_card":
-        if (!currentItem) return null;
+      case "bookmark_card": {
+        const cardItem = hasActiveQueue ? currentQueueItem : currentItem;
+        if (!cardItem) return null;
+        const intentBadge = cardItem.bookmark.intent
+          ? INTENT_BADGE_STYLES[cardItem.bookmark.intent]
+          : null;
+        const kindLabel = inferKindBadge(cardItem.bookmark);
+        const handleCardClick = (e: React.MouseEvent | React.KeyboardEvent) => {
+          e.preventDefault();
+          if (hasActiveQueue) {
+            handleReadNow();
+          } else {
+            onOpenBookmark(cardItem.bookmark);
+          }
+        };
         return (
           <a
-            href={getBookmarkHref(currentItem.bookmark)}
+            key={cardItem.bookmark.tweetId}
+            href={getBookmarkHref(cardItem.bookmark)}
             className={cn(
               cardBase,
               "block cursor-pointer p-4 no-underline hover:bg-main-bg-hover max-sm:py-3.5",
               cardEngaged && "bg-main-bg-hover",
+              hasActiveQueue && "animate-card-in",
             )}
+            onClick={handleCardClick}
             onMouseEnter={() => setCardEngaged(true)}
             onMouseLeave={() => setCardEngaged(false)}
             onFocusCapture={() => setCardEngaged(true)}
@@ -315,24 +417,22 @@ export function NewTabHome({
               if (event.key === " ") {
                 event.preventDefault();
                 event.stopPropagation();
-                onOpenBookmark(currentItem.bookmark);
+                handleCardClick(event);
               }
             }}
-            aria-label={`Read ${currentItem.title} by @${
-              currentItem.bookmark.author.screenName
+            aria-label={`Read ${cardItem.title} by @${
+              cardItem.bookmark.author.screenName
             }${
-              currentItem.minutes !== null
-                ? `, ${currentItem.minutes} min read`
+              cardItem.minutes !== null
+                ? `, ${cardItem.minutes} min read`
                 : ""
             }`}
           >
             <div className="flex min-h-32 flex-col translate-y-0 opacity-100 transition-[transform,opacity] duration-200 ease-overlay-in max-sm:min-h-28">
-              <div className="flex justify-between">
+              <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
                   <p className="text-xs font-semibold uppercase tracking-extra-wide text-accent">
-                    {recommendationSource === "pinned"
-                      ? "pinned"
-                      : "your next read"}
+                    your next read
                   </p>
                   {offlineMode && (
                     <span title="Not signed in — showing cached bookmarks">
@@ -340,36 +440,58 @@ export function NewTabHome({
                     </span>
                   )}
                 </div>
-                <kbd className="ml-2 border-home-secondary-border bg-accent-tint text-home-fg-muted shadow-kbd">
-                  Space
-                </kbd>
+                {intentBadge && (
+                  <span
+                    className={cn(
+                      "shrink-0 rounded px-1.5 py-0.5 text-xxs font-medium",
+                      intentBadge.className,
+                    )}
+                  >
+                    {intentBadge.label}
+                  </span>
+                )}
+                {!intentBadge && !hasActiveQueue && (
+                  <kbd className="ml-2 border-home-secondary-border bg-accent-tint text-home-fg-muted shadow-kbd">
+                    Space
+                  </kbd>
+                )}
               </div>
               <div className="mt-4 flex flex-col gap-1">
                 <h2 className="capitalize font-serif line-clamp-2 text-balance text-lg font-medium leading-snug text-home-fg-secondary max-sm:text-base lg:text-xl">
-                  {currentItem.title}
+                  {cardItem.title}
                 </h2>
                 <p className="line-clamp-1 text-xs text-home-description/80">
-                  {currentItem.excerpt}
+                  {cardItem.excerpt}
                 </p>
+                {(cardItem.minutes !== null || kindLabel) && (
+                  <p className="mt-0.5 text-xxs text-home-fg-muted">
+                    {cardItem.minutes !== null && `${cardItem.minutes} min`}
+                    {cardItem.minutes !== null && kindLabel && " · "}
+                    {kindLabel && kindLabel.toLowerCase()}
+                  </p>
+                )}
               </div>
               <div className="mt-auto flex items-center gap-2.5 pt-3">
                 <img
-                  src={currentItem.bookmark.author.profileImageUrl}
-                  alt={`@${currentItem.bookmark.author.screenName}`}
+                  src={cardItem.bookmark.author.profileImageUrl}
+                  alt={`@${cardItem.bookmark.author.screenName}`}
                   className="size-6 shrink-0 rounded-full shadow-[inset_0_0_0_1px_rgba(0,0,0,0.06)] dark:shadow-[inset_0_0_0_1px_rgba(255,255,255,0.1)]"
                 />
                 <div className="min-w-0 flex flex-col gap-1">
                   <p className="truncate text-xxs font-medium text-home-fg-secondary">
-                    {currentItem.bookmark.author.name}
+                    {cardItem.bookmark.author.name}
                   </p>
                   <p className="truncate text-xxs text-home-fg-muted">
-                    @{currentItem.bookmark.author.screenName}
+                    @{cardItem.bookmark.author.screenName}
+                    {" · "}
+                    {formatSaveAge(cardItem.bookmark.createdAt)}
                   </p>
                 </div>
               </div>
             </div>
           </a>
         );
+      }
       case "syncing_bootstrap":
         return (
           <article className={cardCentered}>
@@ -637,37 +759,97 @@ export function NewTabHome({
           </section>
         </main>
 
-        <footer className="mx-auto w-full max-w-lg space-y-6 pb-6">
+        <footer className="mx-auto w-full max-w-lg space-y-4 pb-6">
           {renderFooterCard()}
 
-          <div
-            className={cn(
-              "flex items-center justify-between gap-2.5 max-sm:gap-2",
-              !showCardButtons && "invisible pointer-events-none",
-            )}
-            aria-hidden={!showCardButtons || undefined}
-          >
-            <Button
-              variant="secondary"
-              className="bg-home-secondary-bg px-5 py-2.5 font-semibold leading-none text-home-secondary-text shadow-glass transition-colors duration-150 ease-hover hover:bg-main-bg-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-400/80"
-              onClick={onOpenReading}
+          {hasActiveQueue && showCardButtons && queueBookmarks.length > 1 && (
+            <div className="flex items-center justify-center gap-2.5">
+              <div className="flex items-center gap-1.5">
+                {queueBookmarks.map((b, i) => (
+                  <button
+                    key={b.id}
+                    type="button"
+                    onClick={() => setQueuePosition(i)}
+                    className={cn(
+                      "size-2 rounded-full transition-colors duration-150 ease-hover",
+                      i === queuePosition
+                        ? "bg-accent scale-125"
+                        : queue?.completedIds.includes(b.id)
+                          ? "bg-white/50"
+                          : queue?.skippedIds.includes(b.id)
+                            ? "bg-white/20"
+                            : "bg-white/30",
+                    )}
+                    aria-label={`Queue item ${i + 1}`}
+                  />
+                ))}
+              </div>
+              <span className="text-xxs tabular-nums text-on-bg-muted">
+                {queuePosition + 1} / {queueBookmarks.length}
+              </span>
+            </div>
+          )}
+
+          {hasActiveQueue && showCardButtons ? (
+            <div className="flex items-center justify-center gap-2.5 max-sm:gap-2">
+              <Button
+                variant="secondary"
+                className="bg-home-accent px-5 py-2.5 font-semibold leading-none text-white shadow-glass transition-colors duration-150 ease-hover hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-400/80"
+                onClick={handleReadNow}
+              >
+                Read now
+                <kbd className="ml-2 border-white/20 bg-white/15 text-white/70 shadow-kbd">
+                  R
+                </kbd>
+              </Button>
+              <Button
+                variant="secondary"
+                className="bg-home-secondary-bg px-5 py-2.5 font-semibold leading-none text-home-secondary-text shadow-glass transition-colors duration-150 ease-hover hover:bg-main-bg-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-400/80"
+                onClick={handleSkip}
+              >
+                Skip
+                <kbd className="ml-2 border-home-secondary-border bg-accent-tint text-home-fg-muted shadow-kbd">
+                  S
+                </kbd>
+              </Button>
+              <Button
+                variant="ghost"
+                className="bg-transparent px-4 py-2.5 font-semibold leading-none text-on-bg-muted transition-colors duration-150 ease-hover hover:text-on-bg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-400/80"
+                onClick={onOpenReading}
+              >
+                Browse queue
+              </Button>
+            </div>
+          ) : (
+            <div
+              className={cn(
+                "flex items-center justify-between gap-2.5 max-sm:gap-2",
+                !showCardButtons && "invisible pointer-events-none",
+              )}
+              aria-hidden={!showCardButtons || undefined}
             >
-              Open reading list
-              <kbd className="ml-2 border-home-secondary-border bg-accent-tint text-home-fg-muted shadow-kbd">
-                L
-              </kbd>
-            </Button>
-            <Button
-              variant="secondary"
-              className="bg-home-secondary-bg px-5 py-2.5 font-semibold leading-none text-home-secondary-text shadow-glass transition-colors duration-150 ease-hover hover:bg-main-bg-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-400/80"
-              onClick={surpriseMe}
-            >
-              Surprise me
-              <kbd className="ml-2 border-home-secondary-border bg-accent-tint text-home-fg-muted shadow-kbd">
-                S
-              </kbd>
-            </Button>
-          </div>
+              <Button
+                variant="secondary"
+                className="bg-home-secondary-bg px-5 py-2.5 font-semibold leading-none text-home-secondary-text shadow-glass transition-colors duration-150 ease-hover hover:bg-main-bg-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-400/80"
+                onClick={onOpenReading}
+              >
+                Open reading list
+                <kbd className="ml-2 border-home-secondary-border bg-accent-tint text-home-fg-muted shadow-kbd">
+                  L
+                </kbd>
+              </Button>
+              <Button
+                variant="secondary"
+                className="bg-home-secondary-bg px-5 py-2.5 font-semibold leading-none text-home-secondary-text shadow-glass transition-colors duration-150 ease-hover hover:bg-main-bg-hover focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-400/80"
+                onClick={surpriseMe}
+              >
+                Surprise me
+                <kbd className="ml-2 border-home-secondary-border bg-accent-tint text-home-fg-muted shadow-kbd">
+                  S
+                </kbd>
+              </Button>
+            </div>
+          )}
 
           <p
             className={cn(

--- a/src/components/NewTabHome.tsx
+++ b/src/components/NewTabHome.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import {
   ArrowsClockwiseIcon,
+  CaretDownIcon,
+  CheckCircleIcon,
   EnvelopeSimpleIcon,
   GearSixIcon,
   InfoIcon,
@@ -51,6 +53,7 @@ import {
 import { CLOCK_UPDATE_MS } from "../lib/constants";
 import { useStreak } from "../hooks/useStreak";
 import { useDailyQueue } from "../hooks/useDailyQueue";
+import { useDailyStats } from "../hooks/useDailyStats";
 import { useSettings } from "../hooks/useSettings";
 
 interface Props {
@@ -195,6 +198,12 @@ export function NewTabHome({
   }, [queue]);
 
   const hasActiveQueue = queueBookmarks.length > 0 && !queueLoading && remainingQueueIds.length > 0;
+  const queueDone = Boolean(
+    queue &&
+    queue.bookmarkIds.length > 0 &&
+    queue.completedIds.length >= queue.bookmarkIds.length,
+  );
+  const dailyStats = useDailyStats(bookmarks, queueDone);
 
   useEffect(() => {
     if (!queue || queueBookmarks.length === 0) return;
@@ -376,6 +385,48 @@ export function NewTabHome({
           </article>
         );
       case "bookmark_card": {
+        if (queueDone) {
+          const statItems = [
+            { value: dailyStats.readCount, label: "READ" },
+            { value: dailyStats.filedToActCount, label: "FILED TO ACT" },
+            ...(dailyStats.timeMinutes > 0
+              ? [{ value: `${dailyStats.timeMinutes}m`, label: "TIME" }]
+              : []),
+          ];
+          return (
+            <article
+              className={cn(cardBase, "animate-fade-in text-center")}
+            >
+              <div className="flex min-h-32 flex-col items-center justify-center gap-4 max-sm:min-h-28">
+                <span className="inline-flex size-12 items-center justify-center rounded-full bg-accent/10">
+                  <CheckCircleIcon weight="fill" className="size-7 text-accent" />
+                </span>
+                <div>
+                  <h2 className="font-serif text-xl font-medium text-home-fg-secondary">
+                    Done for today.
+                  </h2>
+                  <p className="mt-1 text-sm italic text-home-fg-muted">
+                    Come back tomorrow for the next three.
+                  </p>
+                </div>
+                {statItems.length > 0 && (
+                  <div className="flex items-center gap-4">
+                    {statItems.map((s) => (
+                      <div key={s.label} className="flex flex-col items-center">
+                        <span className="text-base font-semibold tabular-nums text-home-fg-secondary">
+                          {s.value}
+                        </span>
+                        <span className="text-xxs font-medium uppercase tracking-extra-wide text-home-fg-muted">
+                          {s.label}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </article>
+          );
+        }
         const cardItem = hasActiveQueue ? currentQueueItem : currentItem;
         if (!cardItem) return null;
         const intentBadge = cardItem.bookmark.intent
@@ -762,7 +813,7 @@ export function NewTabHome({
         <footer className="mx-auto w-full max-w-lg space-y-4 pb-6">
           {renderFooterCard()}
 
-          {hasActiveQueue && showCardButtons && queueBookmarks.length > 1 && (
+          {hasActiveQueue && showCardButtons && !queueDone && queueBookmarks.length > 1 && (
             <div className="flex items-center justify-center gap-2.5">
               <div className="flex items-center gap-1.5">
                 {queueBookmarks.map((b, i) => (
@@ -790,7 +841,18 @@ export function NewTabHome({
             </div>
           )}
 
-          {hasActiveQueue && showCardButtons ? (
+          {queueDone && showCardButtons ? (
+            <div className="flex justify-center">
+              <button
+                type="button"
+                onClick={onOpenReading}
+                className="flex flex-col items-center gap-1 text-on-bg-muted transition-colors duration-150 ease-hover hover:text-on-bg"
+                aria-label="Browse library"
+              >
+                <CaretDownIcon className="size-5 animate-[bounce_2s_ease-in-out_infinite]" />
+              </button>
+            </div>
+          ) : hasActiveQueue && showCardButtons ? (
             <div className="flex items-center justify-center gap-2.5 max-sm:gap-2">
               <Button
                 variant="secondary"

--- a/src/components/reader/IntentTray.tsx
+++ b/src/components/reader/IntentTray.tsx
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import type { BookmarkIntent } from "../../types";
+
+const CHIPS: { intent: BookmarkIntent; label: string; key: string }[] = [
+  { intent: "read_soon", label: "Read soon", key: "r" },
+  { intent: "reference", label: "Reference", key: "f" },
+  { intent: "act_on", label: "Act on", key: "a" },
+];
+
+const AUTO_DISMISS_MS = 8000;
+
+interface IntentTrayProps {
+  onSelect: (intent: BookmarkIntent) => void;
+  onDismiss: () => void;
+}
+
+export function IntentTray({ onSelect, onDismiss }: IntentTrayProps) {
+  const [exiting, setExiting] = useState(false);
+  const trayRef = useRef<HTMLDivElement>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(null);
+
+  const dismiss = useCallback(() => {
+    setExiting(true);
+  }, []);
+
+  const handleSelect = useCallback(
+    (intent: BookmarkIntent) => {
+      onSelect(intent);
+      setExiting(true);
+    },
+    [onSelect],
+  );
+
+  useEffect(() => {
+    timerRef.current = setTimeout(dismiss, AUTO_DISMISS_MS);
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [dismiss]);
+
+  useHotkeys("r", () => handleSelect("read_soon"), { preventDefault: true }, [handleSelect]);
+  useHotkeys("f", () => handleSelect("reference"), { preventDefault: true }, [handleSelect]);
+  useHotkeys("a", () => handleSelect("act_on"), { preventDefault: true }, [handleSelect]);
+  useHotkeys("escape", dismiss, { preventDefault: true }, [dismiss]);
+
+  return (
+    <div
+      ref={trayRef}
+      role="toolbar"
+      aria-label="File as"
+      className="fixed bottom-6 left-1/2 z-50 -translate-x-1/2"
+      style={{
+        animation: exiting
+          ? "intent-tray-out 150ms ease-in forwards"
+          : "intent-tray-in 200ms cubic-bezier(0.23, 1, 0.32, 1) forwards",
+      }}
+      onAnimationEnd={() => {
+        if (exiting) onDismiss();
+      }}
+    >
+      <div className="flex items-center gap-1.5 rounded-lg border border-border bg-surface-card px-3 py-2 shadow-[0_4px_24px_rgba(0,0,0,0.12),0_1px_4px_rgba(0,0,0,0.08)] dark:shadow-[0_4px_24px_rgba(0,0,0,0.4),0_1px_4px_rgba(0,0,0,0.2)]">
+        <span className="mr-1 text-xs text-muted">File as</span>
+        {CHIPS.map(({ intent, label, key }) => (
+          <button
+            key={intent}
+            type="button"
+            onClick={() => handleSelect(intent)}
+            className="rounded-md bg-accent-surface px-2.5 py-1 text-xs font-medium text-accent transition-colors hover:bg-accent-surface-hover"
+          >
+            {label}
+            <kbd className="ml-1.5 text-[0.625rem] uppercase opacity-50">{key}</kbd>
+          </button>
+        ))}
+        <button
+          type="button"
+          onClick={dismiss}
+          className="rounded-md px-2.5 py-1 text-xs font-medium text-muted transition-colors hover:bg-surface-hover hover:text-foreground"
+        >
+          done
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/db/__tests__/intent-repo.test.ts
+++ b/src/db/__tests__/intent-repo.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { Bookmark, BookmarkIntent, IntentSource } from "../../types";
+
+function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: "bk-1",
+    tweetId: "tw-1",
+    text: "test bookmark",
+    createdAt: Date.now(),
+    sortIndex: "1234567890000000000",
+    bookmarked: true,
+    author: {
+      name: "Test User",
+      screenName: "testuser",
+      profileImageUrl: "https://example.com/avatar.jpg",
+      verified: false,
+    },
+    metrics: { likes: 0, retweets: 0, replies: 0, views: 0, bookmarks: 0 },
+    media: [],
+    urls: [],
+    isThread: false,
+    hasImage: false,
+    hasVideo: false,
+    hasLink: false,
+    quotedTweet: null,
+    intent: "unsorted",
+    ...overrides,
+  };
+}
+
+describe("intent types and contracts", () => {
+  it("valid intent values are exhaustive", () => {
+    const intents: BookmarkIntent[] = ["read_soon", "reference", "act_on", "unsorted"];
+    expect(intents).toHaveLength(4);
+    for (const intent of intents) {
+      const bookmark = makeBookmark({ intent });
+      expect(bookmark.intent).toBe(intent);
+    }
+  });
+
+  it("valid intent sources", () => {
+    const sources: IntentSource[] = ["structural", "keyword", "manual"];
+    expect(sources).toHaveLength(3);
+  });
+
+  it("manual intent assignment preserves all bookmark fields", () => {
+    const original = makeBookmark({
+      intent: "unsorted",
+      text: "important thread about DeFi",
+      isThread: true,
+    });
+
+    const updated: Bookmark = {
+      ...original,
+      intent: "read_soon",
+      intentSource: "manual",
+      intentConfidence: undefined,
+      intentAssignedAt: new Date().toISOString(),
+    };
+
+    expect(updated.intent).toBe("read_soon");
+    expect(updated.intentSource).toBe("manual");
+    expect(updated.text).toBe(original.text);
+    expect(updated.isThread).toBe(true);
+    expect(updated.tweetId).toBe(original.tweetId);
+  });
+
+  it("manual source is never overwritten by auto-classifier", () => {
+    const manualBookmark = makeBookmark({
+      intent: "act_on",
+      intentSource: "manual",
+      intentAssignedAt: "2026-01-01T00:00:00.000Z",
+    });
+
+    const shouldSkip = manualBookmark.intentSource === "manual";
+    expect(shouldSkip).toBe(true);
+  });
+
+  it("intent defaults to unsorted for new bookmarks", () => {
+    const bookmark = makeBookmark();
+    expect(bookmark.intent).toBe("unsorted");
+  });
+
+  it("bookmark with no intent field defaults safely", () => {
+    const raw = makeBookmark();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (raw as any).intent;
+    const intent = raw.intent ?? "unsorted";
+    expect(intent).toBe("unsorted");
+  });
+
+  it("intent fields are optional on Bookmark type", () => {
+    const minimal: Bookmark = {
+      id: "bk-1",
+      tweetId: "tw-1",
+      text: "test",
+      createdAt: Date.now(),
+      sortIndex: "1234567890000000000",
+      bookmarked: true,
+      author: { name: "T", screenName: "t", profileImageUrl: "", verified: false },
+      metrics: { likes: 0, retweets: 0, replies: 0, views: 0, bookmarks: 0 },
+      media: [],
+      urls: [],
+      isThread: false,
+      hasImage: false,
+      hasVideo: false,
+      hasLink: false,
+      quotedTweet: null,
+    };
+    expect(minimal.id).toBe("bk-1");
+    expect(minimal.intent).toBeUndefined();
+  });
+
+  it("bulkSetIntent contract: applies same intent to multiple bookmarks", () => {
+    const bookmarks = [
+      makeBookmark({ id: "bk-1", tweetId: "tw-1", intent: "unsorted" }),
+      makeBookmark({ id: "bk-2", tweetId: "tw-2", intent: "unsorted" }),
+      makeBookmark({ id: "bk-3", tweetId: "tw-3", intent: "reference" }),
+    ];
+    const idsToUpdate = new Set(["bk-1", "bk-3"]);
+    const targetIntent: BookmarkIntent = "act_on";
+    const now = new Date().toISOString();
+
+    const updated = bookmarks.map((b) =>
+      idsToUpdate.has(b.id)
+        ? { ...b, intent: targetIntent, intentSource: "manual" as IntentSource, intentAssignedAt: now }
+        : b,
+    );
+
+    expect(updated[0].intent).toBe("act_on");
+    expect(updated[1].intent).toBe("unsorted");
+    expect(updated[2].intent).toBe("act_on");
+  });
+
+  it("getByIntent contract: filters bookmarks by intent", () => {
+    const bookmarks = [
+      makeBookmark({ id: "bk-1", intent: "read_soon" }),
+      makeBookmark({ id: "bk-2", intent: "reference" }),
+      makeBookmark({ id: "bk-3", intent: "read_soon" }),
+      makeBookmark({ id: "bk-4", intent: "unsorted" }),
+    ];
+
+    const readSoon = bookmarks.filter((b) => (b.intent ?? "unsorted") === "read_soon");
+    expect(readSoon).toHaveLength(2);
+    expect(readSoon.map((b) => b.id)).toEqual(["bk-1", "bk-3"]);
+
+    const unsorted = bookmarks.filter((b) => (b.intent ?? "unsorted") === "unsorted");
+    expect(unsorted).toHaveLength(1);
+  });
+});

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -5,6 +5,7 @@ import type {
   ReadingProgress,
   Highlight,
   ReadLogEntry,
+  DailyQueue,
 } from "../types";
 import { sanitizeBookmark } from "../lib/sanitize";
 import { emitReaderActivity } from "../lib/reader-activity";
@@ -17,6 +18,7 @@ import {
   STORE_READING_PROGRESS as PROGRESS_STORE_NAME,
   STORE_HIGHLIGHTS as HIGHLIGHTS_STORE_NAME,
   STORE_READ_LOG as READ_LOG_STORE_NAME,
+  STORE_DAILY_QUEUE as DAILY_QUEUE_STORE_NAME,
 } from "../lib/constants";
 import { LEGACY_IDB_DATABASE_NAME } from "../lib/storage-keys";
 
@@ -59,6 +61,10 @@ interface XBookmarksDbSchema extends DBSchema {
     indexes: {
       markedReadAt: number;
     };
+  };
+  daily_queue: {
+    key: string;
+    value: DailyQueue;
   };
 }
 
@@ -161,6 +167,10 @@ function createDb(dbName: string) {
         readLogStore.createIndex("markedReadAt", "markedReadAt", {
           unique: false,
         });
+      }
+
+      if (!db.objectStoreNames.contains(DAILY_QUEUE_STORE_NAME)) {
+        db.createObjectStore(DAILY_QUEUE_STORE_NAME, { keyPath: "date" });
       }
 
       if (oldVersion < 7) {
@@ -354,7 +364,7 @@ export async function getAllBookmarks(): Promise<Bookmark[]> {
 export async function clearAllLocalData(): Promise<void> {
   const db = await getDb();
   const tx = db.transaction(
-    [STORE_NAME, DETAIL_STORE_NAME, PROGRESS_STORE_NAME, HIGHLIGHTS_STORE_NAME, READ_LOG_STORE_NAME],
+    [STORE_NAME, DETAIL_STORE_NAME, PROGRESS_STORE_NAME, HIGHLIGHTS_STORE_NAME, READ_LOG_STORE_NAME, DAILY_QUEUE_STORE_NAME],
     "readwrite",
   );
   tx.objectStore(STORE_NAME).clear();
@@ -362,6 +372,7 @@ export async function clearAllLocalData(): Promise<void> {
   tx.objectStore(PROGRESS_STORE_NAME).clear();
   tx.objectStore(HIGHLIGHTS_STORE_NAME).clear();
   tx.objectStore(READ_LOG_STORE_NAME).clear();
+  tx.objectStore(DAILY_QUEUE_STORE_NAME).clear();
   await tx.done;
 }
 
@@ -602,6 +613,17 @@ export async function appendReadLogEntry(bookmarkId: string): Promise<void> {
 export async function getReadLog(): Promise<ReadLogEntry[]> {
   const db = await getDb();
   return db.getAllFromIndex(READ_LOG_STORE_NAME, "markedReadAt");
+}
+
+export async function getDailyQueue(date: string): Promise<DailyQueue | null> {
+  const db = await getDb();
+  const row = await db.get(DAILY_QUEUE_STORE_NAME, date);
+  return row ?? null;
+}
+
+export async function putDailyQueue(queue: DailyQueue): Promise<void> {
+  const db = await getDb();
+  await db.put(DAILY_QUEUE_STORE_NAME, queue);
 }
 
 export async function cleanupOldTweetDetails(

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -86,7 +86,7 @@ export function setActiveAccountId(accountId: string | null | undefined): string
 
 function createDb(dbName: string) {
   return openDB<XBookmarksDbSchema>(dbName, DB_VERSION, {
-    upgrade(db, _oldVersion, _newVersion, tx) {
+    upgrade(db, oldVersion, _newVersion, tx) {
       const bookmarksStore = db.objectStoreNames.contains(STORE_NAME)
         ? tx.objectStore(STORE_NAME)
         : db.createObjectStore(STORE_NAME, { keyPath: "id" });
@@ -138,6 +138,18 @@ function createDb(dbName: string) {
       if (!highlightsStore.indexNames.contains("createdAt")) {
         highlightsStore.createIndex("createdAt", "createdAt", {
           unique: false,
+        });
+      }
+
+      if (oldVersion < 7) {
+        const store = tx.objectStore(STORE_NAME);
+        store.openCursor().then(function migrate(cursor): void {
+          if (!cursor) return;
+          const value = cursor.value;
+          if (!value.intent) {
+            cursor.update({ ...value, intent: "unsorted" });
+          }
+          void cursor.continue().then(migrate);
         });
       }
     },
@@ -309,6 +321,9 @@ export async function getAllBookmarks(): Promise<Bookmark[]> {
     sanitizeBookmark(row);
     if (typeof row.bookmarked !== "boolean") {
       row.bookmarked = true;
+    }
+    if (!row.intent) {
+      row.intent = "unsorted";
     }
   }
   return rows;

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -4,6 +4,7 @@ import type {
   TweetDetailCache,
   ReadingProgress,
   Highlight,
+  ReadLogEntry,
 } from "../types";
 import { sanitizeBookmark } from "../lib/sanitize";
 import { emitReaderActivity } from "../lib/reader-activity";
@@ -15,6 +16,7 @@ import {
   STORE_TWEET_DETAILS as DETAIL_STORE_NAME,
   STORE_READING_PROGRESS as PROGRESS_STORE_NAME,
   STORE_HIGHLIGHTS as HIGHLIGHTS_STORE_NAME,
+  STORE_READ_LOG as READ_LOG_STORE_NAME,
 } from "../lib/constants";
 import { LEGACY_IDB_DATABASE_NAME } from "../lib/storage-keys";
 
@@ -49,6 +51,13 @@ interface XBookmarksDbSchema extends DBSchema {
     indexes: {
       tweetId: string;
       createdAt: number;
+    };
+  };
+  read_log: {
+    key: number;
+    value: ReadLogEntry;
+    indexes: {
+      markedReadAt: number;
     };
   };
 }
@@ -137,6 +146,19 @@ function createDb(dbName: string) {
       }
       if (!highlightsStore.indexNames.contains("createdAt")) {
         highlightsStore.createIndex("createdAt", "createdAt", {
+          unique: false,
+        });
+      }
+
+      const readLogStore = db.objectStoreNames.contains(READ_LOG_STORE_NAME)
+        ? tx.objectStore(READ_LOG_STORE_NAME)
+        : db.createObjectStore(READ_LOG_STORE_NAME, {
+            keyPath: "id",
+            autoIncrement: true,
+          });
+
+      if (!readLogStore.indexNames.contains("markedReadAt")) {
+        readLogStore.createIndex("markedReadAt", "markedReadAt", {
           unique: false,
         });
       }
@@ -332,13 +354,14 @@ export async function getAllBookmarks(): Promise<Bookmark[]> {
 export async function clearAllLocalData(): Promise<void> {
   const db = await getDb();
   const tx = db.transaction(
-    [STORE_NAME, DETAIL_STORE_NAME, PROGRESS_STORE_NAME, HIGHLIGHTS_STORE_NAME],
+    [STORE_NAME, DETAIL_STORE_NAME, PROGRESS_STORE_NAME, HIGHLIGHTS_STORE_NAME, READ_LOG_STORE_NAME],
     "readwrite",
   );
   tx.objectStore(STORE_NAME).clear();
   tx.objectStore(DETAIL_STORE_NAME).clear();
   tx.objectStore(PROGRESS_STORE_NAME).clear();
   tx.objectStore(HIGHLIGHTS_STORE_NAME).clear();
+  tx.objectStore(READ_LOG_STORE_NAME).clear();
   await tx.done;
 }
 
@@ -564,6 +587,21 @@ export async function getHighlightCountsByTweetIds(
     }
   }
   return result;
+}
+
+export async function appendReadLogEntry(bookmarkId: string): Promise<void> {
+  if (!bookmarkId) return;
+  const db = await getDb();
+  await db.add(READ_LOG_STORE_NAME, {
+    bookmarkId,
+    markedReadAt: Date.now(),
+  } as ReadLogEntry);
+  emitReaderActivity();
+}
+
+export async function getReadLog(): Promise<ReadLogEntry[]> {
+  const db = await getDb();
+  return db.getAllFromIndex(READ_LOG_STORE_NAME, "markedReadAt");
 }
 
 export async function cleanupOldTweetDetails(

--- a/src/db/intent-repo.ts
+++ b/src/db/intent-repo.ts
@@ -1,0 +1,69 @@
+import type { Bookmark, BookmarkIntent, IntentSource } from "../types";
+import { getAllBookmarks, upsertBookmarks } from "./index";
+
+export interface IntentUpdate {
+  intent: BookmarkIntent;
+  intentSource: IntentSource;
+  intentConfidence?: number;
+}
+
+export async function getIntent(
+  bookmarkId: string,
+): Promise<BookmarkIntent | null> {
+  const all = await getAllBookmarks();
+  const bookmark = all.find((b) => b.id === bookmarkId);
+  return bookmark?.intent ?? null;
+}
+
+export async function setIntent(
+  bookmarkId: string,
+  update: IntentUpdate,
+): Promise<void> {
+  const all = await getAllBookmarks();
+  const bookmark = all.find((b) => b.id === bookmarkId);
+  if (!bookmark) return;
+
+  const updated: Bookmark = {
+    ...bookmark,
+    intent: update.intent,
+    intentSource: update.intentSource,
+    intentConfidence: update.intentConfidence,
+    intentAssignedAt: new Date().toISOString(),
+  };
+  await upsertBookmarks([updated]);
+}
+
+export async function bulkSetIntent(
+  bookmarkIds: string[],
+  update: IntentUpdate,
+): Promise<void> {
+  if (bookmarkIds.length === 0) return;
+
+  const all = await getAllBookmarks();
+  const idSet = new Set(bookmarkIds);
+  const now = new Date().toISOString();
+  const toUpdate: Bookmark[] = [];
+
+  for (const bookmark of all) {
+    if (idSet.has(bookmark.id)) {
+      toUpdate.push({
+        ...bookmark,
+        intent: update.intent,
+        intentSource: update.intentSource,
+        intentConfidence: update.intentConfidence,
+        intentAssignedAt: now,
+      });
+    }
+  }
+
+  if (toUpdate.length > 0) {
+    await upsertBookmarks(toUpdate);
+  }
+}
+
+export async function getByIntent(
+  intent: BookmarkIntent,
+): Promise<Bookmark[]> {
+  const all = await getAllBookmarks();
+  return all.filter((b) => (b.intent ?? "unsorted") === intent);
+}

--- a/src/hooks/useDailyQueue.ts
+++ b/src/hooks/useDailyQueue.ts
@@ -1,0 +1,130 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Bookmark, DailyQueue } from "../types";
+import { getDailyQueue, putDailyQueue } from "../db";
+import {
+  buildQueue,
+  toLocalDateKey,
+  addDaysToDateKey,
+} from "../lib/queue-builder";
+import { subscribeToReaderActivity } from "../lib/reader-activity";
+
+export interface DailyQueueState {
+  queue: DailyQueue | null;
+  queueBookmarks: Bookmark[];
+  loading: boolean;
+  markCompleted: (bookmarkId: string) => void;
+  markSkipped: (bookmarkId: string) => void;
+}
+
+export function useDailyQueue(
+  bookmarks: Bookmark[],
+  dailyQueueSize: number,
+): DailyQueueState {
+  const [queue, setQueue] = useState<DailyQueue | null>(null);
+  const [loading, setLoading] = useState(true);
+  const buildingRef = useRef(false);
+
+  const todayKey = toLocalDateKey(new Date());
+
+  useEffect(() => {
+    if (bookmarks.length === 0) {
+      setLoading(false);
+      return;
+    }
+    if (buildingRef.current) return;
+
+    let cancelled = false;
+    buildingRef.current = true;
+
+    (async () => {
+      const existing = await getDailyQueue(todayKey);
+      if (cancelled) return;
+
+      if (existing) {
+        setQueue(existing);
+        setLoading(false);
+        buildingRef.current = false;
+        return;
+      }
+
+      const yesterdayKey = addDaysToDateKey(todayKey, -1);
+      const yesterdayQueue = await getDailyQueue(yesterdayKey);
+      if (cancelled) return;
+
+      const built = buildQueue({
+        bookmarks,
+        yesterdayQueue,
+        today: todayKey,
+        size: dailyQueueSize,
+      });
+
+      const newQueue: DailyQueue = {
+        date: todayKey,
+        ...built,
+        createdAt: Date.now(),
+      };
+
+      await putDailyQueue(newQueue);
+      if (cancelled) return;
+
+      setQueue(newQueue);
+      setLoading(false);
+      buildingRef.current = false;
+    })().catch(() => {
+      buildingRef.current = false;
+      setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [todayKey, bookmarks.length, dailyQueueSize, bookmarks]);
+
+  useEffect(() => {
+    return subscribeToReaderActivity(() => {
+      getDailyQueue(todayKey).then((q) => {
+        if (q) setQueue(q);
+      }).catch(() => {});
+    });
+  }, [todayKey]);
+
+  const markCompleted = useCallback(
+    (bookmarkId: string) => {
+      setQueue((prev) => {
+        if (!prev) return prev;
+        if (prev.completedIds.includes(bookmarkId)) return prev;
+        const next: DailyQueue = {
+          ...prev,
+          completedIds: [...prev.completedIds, bookmarkId],
+        };
+        void putDailyQueue(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const markSkipped = useCallback(
+    (bookmarkId: string) => {
+      setQueue((prev) => {
+        if (!prev) return prev;
+        if (prev.skippedIds.includes(bookmarkId)) return prev;
+        const next: DailyQueue = {
+          ...prev,
+          skippedIds: [...prev.skippedIds, bookmarkId],
+        };
+        void putDailyQueue(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const queueBookmarks = queue
+    ? queue.bookmarkIds
+        .map((id) => bookmarks.find((b) => b.id === id))
+        .filter((b): b is Bookmark => b != null)
+    : [];
+
+  return { queue, queueBookmarks, loading, markCompleted, markSkipped };
+}

--- a/src/hooks/useDailyStats.ts
+++ b/src/hooks/useDailyStats.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { getReadLog, getAllReadingProgress } from "../db";
+import { computeDailyStats, type DailyStats } from "../lib/daily-progress";
+import { subscribeToReaderActivity } from "../lib/reader-activity";
+import type { Bookmark } from "../types";
+
+const EMPTY: DailyStats = { readCount: 0, filedToActCount: 0, timeMinutes: 0 };
+
+export function useDailyStats(
+  bookmarks: Bookmark[],
+  enabled: boolean,
+): DailyStats {
+  const [stats, setStats] = useState<DailyStats>(EMPTY);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const refresh = async () => {
+      const [readLog, progress] = await Promise.all([
+        getReadLog(),
+        getAllReadingProgress(),
+      ]);
+      setStats(computeDailyStats(readLog, bookmarks, progress, new Date()));
+    };
+
+    refresh().catch(() => {});
+    return subscribeToReaderActivity(() => {
+      refresh().catch(() => {});
+    });
+  }, [enabled, bookmarks]);
+
+  return stats;
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -28,6 +28,7 @@ const DEFAULT_SETTINGS: UserSettings = {
   backgroundMode: "images",
   searchEngine: "google",
   recommendationSource: "random",
+  dailyQueueSize: 5,
 };
 
 function normalizeSettings(value: unknown): UserSettings {
@@ -64,6 +65,12 @@ function normalizeSettings(value: unknown): UserSettings {
       VALID_RECOMMENDATION_SOURCES.includes(raw.recommendationSource as RecommendationSource)
         ? (raw.recommendationSource as RecommendationSource)
         : DEFAULT_SETTINGS.recommendationSource,
+    dailyQueueSize:
+      typeof raw.dailyQueueSize === "number" &&
+      raw.dailyQueueSize >= 3 &&
+      raw.dailyQueueSize <= 10
+        ? raw.dailyQueueSize
+        : DEFAULT_SETTINGS.dailyQueueSize,
   };
 }
 

--- a/src/hooks/useStreak.ts
+++ b/src/hooks/useStreak.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useState } from "react";
+import { getReadLog } from "../db";
+import { computeStreak, type StreakResult } from "../lib/streak-tracker";
+import { subscribeToReaderActivity } from "../lib/reader-activity";
+
+const EMPTY: StreakResult = { current: 0, longest: 0, isAtRisk: false, earnedToday: false };
+
+export function useStreak(): StreakResult {
+  const [result, setResult] = useState<StreakResult>(EMPTY);
+
+  const refresh = useCallback(() => {
+    getReadLog()
+      .then((log) => setResult(computeStreak(log, new Date())))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    return subscribeToReaderActivity(refresh);
+  }, [refresh]);
+
+  return result;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -217,6 +217,27 @@
             opacity: 0;
         }
     }
+
+    @keyframes intent-tray-in {
+        from {
+            opacity: 0;
+            transform: translateX(-50%) translateY(12px);
+        }
+        to {
+            opacity: 1;
+            transform: translateX(-50%) translateY(0);
+        }
+    }
+    @keyframes intent-tray-out {
+        from {
+            opacity: 1;
+            transform: translateX(-50%) translateY(0);
+        }
+        to {
+            opacity: 0;
+            transform: translateX(-50%) translateY(12px);
+        }
+    }
 }
 
 @layer base {

--- a/src/lib/__tests__/classifier.test.ts
+++ b/src/lib/__tests__/classifier.test.ts
@@ -1,0 +1,313 @@
+import { describe, expect, it } from "vitest";
+import { classify, classifyBatch } from "../classifier";
+import type { Bookmark, TweetUrl } from "../../types";
+
+function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
+  return {
+    id: "bk-1",
+    tweetId: "tw-1",
+    text: "test bookmark text",
+    createdAt: Date.now(),
+    sortIndex: "1234567890000000000",
+    bookmarked: true,
+    author: {
+      name: "Test User",
+      screenName: "testuser",
+      profileImageUrl: "https://example.com/avatar.jpg",
+      verified: false,
+    },
+    metrics: { likes: 10, retweets: 2, replies: 1, views: 500, bookmarks: 0 },
+    media: [],
+    urls: [],
+    isThread: false,
+    hasImage: false,
+    hasVideo: false,
+    hasLink: false,
+    quotedTweet: null,
+    intent: "unsorted",
+    ...overrides,
+  };
+}
+
+function makeUrl(expandedUrl: string, card?: TweetUrl["card"]): TweetUrl {
+  return {
+    url: expandedUrl,
+    displayUrl: expandedUrl,
+    expandedUrl,
+    card,
+  };
+}
+
+describe("classify — Layer 1 structural rules", () => {
+  it("github.com URL → reference", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://github.com/facebook/react")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "reference", confidence: 0.9, source: "structural" });
+  });
+
+  it("arxiv.org URL → reference", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://arxiv.org/abs/2301.00001")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "reference", confidence: 0.9, source: "structural" });
+  });
+
+  it("readthedocs URL → reference", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://flask.readthedocs.io/en/latest/")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "reference", confidence: 0.9, source: "structural" });
+  });
+
+  it("docs subdomain → reference", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://docs.stripe.com/api/charges")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "reference", confidence: 0.9, source: "structural" });
+  });
+
+  it("developer subdomain → reference", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "reference", confidence: 0.9, source: "structural" });
+  });
+
+  it("api subdomain → reference", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://api.openai.com/v1/chat/completions")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "reference", confidence: 0.9, source: "structural" });
+  });
+
+  it("stackoverflow URL → reference", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://stackoverflow.com/questions/12345/how-to-do-x")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "reference", confidence: 0.9, source: "structural" });
+  });
+
+  it("youtube URL → read_soon", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.85, source: "structural" });
+  });
+
+  it("medium blog URL → read_soon", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://medium.com/@author/great-article-abc123")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.85, source: "structural" });
+  });
+
+  it("substack URL → read_soon", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://newsletter.substack.com/p/interesting-post")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.85, source: "structural" });
+  });
+
+  it("tweetKind article → read_soon", () => {
+    const bm = makeBookmark({ tweetKind: "article" });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.9, source: "structural" });
+  });
+
+  it("isThread true → read_soon", () => {
+    const bm = makeBookmark({ isThread: true });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.85, source: "structural" });
+  });
+
+  it("thread opener 1/ → read_soon", () => {
+    const bm = makeBookmark({
+      text: "1/ Here's why this matters for the future of AI...",
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.85, source: "structural" });
+  });
+
+  it("thread opener 1. → read_soon", () => {
+    const bm = makeBookmark({
+      text: "1. A thread on distributed systems fundamentals",
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.85, source: "structural" });
+  });
+
+  it("thread opener 🧵 → read_soon", () => {
+    const bm = makeBookmark({
+      text: "🧵 Let me explain how React Server Components work",
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.85, source: "structural" });
+  });
+
+  it("short no-link post → read_soon", () => {
+    const bm = makeBookmark({
+      text: "Hot take: TypeScript is better than Go for web services.",
+      hasLink: false,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.8, source: "structural" });
+  });
+
+  it("ambiguous long post with unknown link → null", () => {
+    const bm = makeBookmark({
+      text: "This is a somewhat longer post that talks about various things. It has a link to an unknown site that doesn't match any patterns. The text is well over 180 characters so it doesn't match the short post rule either.",
+      urls: [makeUrl("https://randomsite.example.com/page")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toBeNull();
+  });
+
+  it("reference URL takes priority over read_soon URL when both present", () => {
+    const bm = makeBookmark({
+      urls: [
+        makeUrl("https://github.com/some/repo"),
+        makeUrl("https://medium.com/@author/about-the-repo"),
+      ],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result?.intent).toBe("reference");
+  });
+
+  it("/docs path → reference", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://nextjs.org/docs/getting-started")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "reference", confidence: 0.9, source: "structural" });
+  });
+
+  it("blog subdomain → read_soon", () => {
+    const bm = makeBookmark({
+      urls: [makeUrl("https://blog.vercel.com/new-features")],
+      hasLink: true,
+    });
+    const result = classify(bm);
+    expect(result).toEqual({ intent: "read_soon", confidence: 0.85, source: "structural" });
+  });
+});
+
+describe("classifyBatch", () => {
+  it("skips manual-intent bookmarks", () => {
+    const bookmarks = [
+      makeBookmark({
+        id: "manual",
+        intent: "act_on",
+        intentSource: "manual",
+        intentAssignedAt: "2026-01-01T00:00:00.000Z",
+        urls: [makeUrl("https://github.com/facebook/react")],
+        hasLink: true,
+      }),
+    ];
+    const updated = classifyBatch(bookmarks);
+    expect(updated).toHaveLength(0);
+  });
+
+  it("skips already-classified bookmarks", () => {
+    const bookmarks = [
+      makeBookmark({
+        id: "structural",
+        intent: "reference",
+        intentSource: "structural",
+        intentConfidence: 0.9,
+      }),
+    ];
+    const updated = classifyBatch(bookmarks);
+    expect(updated).toHaveLength(0);
+  });
+
+  it("classifies unsorted bookmarks in batch", () => {
+    const bookmarks = [
+      makeBookmark({
+        id: "bk-gh",
+        tweetId: "tw-gh",
+        intent: "unsorted",
+        urls: [makeUrl("https://github.com/repo/name")],
+        hasLink: true,
+      }),
+      makeBookmark({
+        id: "bk-yt",
+        tweetId: "tw-yt",
+        intent: "unsorted",
+        urls: [makeUrl("https://youtube.com/watch?v=123")],
+        hasLink: true,
+      }),
+      makeBookmark({
+        id: "bk-ambig",
+        tweetId: "tw-ambig",
+        intent: "unsorted",
+        text: "A long post about various things that doesn't match any specific patterns and is over 180 characters long so it won't trigger the short post rule at all here.",
+        urls: [makeUrl("https://randomsite.example.com/page")],
+        hasLink: true,
+      }),
+    ];
+    const updated = classifyBatch(bookmarks);
+    expect(updated).toHaveLength(2);
+    expect(updated[0].id).toBe("bk-gh");
+    expect(updated[0].intent).toBe("reference");
+    expect(updated[0].intentSource).toBe("structural");
+    expect(updated[1].id).toBe("bk-yt");
+    expect(updated[1].intent).toBe("read_soon");
+  });
+
+  it("sets intentAssignedAt on classified bookmarks", () => {
+    const bookmarks = [
+      makeBookmark({
+        intent: "unsorted",
+        tweetKind: "article",
+      }),
+    ];
+    const updated = classifyBatch(bookmarks);
+    expect(updated).toHaveLength(1);
+    expect(updated[0].intentAssignedAt).toBeDefined();
+    expect(new Date(updated[0].intentAssignedAt!).getTime()).toBeGreaterThan(0);
+  });
+
+  it("treats missing intent as unsorted", () => {
+    const bm = makeBookmark({ tweetKind: "article" });
+    delete (bm as unknown as Record<string, unknown>).intent;
+    const updated = classifyBatch([bm]);
+    expect(updated).toHaveLength(1);
+    expect(updated[0].intent).toBe("read_soon");
+  });
+
+  it("returns empty array when all bookmarks are ambiguous", () => {
+    const bookmarks = [
+      makeBookmark({
+        text: "Here is a very long post about something. It has a link to an unknown domain and the text itself is well over 180 characters, so no structural rule triggers for this particular bookmark entry.",
+        urls: [makeUrl("https://unknown.example.com/page")],
+        hasLink: true,
+      }),
+    ];
+    const updated = classifyBatch(bookmarks);
+    expect(updated).toHaveLength(0);
+  });
+});

--- a/src/lib/__tests__/classifier.test.ts
+++ b/src/lib/__tests__/classifier.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { classify, classifyBatch } from "../classifier";
+import { classify, classifyBatch, classifyLayer2 } from "../classifier";
 import type { Bookmark, TweetUrl } from "../../types";
 
 function makeBookmark(overrides: Partial<Bookmark> = {}): Bookmark {
@@ -305,6 +305,187 @@ describe("classifyBatch", () => {
         text: "Here is a very long post about something. It has a link to an unknown domain and the text itself is well over 180 characters, so no structural rule triggers for this particular bookmark entry.",
         urls: [makeUrl("https://unknown.example.com/page")],
         hasLink: true,
+      }),
+    ];
+    const updated = classifyBatch(bookmarks);
+    expect(updated).toHaveLength(0);
+  });
+
+  it("chains to Layer 2 when Layer 1 returns null", () => {
+    const bookmarks = [
+      makeBookmark({
+        id: "bk-cheat",
+        intent: "unsorted",
+        text: "The ultimate cheat sheet for Docker commands — bookmark this reference guide for later.",
+        urls: [makeUrl("https://randomsite.example.com/docker")],
+        hasLink: true,
+      }),
+    ];
+    const updated = classifyBatch(bookmarks);
+    expect(updated).toHaveLength(1);
+    expect(updated[0].intent).toBe("reference");
+    expect(updated[0].intentSource).toBe("keyword");
+  });
+
+  it("passes highlightedTweetIds to Layer 2", () => {
+    const bookmarks = [
+      makeBookmark({
+        id: "bk-hl",
+        tweetId: "tw-hl",
+        intent: "unsorted",
+        text: "A long post that doesn't match any structural rules and is over 180 characters. It contains some interesting thoughts about technology and the future of computing but nothing pattern-matching.",
+        createdAt: Date.now() - 100 * 86_400_000,
+        urls: [makeUrl("https://randomsite.example.com/post")],
+        hasLink: true,
+      }),
+    ];
+    const hlSet = new Set(["tw-hl"]);
+    const updated = classifyBatch(bookmarks, hlSet);
+    expect(updated).toHaveLength(1);
+    expect(updated[0].intent).toBe("reference");
+    expect(updated[0].intentSource).toBe("keyword");
+  });
+});
+
+describe("classifyLayer2 — keyword + signal scoring", () => {
+  const NOW = Date.now();
+
+  it("DM me tweet → act_on", () => {
+    const bm = makeBookmark({
+      text: "Just shipped a new tool for React devs. DM me if you want early access, limited spots available.",
+      urls: [makeUrl("https://example.com/tool")],
+      hasLink: true,
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    expect(result).not.toBeNull();
+    expect(result!.intent).toBe("act_on");
+    expect(result!.source).toBe("keyword");
+  });
+
+  it("cheat sheet language → reference", () => {
+    const bm = makeBookmark({
+      text: "The complete cheat sheet for CSS Grid — save this for your next project. A comprehensive reference guide.",
+      urls: [makeUrl("https://example.com/css-grid")],
+      hasLink: true,
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    expect(result).not.toBeNull();
+    expect(result!.intent).toBe("reference");
+  });
+
+  it("stale thread (>90d) with resource language → reference", () => {
+    const bm = makeBookmark({
+      text: "A comprehensive list of resources and tools for building distributed systems. This compilation covers everything from consensus algorithms to observability toolkits.",
+      createdAt: NOW - 100 * 86_400_000,
+      urls: [makeUrl("https://example.com/old")],
+      hasLink: true,
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    expect(result).not.toBeNull();
+    expect(result!.intent).toBe("reference");
+  });
+
+  it("high engagement (>500 retweets) + staleness + resource keywords → reference", () => {
+    const bm = makeBookmark({
+      text: "The best compilation of resources for startup founders. A toolkit and benchmark comparison of every tool you need to know about.",
+      createdAt: NOW - 45 * 86_400_000,
+      metrics: { likes: 5000, retweets: 1200, replies: 300, views: 500000, bookmarks: 200 },
+      urls: [makeUrl("https://example.com/viral")],
+      hasLink: true,
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    expect(result).not.toBeNull();
+    expect(result!.intent).toBe("reference");
+  });
+
+  it("highlights signal → reference boost", () => {
+    const bm = makeBookmark({
+      text: "A generic post that doesn't match keywords well. But the user highlighted parts of it, so it should be classified as a reference. Some more text to make it long enough.",
+      createdAt: NOW - 35 * 86_400_000,
+      urls: [makeUrl("https://example.com/highlighted")],
+      hasLink: true,
+    });
+    const result = classifyLayer2(bm, { hasHighlights: true, now: NOW });
+    expect(result).not.toBeNull();
+    expect(result!.intent).toBe("reference");
+  });
+
+  it("hiring + open roles + join us → act_on", () => {
+    const bm = makeBookmark({
+      text: "We're hiring senior engineers! Open roles in backend and infra. Join us to build the next generation of developer tools. Apply now at the link below.",
+      urls: [makeUrl("https://example.com/careers")],
+      hasLink: true,
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    expect(result).not.toBeNull();
+    expect(result!.intent).toBe("act_on");
+  });
+
+  it("deep dive + must-read content language → read_soon", () => {
+    const bm = makeBookmark({
+      text: "A must-read deep dive into how the Linux kernel handles memory management. Lessons learned from debugging production issues at scale.",
+      urls: [makeUrl("https://example.com/linux")],
+      hasLink: true,
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    expect(result).not.toBeNull();
+    expect(result!.intent).toBe("read_soon");
+  });
+
+  it("ambiguous post with no signals → null", () => {
+    const bm = makeBookmark({
+      text: "Just saw something interesting today. Made me think about how we approach problems differently depending on context.",
+      urls: [makeUrl("https://example.com/random")],
+      hasLink: true,
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    expect(result).toBeNull();
+  });
+
+  it("keyword in card title also scores", () => {
+    const bm = makeBookmark({
+      text: "Bookmark this one.",
+      urls: [
+        makeUrl("https://example.com/page", {
+          title: "The Ultimate Docker Cheat Sheet — A Complete Reference Guide",
+          description: "Everything you need",
+          domain: "example.com",
+        }),
+      ],
+      hasLink: true,
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    expect(result).not.toBeNull();
+    expect(result!.intent).toBe("reference");
+  });
+
+  it("returns confidence between 0.6 and 0.95", () => {
+    const bm = makeBookmark({
+      text: "DM me for the cheat sheet compilation — limited spots for the waitlist, apply now before the deadline.",
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    expect(result).not.toBeNull();
+    expect(result!.confidence).toBeGreaterThanOrEqual(0.6);
+    expect(result!.confidence).toBeLessThanOrEqual(0.95);
+  });
+
+  it("margin check: close scores between intents → null", () => {
+    const bm = makeBookmark({
+      text: "Here is a useful resource with a deep dive breakdown of the topic. Also hiring if you're interested.",
+    });
+    const result = classifyLayer2(bm, { now: NOW });
+    if (result) {
+      expect(result.confidence).toBeGreaterThanOrEqual(0.6);
+    }
+  });
+
+  it("manual intent never overwritten in batch with L2", () => {
+    const bookmarks = [
+      makeBookmark({
+        id: "manual-l2",
+        intent: "act_on",
+        intentSource: "manual",
+        text: "The complete cheat sheet reference guide handbook compilation of resources.",
       }),
     ];
     const updated = classifyBatch(bookmarks);

--- a/src/lib/__tests__/daily-progress.test.ts
+++ b/src/lib/__tests__/daily-progress.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { computeDailyStats } from "../daily-progress";
+import type { Bookmark, ReadLogEntry, ReadingProgress } from "../../types";
+
+const TODAY = new Date("2026-04-17T14:00:00");
+const TODAY_MS = TODAY.getTime();
+const YESTERDAY_MS = TODAY_MS - 24 * 60 * 60 * 1000;
+
+function makeReadEntry(
+  bookmarkId: string,
+  markedReadAt: number,
+): ReadLogEntry {
+  return { bookmarkId, markedReadAt };
+}
+
+function makeBookmark(
+  overrides: Partial<Bookmark> = {},
+): Bookmark {
+  return {
+    id: overrides.id ?? "bm-1",
+    tweetId: overrides.tweetId ?? "t-1",
+    text: "",
+    createdAt: YESTERDAY_MS,
+    author: {
+      id: "a1",
+      name: "Test",
+      screenName: "test",
+      profileImageUrl: "",
+    },
+    metrics: { retweets: 0, likes: 0, replies: 0, quotes: 0 },
+    urls: [],
+    ...overrides,
+  } as Bookmark;
+}
+
+function makeProgress(
+  tweetId: string,
+  openedAt: number,
+  lastReadAt: number,
+): ReadingProgress {
+  return { tweetId, openedAt, lastReadAt, scrollY: 0, scrollHeight: 1000, completed: false };
+}
+
+describe("computeDailyStats", () => {
+  it("counts reads from today only", () => {
+    const log = [
+      makeReadEntry("a", TODAY_MS - 3600_000),
+      makeReadEntry("b", TODAY_MS - 1800_000),
+      makeReadEntry("c", YESTERDAY_MS),
+    ];
+    const stats = computeDailyStats(log, [], [], TODAY);
+    expect(stats.readCount).toBe(2);
+  });
+
+  it("counts act_on filed today", () => {
+    const bookmarks = [
+      makeBookmark({ id: "1", intent: "act_on", intentAssignedAt: TODAY.toISOString() }),
+      makeBookmark({ id: "2", intent: "act_on", intentAssignedAt: new Date(YESTERDAY_MS).toISOString() }),
+      makeBookmark({ id: "3", intent: "reference", intentAssignedAt: TODAY.toISOString() }),
+      makeBookmark({ id: "4", intent: "act_on" }),
+    ];
+    const stats = computeDailyStats([], bookmarks, [], TODAY);
+    expect(stats.filedToActCount).toBe(1);
+  });
+
+  it("sums reading time from today sessions", () => {
+    const progress = [
+      makeProgress("t1", TODAY_MS - 600_000, TODAY_MS - 300_000),
+      makeProgress("t2", TODAY_MS - 120_000, TODAY_MS - 60_000),
+      makeProgress("t3", YESTERDAY_MS - 600_000, YESTERDAY_MS - 300_000),
+    ];
+    const stats = computeDailyStats([], [], progress, TODAY);
+    expect(stats.timeMinutes).toBe(6);
+  });
+
+  it("returns zeros when empty", () => {
+    const stats = computeDailyStats([], [], [], TODAY);
+    expect(stats.readCount).toBe(0);
+    expect(stats.filedToActCount).toBe(0);
+    expect(stats.timeMinutes).toBe(0);
+  });
+
+  it("ignores progress entries with invalid timestamps", () => {
+    const progress = [
+      makeProgress("t1", 0, TODAY_MS),
+      makeProgress("t2", TODAY_MS, TODAY_MS - 100),
+    ];
+    const stats = computeDailyStats([], [], progress, TODAY);
+    expect(stats.timeMinutes).toBe(0);
+  });
+});

--- a/src/lib/__tests__/queue-builder.test.ts
+++ b/src/lib/__tests__/queue-builder.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildQueue,
+  toLocalDateKey,
+  addDaysToDateKey,
+} from "../queue-builder";
+import type { Bookmark, DailyQueue } from "../../types";
+
+function makeBookmark(
+  overrides: Partial<Bookmark> & { id: string },
+): Bookmark {
+  return {
+    tweetId: overrides.id,
+    text: "test",
+    createdAt: Date.now() - 30 * 24 * 60 * 60 * 1000,
+    sortIndex: "0",
+    bookmarked: true,
+    author: {
+      name: "Test",
+      screenName: "test",
+      profileImageUrl: "",
+      verified: false,
+    },
+    metrics: { likes: 0, retweets: 0, replies: 0, views: 0, bookmarks: 0 },
+    media: [],
+    urls: [],
+    isThread: false,
+    hasImage: false,
+    hasVideo: false,
+    hasLink: false,
+    quotedTweet: null,
+    intent: "unsorted",
+    ...overrides,
+  };
+}
+
+function makeQueue(overrides: Partial<DailyQueue>): DailyQueue {
+  return {
+    date: "2026-04-16",
+    bookmarkIds: [],
+    completedIds: [],
+    skippedIds: [],
+    createdAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe("buildQueue", () => {
+  it("returns empty queue when no bookmarks", () => {
+    const result = buildQueue({
+      bookmarks: [],
+      yesterdayQueue: null,
+      today: "2026-04-17",
+      size: 5,
+    });
+    expect(result.bookmarkIds).toEqual([]);
+  });
+
+  it("picks act_on items before read_soon", () => {
+    const bookmarks = [
+      makeBookmark({ id: "rs-1", intent: "read_soon", createdAt: 1000 }),
+      makeBookmark({ id: "ao-1", intent: "act_on", createdAt: 2000 }),
+      makeBookmark({ id: "rs-2", intent: "read_soon", createdAt: 500 }),
+    ];
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: null,
+      today: "2026-04-17",
+      size: 5,
+    });
+    expect(result.bookmarkIds[0]).toBe("ao-1");
+  });
+
+  it("carries over yesterday skipped items first", () => {
+    const bookmarks = [
+      makeBookmark({ id: "sk-1", intent: "read_soon", createdAt: 1000 }),
+      makeBookmark({ id: "ao-1", intent: "act_on", createdAt: 2000 }),
+    ];
+    const yesterday = makeQueue({
+      date: "2026-04-16",
+      skippedIds: ["sk-1"],
+    });
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: yesterday,
+      today: "2026-04-17",
+      size: 5,
+    });
+    expect(result.bookmarkIds[0]).toBe("sk-1");
+    expect(result.bookmarkIds[1]).toBe("ao-1");
+  });
+
+  it("excludes items in cooldown", () => {
+    const tomorrow = new Date("2026-04-18T00:00:00").toISOString();
+    const bookmarks = [
+      makeBookmark({
+        id: "cd-1",
+        intent: "read_soon",
+        cooldownUntil: tomorrow,
+        createdAt: 1000,
+      }),
+      makeBookmark({ id: "ok-1", intent: "read_soon", createdAt: 2000 }),
+    ];
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: null,
+      today: "2026-04-17",
+      size: 5,
+    });
+    expect(result.bookmarkIds).toEqual(["ok-1"]);
+  });
+
+  it("excludes skipped items with skipCount >= 3 (non-manual)", () => {
+    const bookmarks = [
+      makeBookmark({
+        id: "sk3-1",
+        intent: "read_soon",
+        skipCount: 3,
+        intentSource: "structural",
+        createdAt: 1000,
+      }),
+    ];
+    const yesterday = makeQueue({ skippedIds: ["sk3-1"] });
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: yesterday,
+      today: "2026-04-17",
+      size: 5,
+    });
+    expect(result.bookmarkIds).not.toContain("sk3-1");
+  });
+
+  it("keeps manual-intent items even with skipCount >= 3", () => {
+    const bookmarks = [
+      makeBookmark({
+        id: "m-1",
+        intent: "read_soon",
+        skipCount: 3,
+        intentSource: "manual",
+        createdAt: 1000,
+      }),
+    ];
+    const yesterday = makeQueue({ skippedIds: ["m-1"] });
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: yesterday,
+      today: "2026-04-17",
+      size: 5,
+    });
+    expect(result.bookmarkIds).toContain("m-1");
+  });
+
+  it("truncates to size", () => {
+    const bookmarks = Array.from({ length: 10 }, (_, i) =>
+      makeBookmark({
+        id: `b-${i}`,
+        intent: "read_soon",
+        createdAt: i * 1000,
+      }),
+    );
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: null,
+      today: "2026-04-17",
+      size: 3,
+    });
+    expect(result.bookmarkIds).toHaveLength(3);
+  });
+
+  it("picks oldest read_soon first, then recent for variety", () => {
+    const now = new Date("2026-04-17T12:00:00").getTime();
+    const bookmarks = [
+      makeBookmark({ id: "old-1", intent: "read_soon", createdAt: 1000 }),
+      makeBookmark({ id: "old-2", intent: "read_soon", createdAt: 2000 }),
+      makeBookmark({ id: "old-3", intent: "read_soon", createdAt: 3000 }),
+      makeBookmark({
+        id: "new-1",
+        intent: "read_soon",
+        createdAt: now - 2 * 24 * 60 * 60 * 1000,
+      }),
+      makeBookmark({
+        id: "new-2",
+        intent: "read_soon",
+        createdAt: now - 1 * 24 * 60 * 60 * 1000,
+      }),
+    ];
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: null,
+      today: "2026-04-17",
+      size: 5,
+    });
+    expect(result.bookmarkIds.slice(0, 3)).toEqual([
+      "old-1",
+      "old-2",
+      "old-3",
+    ]);
+  });
+
+  it("ignores reference and unsorted bookmarks", () => {
+    const bookmarks = [
+      makeBookmark({ id: "ref-1", intent: "reference", createdAt: 1000 }),
+      makeBookmark({ id: "uns-1", intent: "unsorted", createdAt: 2000 }),
+      makeBookmark({ id: "rs-1", intent: "read_soon", createdAt: 3000 }),
+    ];
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: null,
+      today: "2026-04-17",
+      size: 5,
+    });
+    expect(result.bookmarkIds).toEqual(["rs-1"]);
+  });
+
+  it("does not duplicate carry-over items", () => {
+    const bookmarks = [
+      makeBookmark({ id: "sk-1", intent: "act_on", createdAt: 1000 }),
+    ];
+    const yesterday = makeQueue({ skippedIds: ["sk-1"] });
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: yesterday,
+      today: "2026-04-17",
+      size: 5,
+    });
+    const occurrences = result.bookmarkIds.filter(
+      (id) => id === "sk-1",
+    ).length;
+    expect(occurrences).toBe(1);
+  });
+
+  it("initializes with empty completedIds and skippedIds", () => {
+    const bookmarks = [
+      makeBookmark({ id: "b-1", intent: "read_soon", createdAt: 1000 }),
+    ];
+    const result = buildQueue({
+      bookmarks,
+      yesterdayQueue: null,
+      today: "2026-04-17",
+      size: 5,
+    });
+    expect(result.completedIds).toEqual([]);
+    expect(result.skippedIds).toEqual([]);
+  });
+});
+
+describe("toLocalDateKey", () => {
+  it("formats date as YYYY-MM-DD", () => {
+    expect(toLocalDateKey(new Date(2026, 3, 17))).toBe("2026-04-17");
+  });
+
+  it("zero-pads month and day", () => {
+    expect(toLocalDateKey(new Date(2026, 0, 5))).toBe("2026-01-05");
+  });
+});
+
+describe("addDaysToDateKey", () => {
+  it("adds days correctly", () => {
+    expect(addDaysToDateKey("2026-04-17", 1)).toBe("2026-04-18");
+  });
+
+  it("subtracts days correctly", () => {
+    expect(addDaysToDateKey("2026-04-17", -1)).toBe("2026-04-16");
+  });
+
+  it("handles month boundaries", () => {
+    expect(addDaysToDateKey("2026-04-30", 1)).toBe("2026-05-01");
+  });
+});

--- a/src/lib/__tests__/streak-tracker.test.ts
+++ b/src/lib/__tests__/streak-tracker.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import { computeStreak } from "../streak-tracker";
+import type { ReadLogEntry } from "../../types";
+
+function entry(bookmarkId: string, markedReadAt: number): ReadLogEntry {
+  return { bookmarkId, markedReadAt };
+}
+
+function localNoon(dateStr: string): Date {
+  return new Date(`${dateStr}T12:00:00`);
+}
+
+function localTimestamp(dateStr: string, hours: number, minutes = 0): number {
+  const d = new Date(`${dateStr}T00:00:00`);
+  d.setHours(hours, minutes, 0, 0);
+  return d.getTime();
+}
+
+describe("computeStreak", () => {
+  it("returns zeros for empty log", () => {
+    const result = computeStreak([], localNoon("2026-04-17"));
+    expect(result).toEqual({ current: 0, longest: 0, isAtRisk: false, earnedToday: false });
+  });
+
+  it("single read today does not earn a streak day", () => {
+    const today = localNoon("2026-04-17");
+    const log = [entry("bk-1", localTimestamp("2026-04-17", 9))];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(0);
+    expect(result.earnedToday).toBe(false);
+  });
+
+  it("two reads today earns streak day", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-17", 9)),
+      entry("bk-2", localTimestamp("2026-04-17", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(1);
+    expect(result.longest).toBe(1);
+    expect(result.earnedToday).toBe(true);
+  });
+
+  it("three reads today still counts as one streak day", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-17", 8)),
+      entry("bk-2", localTimestamp("2026-04-17", 9)),
+      entry("bk-3", localTimestamp("2026-04-17", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(1);
+    expect(result.earnedToday).toBe(true);
+  });
+
+  it("consecutive days build a streak", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-15", 9)),
+      entry("bk-2", localTimestamp("2026-04-15", 10)),
+      entry("bk-3", localTimestamp("2026-04-16", 9)),
+      entry("bk-4", localTimestamp("2026-04-16", 10)),
+      entry("bk-5", localTimestamp("2026-04-17", 9)),
+      entry("bk-6", localTimestamp("2026-04-17", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(3);
+    expect(result.longest).toBe(3);
+    expect(result.earnedToday).toBe(true);
+  });
+
+  it("missing a full day resets current streak to 0", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-14", 9)),
+      entry("bk-2", localTimestamp("2026-04-14", 10)),
+      entry("bk-3", localTimestamp("2026-04-15", 9)),
+      entry("bk-4", localTimestamp("2026-04-15", 10)),
+      // skipped 2026-04-16
+      entry("bk-5", localTimestamp("2026-04-17", 9)),
+      entry("bk-6", localTimestamp("2026-04-17", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(1);
+    expect(result.longest).toBe(2);
+    expect(result.earnedToday).toBe(true);
+  });
+
+  it("longest is preserved even when current resets", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      // 5-day streak in early April
+      ...Array.from({ length: 5 }, (_, i) => [
+        entry(`a-${i}`, localTimestamp(`2026-04-0${i + 1}`, 9)),
+        entry(`b-${i}`, localTimestamp(`2026-04-0${i + 1}`, 10)),
+      ]).flat(),
+      // gap then today
+      entry("bk-x", localTimestamp("2026-04-17", 9)),
+      entry("bk-y", localTimestamp("2026-04-17", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(1);
+    expect(result.longest).toBe(5);
+  });
+
+  it("single-read days do not count toward streak", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-15", 9)),
+      entry("bk-2", localTimestamp("2026-04-15", 10)),
+      // only 1 read on the 16th
+      entry("bk-3", localTimestamp("2026-04-16", 9)),
+      entry("bk-4", localTimestamp("2026-04-17", 9)),
+      entry("bk-5", localTimestamp("2026-04-17", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(1);
+    expect(result.earnedToday).toBe(true);
+  });
+
+  it("yesterday-only streak is current if no reads today", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-16", 9)),
+      entry("bk-2", localTimestamp("2026-04-16", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(1);
+    expect(result.earnedToday).toBe(false);
+    expect(result.isAtRisk).toBe(true);
+  });
+
+  it("streak from two days ago with no yesterday or today is broken", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-15", 9)),
+      entry("bk-2", localTimestamp("2026-04-15", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(0);
+    expect(result.earnedToday).toBe(false);
+    expect(result.isAtRisk).toBe(false);
+  });
+
+  it("isAtRisk is true when yesterday qualified but today has not yet", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-15", 9)),
+      entry("bk-2", localTimestamp("2026-04-15", 10)),
+      entry("bk-3", localTimestamp("2026-04-16", 9)),
+      entry("bk-4", localTimestamp("2026-04-16", 10)),
+      // only 1 read today
+      entry("bk-5", localTimestamp("2026-04-17", 9)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(2);
+    expect(result.earnedToday).toBe(false);
+    expect(result.isAtRisk).toBe(true);
+  });
+
+  it("isAtRisk is false when today is already earned", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-16", 9)),
+      entry("bk-2", localTimestamp("2026-04-16", 10)),
+      entry("bk-3", localTimestamp("2026-04-17", 9)),
+      entry("bk-4", localTimestamp("2026-04-17", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.earnedToday).toBe(true);
+    expect(result.isAtRisk).toBe(false);
+  });
+
+  it("handles midnight boundary — reads at 23:59 and 00:01 are different days", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-16", 23, 58)),
+      entry("bk-2", localTimestamp("2026-04-16", 23, 59)),
+      entry("bk-3", localTimestamp("2026-04-17", 0, 1)),
+      entry("bk-4", localTimestamp("2026-04-17", 0, 2)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(2);
+    expect(result.earnedToday).toBe(true);
+  });
+
+  it("duplicate bookmark reads still count toward threshold", () => {
+    const today = localNoon("2026-04-17");
+    const log = [
+      entry("bk-1", localTimestamp("2026-04-17", 9)),
+      entry("bk-1", localTimestamp("2026-04-17", 10)),
+    ];
+    const result = computeStreak(log, today);
+    expect(result.current).toBe(1);
+    expect(result.earnedToday).toBe(true);
+  });
+});

--- a/src/lib/classifier.ts
+++ b/src/lib/classifier.ts
@@ -3,7 +3,7 @@ import type { Bookmark, BookmarkIntent } from "../types";
 export interface ClassifyResult {
   intent: BookmarkIntent;
   confidence: number;
-  source: "structural";
+  source: "structural" | "keyword";
 }
 
 const REFERENCE_URL_PATTERNS: RegExp[] = [
@@ -82,15 +82,152 @@ export function classify(bookmark: Bookmark): ClassifyResult | null {
   return null;
 }
 
-export function classifyBatch(bookmarks: Bookmark[]): Bookmark[] {
+// --- Layer 2: keyword + signal scoring ---
+
+interface KeywordRule {
+  pattern: RegExp;
+  intent: BookmarkIntent;
+  weight: number;
+}
+
+const KEYWORD_RULES: KeywordRule[] = [
+  // act_on patterns
+  { pattern: /\bDM me\b/i, intent: "act_on", weight: 1.5 },
+  { pattern: /\bsign up\b/i, intent: "act_on", weight: 1.0 },
+  { pattern: /\bapply\s+(now|here|today)\b/i, intent: "act_on", weight: 1.2 },
+  { pattern: /\bregister\s+(now|here|today)\b/i, intent: "act_on", weight: 1.0 },
+  { pattern: /\bdeadline\b/i, intent: "act_on", weight: 1.0 },
+  { pattern: /\blast\s+(day|chance)\b/i, intent: "act_on", weight: 1.0 },
+  { pattern: /\blimited\s+(spots?|seats?|time)\b/i, intent: "act_on", weight: 1.0 },
+  { pattern: /\bhiring\b/i, intent: "act_on", weight: 0.8 },
+  { pattern: /\bopen\s+roles?\b/i, intent: "act_on", weight: 0.8 },
+  { pattern: /\bjoin\s+(us|our)\b/i, intent: "act_on", weight: 0.6 },
+  { pattern: /\blanuch(ing|ed)?\b/i, intent: "act_on", weight: 0.6 },
+  { pattern: /\bwaitlist\b/i, intent: "act_on", weight: 0.8 },
+
+  // reference patterns (cheat-sheet / resource language)
+  { pattern: /\bcheat\s*sheet\b/i, intent: "reference", weight: 1.5 },
+  { pattern: /\bresources?\b/i, intent: "reference", weight: 0.6 },
+  { pattern: /\bhandbook\b/i, intent: "reference", weight: 1.0 },
+  { pattern: /\breference\s+guide\b/i, intent: "reference", weight: 1.2 },
+  { pattern: /\bcompilation\b/i, intent: "reference", weight: 0.8 },
+  { pattern: /\blist\s+of\b/i, intent: "reference", weight: 0.6 },
+  { pattern: /\bawesome[\s-]/i, intent: "reference", weight: 1.0 },
+  { pattern: /\bcollection\s+of\b/i, intent: "reference", weight: 0.6 },
+  { pattern: /\bbenchmark/i, intent: "reference", weight: 0.6 },
+  { pattern: /\btoolkit\b/i, intent: "reference", weight: 0.6 },
+  { pattern: /\bcomparison\b/i, intent: "reference", weight: 0.6 },
+
+  // read_soon patterns (content language)
+  { pattern: /\bdeep\s+dive\b/i, intent: "read_soon", weight: 1.0 },
+  { pattern: /\bbreakdown\b/i, intent: "read_soon", weight: 0.6 },
+  { pattern: /\bexplained\b/i, intent: "read_soon", weight: 0.6 },
+  { pattern: /\blessons?\s+learned\b/i, intent: "read_soon", weight: 0.8 },
+  { pattern: /\bmistakes?\s+(I|we)\b/i, intent: "read_soon", weight: 0.8 },
+  { pattern: /\bunpopular\s+opinion\b/i, intent: "read_soon", weight: 0.6 },
+  { pattern: /\bhot\s+take\b/i, intent: "read_soon", weight: 0.6 },
+  { pattern: /\bhere'?s?\s+(what|how|why)\b/i, intent: "read_soon", weight: 0.5 },
+  { pattern: /\bmust[\s-]read\b/i, intent: "read_soon", weight: 1.0 },
+];
+
+const L2_SCORE_THRESHOLD = 1.5;
+const L2_MARGIN = 0.5;
+const DAY_MS = 86_400_000;
+
+function getTextForScoring(bookmark: Bookmark): string {
+  const parts: string[] = [];
+  if (bookmark.text) parts.push(bookmark.text);
+  const cardTitle = bookmark.urls?.[0]?.card?.title;
+  if (cardTitle) parts.push(cardTitle);
+  return parts.join(" ");
+}
+
+export interface Layer2Context {
+  hasHighlights?: boolean;
+  now?: number;
+}
+
+export function classifyLayer2(
+  bookmark: Bookmark,
+  ctx: Layer2Context = {},
+): ClassifyResult | null {
+  const scores: Record<BookmarkIntent, number> = {
+    read_soon: 0,
+    reference: 0,
+    act_on: 0,
+    unsorted: 0,
+  };
+
+  const text = getTextForScoring(bookmark);
+
+  for (const rule of KEYWORD_RULES) {
+    if (rule.pattern.test(text)) {
+      scores[rule.intent] += rule.weight;
+    }
+  }
+
+  const now = ctx.now ?? Date.now();
+  const ageMs = now - bookmark.createdAt;
+  const ageDays = ageMs / DAY_MS;
+
+  if (ageDays > 90) {
+    scores.reference += 1;
+    scores.read_soon -= 1;
+  } else if (ageDays > 30) {
+    scores.reference += 0.5;
+  }
+
+  if ((bookmark.metrics?.retweets ?? 0) > 500) {
+    scores.reference += 0.5;
+  }
+
+  if (ctx.hasHighlights) {
+    scores.reference += 1;
+  }
+
+  const intents: BookmarkIntent[] = ["read_soon", "reference", "act_on"];
+  let best: BookmarkIntent = "unsorted";
+  let bestScore = -Infinity;
+  let secondScore = -Infinity;
+
+  for (const intent of intents) {
+    if (scores[intent] > bestScore) {
+      secondScore = bestScore;
+      bestScore = scores[intent];
+      best = intent;
+    } else if (scores[intent] > secondScore) {
+      secondScore = scores[intent];
+    }
+  }
+
+  if (bestScore < L2_SCORE_THRESHOLD) return null;
+  if (bestScore - secondScore < L2_MARGIN) return null;
+
+  const confidence = Math.min(0.6 + bestScore * 0.1, 0.95);
+  return { intent: best, confidence, source: "keyword" };
+}
+
+export function classifyBatch(
+  bookmarks: Bookmark[],
+  highlightedTweetIds?: ReadonlySet<string>,
+): Bookmark[] {
   const now = new Date().toISOString();
+  const nowMs = Date.now();
   const updated: Bookmark[] = [];
 
   for (const bm of bookmarks) {
     if (bm.intentSource === "manual") continue;
     if ((bm.intent ?? "unsorted") !== "unsorted") continue;
 
-    const result = classify(bm);
+    let result = classify(bm);
+
+    if (!result || result.confidence < CONFIDENCE_THRESHOLD) {
+      result = classifyLayer2(bm, {
+        hasHighlights: highlightedTweetIds?.has(bm.tweetId),
+        now: nowMs,
+      });
+    }
+
     if (result && result.confidence >= CONFIDENCE_THRESHOLD) {
       updated.push({
         ...bm,

--- a/src/lib/classifier.ts
+++ b/src/lib/classifier.ts
@@ -1,0 +1,106 @@
+import type { Bookmark, BookmarkIntent } from "../types";
+
+export interface ClassifyResult {
+  intent: BookmarkIntent;
+  confidence: number;
+  source: "structural";
+}
+
+const REFERENCE_URL_PATTERNS: RegExp[] = [
+  /github\.com(?:\/|$)/i,
+  /arxiv\.org/i,
+  /readthedocs\.(io|org)/i,
+  /\bdocs\./i,
+  /\bdeveloper\./i,
+  /\bapi\./i,
+  /\/docs(?:\/|$)/i,
+  /\/api(?:\/|$)/i,
+  /npmjs\.com/i,
+  /pypi\.org/i,
+  /crates\.io/i,
+  /pkg\.go\.dev/i,
+  /mdn\.mozilla\.org/i,
+  /stackoverflow\.com/i,
+];
+
+const READ_SOON_URL_PATTERNS: RegExp[] = [
+  /youtube\.com/i,
+  /youtu\.be/i,
+  /medium\.com/i,
+  /substack\.com/i,
+  /\bblog\./i,
+  /\/blog(?:\/|$)/i,
+];
+
+const THREAD_OPENER = /^(?:1[/.)]\s|🧵)/;
+
+const CONFIDENCE_THRESHOLD = 0.8;
+
+function matchUrl(
+  urls: Bookmark["urls"],
+  patterns: RegExp[],
+): boolean {
+  for (const u of urls) {
+    const href = u.expandedUrl || u.url;
+    if (!href) continue;
+    for (const p of patterns) {
+      if (p.test(href)) return true;
+    }
+  }
+  return false;
+}
+
+export function classify(bookmark: Bookmark): ClassifyResult | null {
+  const urls = bookmark.urls ?? [];
+
+  if (matchUrl(urls, REFERENCE_URL_PATTERNS)) {
+    return { intent: "reference", confidence: 0.9, source: "structural" };
+  }
+
+  if (matchUrl(urls, READ_SOON_URL_PATTERNS)) {
+    return { intent: "read_soon", confidence: 0.85, source: "structural" };
+  }
+
+  if (bookmark.tweetKind === "article") {
+    return { intent: "read_soon", confidence: 0.9, source: "structural" };
+  }
+
+  if (bookmark.isThread) {
+    return { intent: "read_soon", confidence: 0.85, source: "structural" };
+  }
+
+  const text = (bookmark.text ?? "").trim();
+
+  if (THREAD_OPENER.test(text)) {
+    return { intent: "read_soon", confidence: 0.85, source: "structural" };
+  }
+
+  if (!bookmark.hasLink && text.length > 0 && text.length < 180) {
+    return { intent: "read_soon", confidence: 0.8, source: "structural" };
+  }
+
+  return null;
+}
+
+export function classifyBatch(bookmarks: Bookmark[]): Bookmark[] {
+  const now = new Date().toISOString();
+  const updated: Bookmark[] = [];
+
+  for (const bm of bookmarks) {
+    if (bm.intentSource === "manual") continue;
+    if ((bm.intent ?? "unsorted") !== "unsorted") continue;
+
+    const result = classify(bm);
+    if (result && result.confidence >= CONFIDENCE_THRESHOLD) {
+      updated.push({
+        ...bm,
+        intent: result.intent,
+        intentSource: result.source,
+        intentConfidence: result.confidence,
+        intentAssignedAt: now,
+      });
+    }
+  }
+
+  return updated;
+}

--- a/src/lib/constants/db.ts
+++ b/src/lib/constants/db.ts
@@ -2,7 +2,7 @@ import { IDB_ACCOUNT_DATABASE_PREFIX, IDB_DATABASE_NAME } from "../storage-keys"
 
 export const DB_NAME = IDB_DATABASE_NAME;
 export const DB_ACCOUNT_PREFIX = IDB_ACCOUNT_DATABASE_PREFIX;
-export const DB_VERSION = 6;
+export const DB_VERSION = 7;
 export const STORE_BOOKMARKS = "bookmarks";
 export const STORE_TWEET_DETAILS = "tweet_details";
 export const STORE_READING_PROGRESS = "reading_progress";

--- a/src/lib/constants/db.ts
+++ b/src/lib/constants/db.ts
@@ -2,8 +2,9 @@ import { IDB_ACCOUNT_DATABASE_PREFIX, IDB_DATABASE_NAME } from "../storage-keys"
 
 export const DB_NAME = IDB_DATABASE_NAME;
 export const DB_ACCOUNT_PREFIX = IDB_ACCOUNT_DATABASE_PREFIX;
-export const DB_VERSION = 7;
+export const DB_VERSION = 8;
 export const STORE_BOOKMARKS = "bookmarks";
 export const STORE_TWEET_DETAILS = "tweet_details";
 export const STORE_READING_PROGRESS = "reading_progress";
 export const STORE_HIGHLIGHTS = "highlights";
+export const STORE_READ_LOG = "read_log";

--- a/src/lib/constants/db.ts
+++ b/src/lib/constants/db.ts
@@ -2,9 +2,10 @@ import { IDB_ACCOUNT_DATABASE_PREFIX, IDB_DATABASE_NAME } from "../storage-keys"
 
 export const DB_NAME = IDB_DATABASE_NAME;
 export const DB_ACCOUNT_PREFIX = IDB_ACCOUNT_DATABASE_PREFIX;
-export const DB_VERSION = 8;
+export const DB_VERSION = 9;
 export const STORE_BOOKMARKS = "bookmarks";
 export const STORE_TWEET_DETAILS = "tweet_details";
 export const STORE_READING_PROGRESS = "reading_progress";
 export const STORE_HIGHLIGHTS = "highlights";
 export const STORE_READ_LOG = "read_log";
+export const STORE_DAILY_QUEUE = "daily_queue";

--- a/src/lib/daily-progress.ts
+++ b/src/lib/daily-progress.ts
@@ -1,0 +1,44 @@
+import type { Bookmark, ReadLogEntry, ReadingProgress } from "../types";
+import { toLocalDateKey } from "./queue-builder";
+
+export interface DailyStats {
+  readCount: number;
+  filedToActCount: number;
+  timeMinutes: number;
+}
+
+export function computeDailyStats(
+  readLog: ReadLogEntry[],
+  bookmarks: Bookmark[],
+  readingProgress: ReadingProgress[],
+  today: Date,
+): DailyStats {
+  const todayKey = toLocalDateKey(today);
+
+  const readCount = readLog.filter(
+    (entry) => toLocalDateKey(new Date(entry.markedReadAt)) === todayKey,
+  ).length;
+
+  const filedToActCount = bookmarks.filter((b) => {
+    if (b.intent !== "act_on" || !b.intentAssignedAt) return false;
+    return toLocalDateKey(new Date(b.intentAssignedAt)) === todayKey;
+  }).length;
+
+  let timeMs = 0;
+  for (const p of readingProgress) {
+    if (
+      p.lastReadAt > 0 &&
+      p.openedAt > 0 &&
+      p.lastReadAt > p.openedAt &&
+      toLocalDateKey(new Date(p.lastReadAt)) === todayKey
+    ) {
+      timeMs += p.lastReadAt - p.openedAt;
+    }
+  }
+
+  return {
+    readCount,
+    filedToActCount,
+    timeMinutes: Math.round(timeMs / 60_000),
+  };
+}

--- a/src/lib/queue-builder.ts
+++ b/src/lib/queue-builder.ts
@@ -1,0 +1,122 @@
+import type { Bookmark, DailyQueue } from "../types";
+
+export interface QueueBuilderInput {
+  bookmarks: Bookmark[];
+  yesterdayQueue: DailyQueue | null;
+  today: string;
+  size: number;
+}
+
+export interface BuiltQueue {
+  bookmarkIds: string[];
+  completedIds: string[];
+  skippedIds: string[];
+}
+
+function isInCooldown(bookmark: Bookmark, now: number): boolean {
+  if (!bookmark.cooldownUntil) return false;
+  return new Date(bookmark.cooldownUntil).getTime() > now;
+}
+
+export function buildQueue(input: QueueBuilderInput): BuiltQueue {
+  const { bookmarks, yesterdayQueue, today, size } = input;
+  const now = new Date(today + "T12:00:00").getTime();
+  const sevenDaysAgo = now - 7 * 24 * 60 * 60 * 1000;
+
+  const byId = new Map<string, Bookmark>();
+  for (const b of bookmarks) {
+    byId.set(b.id, b);
+  }
+
+  const picked = new Set<string>();
+  const result: string[] = [];
+
+  function add(id: string): boolean {
+    if (picked.has(id)) return false;
+    if (result.length >= size) return false;
+    picked.add(id);
+    result.push(id);
+    return true;
+  }
+
+  // 1. Carry over yesterday's skipped (that still exist and aren't in cooldown)
+  if (yesterdayQueue) {
+    for (const id of yesterdayQueue.skippedIds) {
+      if (result.length >= size) break;
+      const b = byId.get(id);
+      if (!b || isInCooldown(b, now)) continue;
+      if ((b.skipCount ?? 0) >= 3 && b.intentSource !== "manual") continue;
+      add(id);
+    }
+  }
+
+  function shouldExclude(b: Bookmark): boolean {
+    if (isInCooldown(b, now)) return true;
+    if ((b.skipCount ?? 0) >= 3 && b.intentSource !== "manual") return true;
+    return false;
+  }
+
+  // 2. All Act-on items not in cooldown
+  const actOn = bookmarks
+    .filter(
+      (b) =>
+        b.intent === "act_on" && !shouldExclude(b) && !picked.has(b.id),
+    )
+    .sort((a, b) => a.createdAt - b.createdAt);
+  for (const b of actOn) {
+    if (result.length >= size) break;
+    add(b.id);
+  }
+
+  // 3. Oldest Read-soon items not in cooldown
+  const readSoon = bookmarks
+    .filter(
+      (b) =>
+        b.intent === "read_soon" &&
+        !shouldExclude(b) &&
+        !picked.has(b.id),
+    )
+    .sort((a, b) => a.createdAt - b.createdAt);
+  for (const b of readSoon) {
+    if (result.length >= size) break;
+    add(b.id);
+  }
+
+  // 4. 1–2 recent Read-soon saves (last 7 days) for variety
+  if (result.length < size) {
+    const recentReadSoon = bookmarks
+      .filter(
+        (b) =>
+          b.intent === "read_soon" &&
+          !shouldExclude(b) &&
+          !picked.has(b.id) &&
+          b.createdAt >= sevenDaysAgo,
+      )
+      .sort((a, b) => b.createdAt - a.createdAt);
+
+    let added = 0;
+    for (const b of recentReadSoon) {
+      if (result.length >= size || added >= 2) break;
+      if (add(b.id)) added++;
+    }
+  }
+
+  return {
+    bookmarkIds: result,
+    completedIds: [],
+    skippedIds: [],
+  };
+}
+
+export function toLocalDateKey(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
+}
+
+export function addDaysToDateKey(dateKey: string, days: number): string {
+  const d = new Date(dateKey + "T12:00:00");
+  d.setDate(d.getDate() + days);
+  return toLocalDateKey(d);
+}

--- a/src/lib/storage-keys.ts
+++ b/src/lib/storage-keys.ts
@@ -10,6 +10,7 @@ export const LS_MANUAL_SYNC_REQUIRED = "totem_manual_sync_required";
 export const LS_BOOT_SYNC_POLICY = "totem_boot_sync_policy";
 export const LS_PINNED_TWEETS = "totem_pinned_tweets";
 export const LS_READER_ACTIVITY = "totem_reader_activity";
+export const LS_CLASSIFIER_BACKLOG_DONE = "totem_classifier_backlog_done";
 
 export const LOCAL_STORAGE_KEYS = [
   LS_READING_TAB,

--- a/src/lib/streak-tracker.ts
+++ b/src/lib/streak-tracker.ts
@@ -1,0 +1,91 @@
+import type { ReadLogEntry } from "../types";
+
+export interface StreakResult {
+  current: number;
+  longest: number;
+  isAtRisk: boolean;
+  earnedToday: boolean;
+}
+
+const READS_PER_DAY_THRESHOLD = 2;
+
+function toLocalDateKey(timestamp: number, tzOffset: number): string {
+  const d = new Date(timestamp + tzOffset * 60_000);
+  return d.toISOString().slice(0, 10);
+}
+
+function getTzOffset(date: Date): number {
+  return -date.getTimezoneOffset();
+}
+
+function addDays(dateKey: string, days: number): string {
+  const d = new Date(dateKey + "T00:00:00Z");
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+export function computeStreak(
+  readLog: ReadLogEntry[],
+  today: Date,
+): StreakResult {
+  if (readLog.length === 0) {
+    return { current: 0, longest: 0, isAtRisk: false, earnedToday: false };
+  }
+
+  const tzOffset = getTzOffset(today);
+  const todayKey = toLocalDateKey(today.getTime(), tzOffset);
+
+  const countsByDay = new Map<string, number>();
+  for (const entry of readLog) {
+    const key = toLocalDateKey(entry.markedReadAt, tzOffset);
+    countsByDay.set(key, (countsByDay.get(key) ?? 0) + 1);
+  }
+
+  const qualifyingDays = new Set<string>();
+  for (const [day, count] of countsByDay) {
+    if (count >= READS_PER_DAY_THRESHOLD) {
+      qualifyingDays.add(day);
+    }
+  }
+
+  const earnedToday = qualifyingDays.has(todayKey);
+
+  const sorted = Array.from(qualifyingDays).sort();
+  let longest = 0;
+  let current = 0;
+
+  if (sorted.length > 0) {
+    let runLength = 1;
+    for (let i = 1; i < sorted.length; i++) {
+      if (addDays(sorted[i - 1], 1) === sorted[i]) {
+        runLength++;
+      } else {
+        if (runLength > longest) longest = runLength;
+        runLength = 1;
+      }
+    }
+    if (runLength > longest) longest = runLength;
+
+    const lastQualifying = sorted[sorted.length - 1];
+    if (lastQualifying === todayKey || lastQualifying === addDays(todayKey, -1)) {
+      let streak = 1;
+      let cursor = lastQualifying;
+      for (let i = sorted.length - 2; i >= 0; i--) {
+        const expected = addDays(cursor, -1);
+        if (sorted[i] === expected) {
+          streak++;
+          cursor = sorted[i];
+        } else {
+          break;
+        }
+      }
+      current = streak;
+    }
+  }
+
+  const yesterdayKey = addDays(todayKey, -1);
+  const isAtRisk =
+    current > 0 && !earnedToday && qualifyingDays.has(yesterdayKey);
+
+  return { current, longest, isAtRisk, earnedToday };
+}

--- a/src/stores/__tests__/runtime-store.test.ts
+++ b/src/stores/__tests__/runtime-store.test.ts
@@ -5,7 +5,7 @@ import {
   selectRuntimeMode,
 } from "../runtime-store";
 import type { Bookmark, RuntimeSnapshot } from "../../types";
-import { LS_BOOT_SYNC_POLICY } from "../../lib/storage-keys";
+import { LS_BOOT_SYNC_POLICY, LS_CLASSIFIER_BACKLOG_DONE } from "../../lib/storage-keys";
 import type { RuntimeState } from "../runtime-store";
 
 const mocks = vi.hoisted(() => ({
@@ -193,6 +193,7 @@ beforeEach(() => {
   mocks.getDetailedTweetIds.mockResolvedValue(new Set<string>());
   mocks.setActiveAccountId.mockImplementation(() => "totem_acct_acct-1");
   mocks.upsertBookmarks.mockResolvedValue(undefined);
+  localStorage.setItem(LS_CLASSIFIER_BACKLOG_DONE, "1");
 });
 
 describe("runtime-store boot", () => {

--- a/src/stores/runtime-store.ts
+++ b/src/stores/runtime-store.ts
@@ -20,6 +20,7 @@ import {
   deleteBookmarksByTweetIds,
   getAllBookmarks,
   getDetailedTweetIds,
+  getHighlightCountsByTweetIds,
   setActiveAccountId,
   upsertBookmarks,
 } from "../db";
@@ -580,7 +581,12 @@ export function createRuntimeStore() {
 
       if (!localStorage.getItem(LS_CLASSIFIER_BACKLOG_DONE) && bookmarks.length > 0) {
         try {
-          const classified = classifyBatch(bookmarks);
+          const hlCounts = await getHighlightCountsByTweetIds(bookmarks.map((b) => b.tweetId));
+          const hlSet = new Set<string>();
+          for (const [tid, c] of hlCounts) {
+            if (c.highlights > 0 || c.notes > 0) hlSet.add(tid);
+          }
+          const classified = classifyBatch(bookmarks, hlSet);
           if (classified.length > 0) {
             await upsertBookmarks(classified);
             const classifiedIds = new Set(classified.map((b) => b.tweetId));
@@ -964,7 +970,13 @@ export function createRuntimeStore() {
             completionStatus = "success";
 
             try {
-              const classified = classifyBatch(get().bookmarks);
+              const allBm = get().bookmarks;
+              const hlCounts = await getHighlightCountsByTweetIds(allBm.map((b) => b.tweetId));
+              const hlSet = new Set<string>();
+              for (const [tid, c] of hlCounts) {
+                if (c.highlights > 0 || c.notes > 0) hlSet.add(tid);
+              }
+              const classified = classifyBatch(allBm, hlSet);
               if (classified.length > 0) {
                 await upsertBookmarks(classified);
                 const classifiedIds = new Set(classified.map((b) => b.tweetId));

--- a/src/stores/runtime-store.ts
+++ b/src/stores/runtime-store.ts
@@ -43,12 +43,14 @@ import {
   SYNC_MAX_PAGES_PER_JOB,
   WEEK_MS,
 } from "../lib/constants";
+import { classifyBatch } from "../lib/classifier";
 import {
   CS_DB_CLEANUP_AT,
   CS_LAST_SOFT_SYNC,
   CS_LAST_SYNC,
   CS_SOFT_SYNC_NEEDED,
   LS_BOOT_SYNC_POLICY,
+  LS_CLASSIFIER_BACKLOG_DONE,
   LS_MANUAL_SYNC_REQUIRED,
 } from "../lib/storage-keys";
 import type {
@@ -576,6 +578,24 @@ export function createRuntimeStore() {
         syncStatus: state.syncStatus === "syncing" ? state.syncStatus : "idle",
       }));
 
+      if (!localStorage.getItem(LS_CLASSIFIER_BACKLOG_DONE) && bookmarks.length > 0) {
+        try {
+          const classified = classifyBatch(bookmarks);
+          if (classified.length > 0) {
+            await upsertBookmarks(classified);
+            const classifiedIds = new Set(classified.map((b) => b.tweetId));
+            setRuntimeState((state) => ({
+              bookmarks: state.bookmarks.map((b) =>
+                classifiedIds.has(b.tweetId)
+                  ? (classified.find((c) => c.tweetId === b.tweetId) ?? b)
+                  : b,
+              ),
+            }));
+          }
+          localStorage.setItem(LS_CLASSIFIER_BACKLOG_DONE, "1");
+        } catch {}
+      }
+
       if (allowAutoSync) {
         maybeStartAutomaticSync();
       }
@@ -942,6 +962,21 @@ export function createRuntimeStore() {
               syncBlockedReason: null,
             });
             completionStatus = "success";
+
+            try {
+              const classified = classifyBatch(get().bookmarks);
+              if (classified.length > 0) {
+                await upsertBookmarks(classified);
+                const classifiedIds = new Set(classified.map((b) => b.tweetId));
+                setRuntimeState((state) => ({
+                  bookmarks: state.bookmarks.map((b) =>
+                    classifiedIds.has(b.tweetId)
+                      ? (classified.find((c) => c.tweetId === b.tweetId) ?? b)
+                      : b,
+                  ),
+                }));
+              }
+            } catch {}
           }
         }
       } catch (error) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -207,6 +207,12 @@ export interface ReadingProgress {
   completed: boolean;
 }
 
+export interface ReadLogEntry {
+  id?: number;
+  bookmarkId: string;
+  markedReadAt: number;
+}
+
 export interface Highlight {
   id: string;
   tweetId: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -213,6 +213,14 @@ export interface ReadLogEntry {
   markedReadAt: number;
 }
 
+export interface DailyQueue {
+  date: string;
+  bookmarkIds: string[];
+  completedIds: string[];
+  skippedIds: string[];
+  createdAt: number;
+}
+
 export interface Highlight {
   id: string;
   tweetId: string;
@@ -254,6 +262,7 @@ export interface UserSettings {
   backgroundMode: BackgroundMode;
   searchEngine: SearchEngineId;
   recommendationSource: RecommendationSource;
+  dailyQueueSize: number;
 }
 
 export interface TotemSeedPayload {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -121,6 +121,9 @@ export type TweetKind =
   | "thread"
   | "article";
 
+export type BookmarkIntent = "read_soon" | "reference" | "act_on" | "unsorted";
+export type IntentSource = "structural" | "keyword" | "manual";
+
 export interface QuotedTweet {
   tweetId: string;
   text: string;
@@ -171,6 +174,13 @@ export interface Bookmark {
   tweetDisplayType?: string;
   inReplyToTweetId?: string;
   inReplyToScreenName?: string;
+  intent?: BookmarkIntent;
+  intentSource?: IntentSource;
+  intentConfidence?: number;
+  intentAssignedAt?: string;
+  skipCount?: number;
+  cooldownUntil?: string;
+  topicIds?: string[];
 }
 
 export interface TweetDetailCache {


### PR DESCRIPTION
## Parent PRD

#15

## Slices landed on this branch

- [x] #16 — Intent foundation — field, IDB migration, hover dots, left border
- [x] #21 — Read log + streak tracker + streak chip with earned state
- [x] #17 — Classifier Layer 1 (structural rules) + backlog migration
- [x] #18 — Library page rework — search-first, meta, recently saved, from a year ago, browse/list toggle
- [x] #19 — Post-read intent tray in reader
- [x] #20 — Classifier Layer 2 (keyword scoring + staleness + highlights boost)
- [x] #22 — Queue tab grouped by intent (waiting for you / act on / reference library)
- [x] #23 — New tab daily card — Read now / Skip for today / Browse queue + dot carousel
- [x] #24 — "Done for today" finish line + stats panel

_More slices will land on this branch as they're completed._

## Theme review checklist (running, per-slice)

- [ ] Slice #16: no blue/teal/amber hardcodes, verified in light + dark
- [ ] Slice #21: no blue/teal/amber hardcodes, verified in light + dark
- [ ] Slice #17: pure logic module, no UI changes
- [ ] Slice #18: no blue/teal/amber hardcodes, verified in light + dark
- [ ] Slice #19: accent-surface chips only, no ad-hoc colors, verified in light + dark
- [ ] Slice #20: pure logic module, no UI changes
- [ ] Slice #22: accent/muted dot colors, muted caps section headers, no ad-hoc colors
- [ ] Slice #23: intent badge uses accent scale + muted, no ad-hoc colors, buttons from Button.tsx
- [ ] Slice #24: accent checkmark + accent/10 circle, muted stat labels, serif headline, fade-in animation

## Test plan

- [ ] pnpm tsc / test pass at each slice