### PR TITLE
refactor(sw): single withAuthedRequest auth-expiry seam for X API handlers

### DIFF
--- a/src/service-worker/__tests__/api-proxy.test.ts
+++ b/src/service-worker/__tests__/api-proxy.test.ts
@@ -1,0 +1,220 @@
+/**
+ * API proxy auth-expiry policy tests.
+ *
+ * Exercises `withAuthedRequest` — the single seam every X API handler routes
+ * through — via the public handler map, with a scripted `fetchFn` and an
+ * injected `reAuth`. Locks the 401/403 → clear → one silent retry → logout
+ * policy and the session-marking side effects that were previously copy-pasted
+ * and untested across four handlers.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFakeChrome } from "../../test-utils/fake-chrome";
+import { createApiProxyHandlers } from "../api-proxy";
+import { AuthExpiredError, RateLimitError, _resetForTesting as resetQueryId } from "../query-id";
+import { _resetForTesting as resetAuth } from "../auth";
+import type { MessageRequest } from "../../types/messages";
+
+let fakeChrome: ReturnType<typeof createFakeChrome>;
+
+function storage(): typeof chrome.storage.local {
+  return fakeChrome.storage.local as unknown as typeof chrome.storage.local;
+}
+
+async function seedCatalog(pairs: Array<[string, string]>) {
+  const now = Date.now();
+  const endpoints: Record<string, unknown> = {};
+  for (const [operation, queryId] of pairs) {
+    const key = `${operation}:${queryId}`;
+    endpoints[key] = {
+      key,
+      operation,
+      queryId,
+      path: `/i/api/graphql/${queryId}/${operation}`,
+      firstSeen: now,
+      lastSeen: now,
+      seenCount: 1,
+      methods: ["GET"],
+      sampleUrl: `https://x.com/i/api/graphql/${queryId}/${operation}`,
+      sampleVariables: null,
+      sampleFeatures: null,
+      sampleFieldToggles: null,
+    };
+  }
+  await storage().set({
+    totem_graphql_catalog: { version: 1, updatedAt: now, endpoints },
+  });
+}
+
+async function seedAuth() {
+  await storage().set({
+    totem_user_id: "12345",
+    totem_auth_headers: {
+      authorization: "Bearer AAAA",
+      "x-csrf-token": "csrf-token-123",
+      cookie: 'twid="u%3D12345"; ct0=csrf-token-123; auth_token=abc123',
+    },
+    totem_auth_state: "authenticated",
+    totem_auth_state_at: Date.now(),
+  });
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+function makeHandlers(over: {
+  fetchFn: ReturnType<typeof vi.fn>;
+  reAuth?: ReturnType<typeof vi.fn>;
+}) {
+  return createApiProxyHandlers({
+    storage: storage(),
+    tabs: fakeChrome.tabs as unknown as typeof chrome.tabs,
+    fetchFn: over.fetchFn as unknown as typeof fetch,
+    reAuth: over.reAuth as unknown as (() => Promise<boolean>) | undefined,
+  });
+}
+
+const BOOKMARKS_MSG = { type: "FETCH_BOOKMARKS" } as unknown as MessageRequest;
+const SENDER = {} as chrome.runtime.MessageSender;
+
+beforeEach(async () => {
+  fakeChrome = createFakeChrome();
+  resetQueryId();
+  resetAuth();
+  (globalThis as Record<string, unknown>).chrome = fakeChrome;
+  await seedCatalog([
+    ["Bookmarks", "QID_BM"],
+    ["UserByRestId", "QID_VP"],
+  ]);
+});
+
+afterEach(() => {
+  delete (globalThis as Record<string, unknown>).chrome;
+});
+
+describe("api-proxy auth-expiry policy", () => {
+  it("returns data and marks the session authenticated on success", async () => {
+    await seedAuth();
+    const fetchFn = vi.fn().mockResolvedValue(
+      jsonResponse({ data: { bookmark_timeline_v2: {} } }),
+    );
+    const handlers = makeHandlers({ fetchFn });
+
+    const result = await handlers.FETCH_BOOKMARKS!(BOOKMARKS_MSG, SENDER);
+
+    expect(result).toEqual({ data: { data: { bookmark_timeline_v2: {} } } });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const after = await storage().get([
+      "totem_auth_state",
+      "totem_auth_state_reason",
+    ]);
+    expect(after.totem_auth_state).toBe("authenticated");
+    expect(after.totem_auth_state_reason).toBe("bookmarks_ok");
+  });
+
+  it("throws NO_AUTH without fetching when no headers are captured", async () => {
+    const fetchFn = vi.fn();
+    const handlers = makeHandlers({ fetchFn });
+
+    await expect(handlers.FETCH_BOOKMARKS!(BOOKMARKS_MSG, SENDER)).rejects.toThrow(
+      "NO_AUTH",
+    );
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("clears headers, logs out, and throws on 401 when re-auth fails", async () => {
+    await seedAuth();
+    const fetchFn = vi.fn().mockResolvedValue(new Response("", { status: 401 }));
+    const reAuth = vi.fn().mockResolvedValue(false);
+    const handlers = makeHandlers({ fetchFn, reAuth });
+
+    await expect(handlers.FETCH_BOOKMARKS!(BOOKMARKS_MSG, SENDER)).rejects.toBeInstanceOf(
+      AuthExpiredError,
+    );
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(reAuth).toHaveBeenCalledTimes(1);
+    const after = await storage().get([
+      "totem_auth_state",
+      "totem_auth_state_reason",
+      "totem_auth_headers",
+    ]);
+    expect(after.totem_auth_state).toBe("logged_out");
+    expect(after.totem_auth_state_reason).toBe("bookmarks_401");
+    expect(after.totem_auth_headers).toBeUndefined();
+  });
+
+  it("retries once after a successful silent re-auth on 401", async () => {
+    await seedAuth();
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("", { status: 401 }))
+      .mockResolvedValueOnce(jsonResponse({ data: { ok: true } }));
+    // A successful silent re-auth re-captures credentials into storage.
+    const reAuth = vi.fn().mockImplementation(async () => {
+      await seedAuth();
+      return true;
+    });
+    const handlers = makeHandlers({ fetchFn, reAuth });
+
+    const result = await handlers.FETCH_BOOKMARKS!(BOOKMARKS_MSG, SENDER);
+
+    expect(result).toEqual({ data: { data: { ok: true } } });
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(reAuth).toHaveBeenCalledTimes(1);
+    const after = await storage().get(["totem_auth_state"]);
+    expect(after.totem_auth_state).toBe("authenticated");
+  });
+
+  it("logs out after a single retry when 401 persists", async () => {
+    await seedAuth();
+    const fetchFn = vi.fn().mockResolvedValue(new Response("", { status: 403 }));
+    const reAuth = vi.fn().mockImplementation(async () => {
+      await seedAuth();
+      return true;
+    });
+    const handlers = makeHandlers({ fetchFn, reAuth });
+
+    await expect(handlers.FETCH_BOOKMARKS!(BOOKMARKS_MSG, SENDER)).rejects.toBeInstanceOf(
+      AuthExpiredError,
+    );
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(reAuth).toHaveBeenCalledTimes(1);
+    const after = await storage().get(["totem_auth_state_reason"]);
+    expect(after.totem_auth_state_reason).toBe("bookmarks_403");
+  });
+
+  it("treats 429 as a rate limit, not an auth failure", async () => {
+    await seedAuth();
+    const fetchFn = vi.fn().mockResolvedValue(new Response("", { status: 429 }));
+    const reAuth = vi.fn().mockResolvedValue(false);
+    const handlers = makeHandlers({ fetchFn, reAuth });
+
+    await expect(handlers.FETCH_BOOKMARKS!(BOOKMARKS_MSG, SENDER)).rejects.toBeInstanceOf(
+      RateLimitError,
+    );
+    expect(reAuth).not.toHaveBeenCalled();
+    const after = await storage().get(["totem_auth_state"]);
+    expect(after.totem_auth_state).toBe("authenticated");
+  });
+
+  it("applies the same auth-expiry policy to the viewer-profile fetch", async () => {
+    await seedAuth();
+    const fetchFn = vi.fn().mockResolvedValue(new Response("", { status: 401 }));
+    const reAuth = vi.fn().mockResolvedValue(false);
+    const handlers = makeHandlers({ fetchFn, reAuth });
+
+    await expect(
+      handlers.FETCH_VIEWER_PROFILE!(
+        { type: "FETCH_VIEWER_PROFILE" } as unknown as MessageRequest,
+        SENDER,
+      ),
+    ).rejects.toBeInstanceOf(AuthExpiredError);
+    const after = await storage().get([
+      "totem_auth_state",
+      "totem_auth_state_reason",
+    ]);
+    expect(after.totem_auth_state).toBe("logged_out");
+    expect(after.totem_auth_state_reason).toBe("viewer_401");
+  });
+});

--- a/src/service-worker/api-proxy.ts
+++ b/src/service-worker/api-proxy.ts
@@ -1,10 +1,13 @@
 /**
  * API proxy module — bookmark and tweet detail API handlers.
  *
- * Extracted from the SW monolith. Uses `withQueryId` from the query ID
- * module instead of manual retry logic.
+ * Extracted from the SW monolith. Query ID resolution/retry lives in
+ * `withQueryId`; the auth-expiry policy (header attach, 401/403 handling,
+ * session marking) lives in `withAuthedRequest`. Handlers only describe the
+ * request and interpret operation-specific status codes.
  *
- * Handler map for FETCH_BOOKMARKS, DELETE_BOOKMARK, FETCH_TWEET_DETAIL.
+ * Handler map for FETCH_BOOKMARKS, DELETE_BOOKMARK, FETCH_TWEET_DETAIL,
+ * FETCH_VIEWER_PROFILE.
  */
 
 import type { MessageRequest } from "../types/messages";
