### PR TITLE
test(stores): regression test for handleBookmarkEvents persist failure (#48)

### DIFF
--- a/src/stores/__tests__/runtime-store.test.ts
+++ b/src/stores/__tests__/runtime-store.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../runtime-store";
 import type { Bookmark, RuntimeSnapshot } from "../../types";
 import type { RuntimeState } from "../runtime-store";
+import { CREATE_EVENT_DELAY_MS } from "../../lib/constants/timing";
 
 const mocks = vi.hoisted(() => {
   const detailCacheListeners = new Set<(tweetId: string) => void>();
@@ -606,6 +607,42 @@ describe("runtime-store sync", () => {
       trigger: "manual",
       errorCode: undefined,
     });
+  });
+
+  it("leaves create events un-acked and the store unchanged when the IndexedDB write rejects on a bookmark-event refresh", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.getBookmarkEvents.mockResolvedValue([
+        { id: "evt-1", type: "CreateBookmark", tweetId: "tweet-new", at: 1, source: "test" },
+      ]);
+      mocks.fetchBookmarkPage.mockResolvedValue({
+        bookmarks: [createBookmark("tweet-new")],
+        cursor: null,
+        stopOnEmptyResponse: false,
+      });
+      mocks.upsertBookmarks.mockRejectedValue(new Error("IDB_WRITE_FAILED"));
+
+      const store = createRuntimeStore();
+      primeReadyState(store, { bookmarks: [createBookmark("tweet-1")] });
+
+      const promise = store.getState().actions.handleBookmarkEvents();
+      await vi.advanceTimersByTimeAsync(CREATE_EVENT_DELAY_MS);
+      await promise;
+
+      const state = store.getState();
+      // Persist-first on the bookmark-event refresh path: a rejected IndexedDB write
+      // must leave the create events un-acked (so they retry) and must not push the
+      // in-memory store ahead of the durable DB.
+      expect(mocks.upsertBookmarks).toHaveBeenCalledWith([
+        expect.objectContaining({ tweetId: "tweet-new" }),
+      ]);
+      expect(mocks.ackBookmarkEvents).not.toHaveBeenCalled();
+      expect(state.bookmarks.map((bookmark) => bookmark.tweetId)).toEqual([
+        "tweet-1",
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
 });


### PR DESCRIPTION
## Context

The production fix for #48 already landed in **f2513727a** *("fix: persist bookmarks before in-memory update so failed IndexedDB writes fail the sync (#48)")* — both `upsertBookmarks` call sites in `src/stores/runtime-store.ts` were reordered to **persist-first**, so a failed IndexedDB write can no longer be reported as a green sync:

- **Site 1 — `onPage` (sync run):** a rejected write propagates to the sync `catch` → `syncStatus: "error"`, `completionStatus: "failure"`.
- **Site 2 — `handleBookmarkEvents` (bookmark-event refresh):** a rejected write is caught locally → create events stay **un-acked** (so they retry) and the in-memory `setRuntimeState` is never reached → the store is not left ahead of the DB.

That commit added a regression test for **site 1**, but not for **site 2**. The issue's acceptance criteria ask to *"apply to both call sites,"* so site 2 was the only coverage gap left open.

## What this PR adds

A regression test for the `handleBookmarkEvents` path (`src/stores/__tests__/runtime-store.test.ts`) that makes `upsertBookmarks` reject mid-refresh and asserts:

- `upsertBookmarks` was attempted with the newly fetched bookmark,
- `ackBookmarkEvents` was **not** called (create events stay queued for retry),
- in-memory `bookmarks` are **unchanged** (no false-success split-brain / store-ahead-of-DB).

Test-only change — no production code touched. Uses fake timers to skip the `CREATE_EVENT_DELAY_MS` delay.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` — 609/609 passing (52 files), incl. the new case (`runtime-store.test.ts` now 27 tests)

Closes #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