@@ -132,6 +135,7 @@ interface ApiProxyDeps {
   storage?: typeof chrome.storage.local;
   tabs?: typeof chrome.tabs;
   fetchFn?: typeof fetch;
+  reAuth?: () => Promise<boolean>;
 }
 
 function defaultChromeStorage(): typeof chrome.storage.local {
@@ -149,10 +153,41 @@ export function createApiProxyHandlers(deps: ApiProxyDeps = {}): HandlerMap {
   const storage = deps.storage ?? defaultChromeStorage();
   const tabs = deps.tabs ?? defaultChromeTabs();
   const fetchFn = deps.fetchFn ?? fetch;
+  const reAuth = deps.reAuth ?? (() => reAuthSilently(storage, tabs));
+
+  /**
+   * Owns the auth-expiry policy for every X API call: attaches captured
+   * headers, treats 401/403 as expiry (clear headers → one silent re-auth
+   * retry → mark logged out → AuthExpiredError), and marks the session
+   * authenticated on any 2xx. Operation-specific status codes (400 stale
+   * query ID, 429 rate limit) are left to the caller.
+   */
+  async function withAuthedRequest(
+    operation: string,
+    perform: (headers: Record<string, string>) => Promise<Response>,
+    retried = false,
+  ): Promise<Response> {
+    const headers = await buildHeaders(storage);
+    const response = await perform(headers);
+
+    if (response.status === 401 || response.status === 403) {
+      await storage.remove(["totem_auth_headers", "totem_auth_time"]);
+      if (!retried && (await reAuth())) {
+        return withAuthedRequest(operation, perform, true);
+      }
+      await markAuthLoggedOut(`${operation}_${response.status}`, true, storage);
+      throw new AuthExpiredError();
+    }
+
+    if (response.ok) {
+      await markAuthAuthenticated(`${operation}_ok`, storage);
+    }
+
+    return response;
+  }
 
   async function handleFetchBookmarks(
     message: MessageRequest,
-    _retried = false,
   ): Promise<unknown> {
     const msg = message as unknown as Record<string, unknown>;
     const cursor = typeof msg.cursor === "string" ? msg.cursor : undefined;
@@ -162,10 +197,7 @@ export function createApiProxyHandlers(deps: ApiProxyDeps = {}): HandlerMap {
         : 100;
 
     return withQueryId("Bookmarks", async (queryId) => {
-      const stored = await storage.get(["totem_auth_headers", "totem_features"]);
-      if (!parseCapturedAuthHeaders(stored.totem_auth_headers).ok) {
-        throw new Error("NO_AUTH");
-      }
+      const stored = await storage.get(["totem_features"]);
 
       const variables: Record<string, unknown> = {
         count,
@@ -182,27 +214,14 @@ export function createApiProxyHandlers(deps: ApiProxyDeps = {}): HandlerMap {
       });
 
       const url = `https://x.com/i/api/graphql/${queryId}/Bookmarks?${params}`;
-      const requestHeaders = await buildHeaders(storage);
 
-      const response = await fetchFn(url, {
-        method: "GET",
-        credentials: "include",
-        headers: requestHeaders,
-      });
-
-      if (response.status === 401 || response.status === 403) {
-        await storage.remove(["totem_auth_headers", "totem_auth_time"]);
-        if (!_retried) {
-          const success = await reAuthSilently(storage, tabs);
-          if (success) return handleFetchBookmarks(message, true);
-        }
-        await markAuthLoggedOut(
-          `bookmarks_${response.status}`,
-          true,
-          storage,
-        );
-        throw new AuthExpiredError();
-      }
+      const response = await withAuthedRequest("bookmarks", (headers) =>
+        fetchFn(url, {
+          method: "GET",
+          credentials: "include",
+          headers,
+        }),
+      );
 
       if (!response.ok) {
         if (response.status === 429) throw new RateLimitError();
@@ -216,51 +235,31 @@ export function createApiProxyHandlers(deps: ApiProxyDeps = {}): HandlerMap {
       }
 
       const json = await response.json();
-      await markAuthAuthenticated("bookmarks_ok", storage);
       return { data: json };
     });
   }
 
   async function handleDeleteBookmark(
     message: MessageRequest,
-    _retried = false,
   ): Promise<unknown> {
     const msg = message as unknown as Record<string, unknown>;
     const tweetId = typeof msg.tweetId === "string" ? msg.tweetId : "";
     if (!tweetId) throw new Error("MISSING_TWEET_ID");
 
     return withQueryId("DeleteBookmark", async (queryId) => {
-      const stored = await storage.get(["totem_auth_headers"]);
-      if (!parseCapturedAuthHeaders(stored.totem_auth_headers).ok) {
-        throw new Error("NO_AUTH");
-      }
-
       const url = `https://x.com/i/api/graphql/${queryId}/DeleteBookmark`;
-      const requestHeaders = await buildHeaders(storage);
 
-      const response = await fetchFn(url, {
-        method: "POST",
-        credentials: "include",
-        headers: requestHeaders,
-        body: JSON.stringify({
-          variables: { tweet_id: tweetId },
-          queryId,
+      const response = await withAuthedRequest("delete", (headers) =>
+        fetchFn(url, {
+          method: "POST",
+          credentials: "include",
+          headers,
+          body: JSON.stringify({
+            variables: { tweet_id: tweetId },
+            queryId,
+          }),
         }),
-      });
-
-      if (response.status === 401 || response.status === 403) {
-        await storage.remove(["totem_auth_headers", "totem_auth_time"]);
-        if (!_retried) {
-          const success = await reAuthSilently(storage, tabs);
-          if (success) return handleDeleteBookmark(message, true);
-        }
-        await markAuthLoggedOut(
-          `delete_${response.status}`,
-          true,
-          storage,
-        );
-        throw new AuthExpiredError();
-      }
+      );
 
       if (!response.ok) {
         if (response.status === 400) {
@@ -273,27 +272,19 @@ export function createApiProxyHandlers(deps: ApiProxyDeps = {}): HandlerMap {
       }
 
       const json = await response.json().catch(() => null);
-      await markAuthAuthenticated("delete_ok", storage);
       return { ok: true, queryId, data: json };
     });
   }
 
   async function handleFetchTweetDetail(
     message: MessageRequest,
-    _retried = false,
   ): Promise<unknown> {
     const msg = message as unknown as Record<string, unknown>;
     const tweetId = typeof msg.tweetId === "string" ? msg.tweetId : "";
     if (!tweetId) throw new Error("MISSING_TWEET_ID");
 
     return withQueryId("TweetDetail", async (queryId) => {
-      const stored = await storage.get([
-        "totem_auth_headers",
-        "totem_features",
-      ]);
-      if (!parseCapturedAuthHeaders(stored.totem_auth_headers).ok) {
-        throw new Error("NO_AUTH");
-      }
+      const stored = await storage.get(["totem_features"]);
 
       const featureSet = {
         ...DEFAULT_FEATURES,
@@ -326,27 +317,14 @@ export function createApiProxyHandlers(deps: ApiProxyDeps = {}): HandlerMap {
       });
 
       const url = `https://x.com/i/api/graphql/${queryId}/TweetDetail?${params}`;
-      const requestHeaders = await buildHeaders(storage);
 
-      const response = await fetchFn(url, {
-        method: "GET",
-        credentials: "include",
-        headers: requestHeaders,
-      });
-
-      if (response.status === 401 || response.status === 403) {
-        await storage.remove(["totem_auth_headers", "totem_auth_time"]);
-        if (!_retried) {
-          const success = await reAuthSilently(storage, tabs);
-          if (success) return handleFetchTweetDetail(message, true);
-        }
-        await markAuthLoggedOut(
-          `detail_${response.status}`,
-          true,
-          storage,
-        );
-        throw new AuthExpiredError();
-      }
+      const response = await withAuthedRequest("detail", (headers) =>
+        fetchFn(url, {
+          method: "GET",
+          credentials: "include",
+          headers,
+        }),
+      );
 
       if (!response.ok) {
         if (response.status === 400) {
@@ -359,26 +337,17 @@ export function createApiProxyHandlers(deps: ApiProxyDeps = {}): HandlerMap {
       }
 
       const json = await response.json();
-      await markAuthAuthenticated("detail_ok", storage);
       return { data: json };
     });
   }
 
   async function handleFetchViewerProfile(): Promise<unknown> {
     return withQueryId("UserByRestId", async (queryId) => {
-      const stored = await storage.get([
-        "totem_auth_headers",
-        "totem_user_id",
-        "totem_features",
-      ]);
+      const stored = await storage.get(["totem_user_id", "totem_features"]);
 
       const userId =
         typeof stored.totem_user_id === "string" ? stored.totem_user_id : "";
       if (!userId) throw new Error("NO_USER_ID");
-
-      if (!parseCapturedAuthHeaders(stored.totem_auth_headers).ok) {
-        throw new Error("NO_AUTH");
-      }
 
       const features =
         (stored.totem_features as string) || JSON.stringify(DEFAULT_FEATURES);
@@ -395,13 +364,14 @@ export function createApiProxyHandlers(deps: ApiProxyDeps = {}): HandlerMap {
       });
 
       const url = `https://x.com/i/api/graphql/${queryId}/UserByRestId?${params}`;
-      const requestHeaders = await buildHeaders(storage);
 
-      const response = await fetchFn(url, {
-        method: "GET",
-        credentials: "include",
-        headers: requestHeaders,
-      });
+      const response = await withAuthedRequest("viewer", (headers) =>
+        fetchFn(url, {
+          method: "GET",
+          credentials: "include",
+          headers,
+        }),
+      );
 
       if (!response.ok) {
         if (response.status === 400) {


### PR DESCRIPTION
## What

Deepens the X API proxy by extracting the **auth-expiry policy** into a single seam, `withAuthedRequest`. Previously each of the four handlers (`FETCH_BOOKMARKS`, `DELETE_BOOKMARK`, `FETCH_TWEET_DETAIL`, `FETCH_VIEWER_PROFILE`) carried its own copy-pasted block for: the `NO_AUTH` guard, attaching captured headers, the `401/403 → clear headers → one silent re-auth retry → mark logged out → AuthExpiredError` flow, and marking the session authenticated on success.

Now handlers only *describe the request* and interpret operation-specific status codes (`400` stale query ID, `429` rate limit). The wrapper owns everything auth.

## Why

- **Locality** — the auth-expiry policy lives in one place. Fix once, fixed for every operation.
- **Leverage** — `withAuthedRequest(operation, perform)` is a small interface hiding the whole expiry/retry/marking dance.
- **Testability** — re-auth is now an injected seam (`reAuth`, defaulting to the existing `reAuthSilently`). The policy that was **untested across four handlers** now has a focused suite.

## Behavior

Bookmarks / delete / detail: **identical** observable behavior (same retry, same `markAuthLoggedOut`/`markAuthAuthenticated` reasons, same error types).

`FETCH_VIEWER_PROFILE`: **intentional improvement** — it previously had *no* 401/403 handling, so an expired session silently surfaced a generic `VIEWER_PROFILE_401` error and never refreshed auth. It now gets the same re-auth + logout policy as the others. Safe because `useViewerProfile` fires this fire-and-forget (`.catch(() => {})`) and reads the profile from storage — it never inspects the result, so the error-type change is unobservable while the auth refresh is a net gain.

## Tests

New `src/service-worker/__tests__/api-proxy.test.ts` (7 tests) locks, through the public handler map with a scripted `fetchFn` + injected `reAuth`:
- success → data + session marked authenticated (`bookmarks_ok`)
- no captured headers → `NO_AUTH`, no fetch
- 401, re-auth fails → headers cleared, logged out (`bookmarks_401`), `AuthExpiredError`
- 401, re-auth succeeds → one retry, then data (verifies headers are re-read post-reauth)
- 401/403 persists after retry → single retry then logout
- 429 → `RateLimitError`, not treated as auth failure
- viewer profile now follows the same policy (`viewer_401`)

`pnpm typecheck` clean · full suite green (645 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
