### PR TITLE
refactor(runtime): extract pure deriveAuthTransition seam

### DIFF
--- a/src/stores/__tests__/auth-transition.test.ts
+++ b/src/stores/__tests__/auth-transition.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveAuthTransition,
+  type AuthPayload,
+  type AuthTransitionInput,
+  type AuthTransitionOptions,
+} from "../auth-transition";
+
+const REAUTH_DELAY = 500; // AUTH_QUICK_CHECK_MS
+
+function input(overrides: Partial<AuthTransitionInput> = {}): AuthTransitionInput {
+  return {
+    authPhase: "ready",
+    activeAccountId: "acct-A",
+    bookmarksLoaded: true,
+    detailedIdsLoaded: true,
+    bookmarks: [],
+    detailedTweetIds: new Set<string>(),
+    syncStatus: "idle",
+    syncJobKind: "none",
+    bootGeneration: 3,
+    lastSyncAt: 1000,
+    ...overrides,
+  };
+}
+
+function payload(overrides: Partial<AuthPayload> = {}): AuthPayload {
+  return {
+    hasUser: true,
+    hasAuth: true,
+    authState: "authenticated",
+    sessionState: "logged_in",
+    userId: "acct-A",
+    accountContextId: "acct-A",
+    bookmarksApi: "ready",
+    detailApi: "ready",
+    lastSyncAt: 0,
+    ...overrides,
+  };
+}
+
+const LIVE: AuthTransitionOptions = { allowHydration: true, allowAutoSync: true };
+const PUSH: AuthTransitionOptions = { allowHydration: false, allowAutoSync: false };
+
+const kinds = (t: ReturnType<typeof deriveAuthTransition>) =>
+  t.effects.map((e) => e.kind);
+
+describe("deriveAuthTransition — phase machine", () => {
+  it("maps logged_out session to need_login / logged_out with no retry delay", () => {
+    const { patch } = deriveAuthTransition(
+      input(),
+      payload({ sessionState: "logged_out", authState: "logged_out" }),
+      LIVE,
+    );
+    expect(patch.authPhase).toBe("need_login");
+    expect(patch.sessionState).toBe("logged_out");
+    expect(patch.authRetryDelayMs).toBeNull();
+  });
+
+  it("treats authState==='logged_out' as logged_out even when session is unknown", () => {
+    const { patch } = deriveAuthTransition(
+      input({ activeAccountId: "acct-A" }),
+      payload({
+        sessionState: "unknown",
+        authState: "logged_out",
+        userId: null,
+        accountContextId: null,
+      }),
+      LIVE,
+    );
+    expect(patch.authPhase).toBe("need_login");
+    expect(patch.sessionState).toBe("logged_out");
+    // logged_out fallback keeps the existing account pointer.
+    expect(patch.activeAccountId).toBe("acct-A");
+  });
+
+  it("maps logged_in session to ready / logged_in", () => {
+    const { patch } = deriveAuthTransition(input(), payload(), LIVE);
+    expect(patch.authPhase).toBe("ready");
+    expect(patch.sessionState).toBe("logged_in");
+  });
+
+  it("maps no-user/no-auth to need_login", () => {
+    const { patch } = deriveAuthTransition(
+      input(),
+      payload({ hasUser: false, hasAuth: false, sessionState: "unknown", authState: "stale" }),
+      LIVE,
+    );
+    expect(patch.authPhase).toBe("need_login");
+    expect(patch.sessionState).toBe("logged_out");
+  });
+
+  it("maps a user-without-auth to connecting with AUTH_QUICK_CHECK_MS retry", () => {
+    const { patch, effects } = deriveAuthTransition(
+      input(),
+      payload({ hasUser: true, hasAuth: false, sessionState: "unknown", authState: "stale" }),
+      LIVE,
+    );
+    expect(patch.authPhase).toBe("connecting");
+    expect(patch.sessionState).toBe("unknown");
+    expect(patch.authRetryDelayMs).toBe(REAUTH_DELAY);
+    // user present, auth missing, not logged in → auth capture starts.
+    expect(effects.some((e) => e.kind === "startAuthCapture")).toBe(true);
+  });
+
+  it("does not start auth capture while connecting if auth is present", () => {
+    const { effects } = deriveAuthTransition(
+      input(),
+      payload({ hasUser: false, hasAuth: true, sessionState: "unknown", authState: "stale" }),
+      LIVE,
+    );
+    expect(effects.some((e) => e.kind === "startAuthCapture")).toBe(false);
+  });
+});
+
+describe("deriveAuthTransition — hydration", () => {
+  it("hydrates and is terminal when the account changes", () => {
+    const t = deriveAuthTransition(
+      input({ activeAccountId: "acct-A", bootGeneration: 3 }),
+      payload({ userId: "acct-B", accountContextId: "acct-B" }),
+      LIVE,
+    );
+    expect(kinds(t)).toEqual(["releaseActiveWork", "clearScheduledAutoRetry", "hydrate"]);
+    const hydrate = t.effects.at(-1)!;
+    expect(hydrate.kind).toBe("hydrate");
+    if (hydrate.kind === "hydrate") {
+      // boot generation bumps once and the patch agrees with the effect.
+      expect(hydrate.bootGeneration).toBe(4);
+      expect(t.patch.bootGeneration).toBe(4);
+      expect(hydrate.allowAutoSync).toBe(true);
+    }
+  });
+
+  it("clears caches and resets loaded flags when hydrating", () => {
+    const { patch } = deriveAuthTransition(
+      input({ activeAccountId: "acct-A", bookmarks: [{ id: "x" } as never] }),
+      payload({ userId: "acct-B", accountContextId: "acct-B" }),
+      LIVE,
+    );
+    expect(patch.bookmarksLoaded).toBe(false);
+    expect(patch.detailedIdsLoaded).toBe(false);
+    expect(patch.bookmarks).toEqual([]);
+    expect(patch.detailedTweetIds.size).toBe(0);
+  });
+
+  it("hydrates when caches are not yet loaded even if the account is unchanged", () => {
+    const t = deriveAuthTransition(
+      input({ bookmarksLoaded: false, detailedIdsLoaded: true }),
+      payload(),
+      LIVE,
+    );
+    expect(t.effects.some((e) => e.kind === "hydrate")).toBe(true);
+  });
+
+  it("ends at hydrate with no trailing auto-sync / reconcile", () => {
+    const t = deriveAuthTransition(
+      input({ activeAccountId: "acct-A" }),
+      payload({ userId: "acct-B", accountContextId: "acct-B" }),
+      LIVE,
+    );
+    expect(kinds(t)).not.toContain("maybeAutoSync");
+    expect(kinds(t)).not.toContain("reconcilePrefetch");
+    expect(kinds(t).at(-1)).toBe("hydrate");
+  });
+});
+
+describe("deriveAuthTransition — auto-sync & reconcile", () => {
+  it("auto-syncs then reconciles when already hydrated and ready", () => {
+    const t = deriveAuthTransition(input(), payload(), LIVE);
+    expect(kinds(t)).toEqual(["maybeAutoSync", "reconcilePrefetch"]);
+  });
+
+  it("only reconciles when auto-sync is disallowed", () => {
+    const t = deriveAuthTransition(input(), payload(), {
+      allowHydration: true,
+      allowAutoSync: false,
+    });
+    expect(kinds(t)).toEqual(["reconcilePrefetch"]);
+  });
+
+  it("suppresses auto-sync after recovering from reauth and forces sync idle", () => {
+    const t = deriveAuthTransition(
+      input({ authPhase: "ready", syncStatus: "reauthing" }),
+      payload(),
+      LIVE,
+    );
+    expect(t.patch.syncStatus).toBe("idle");
+    expect(t.patch.syncJobKind).toBe("none");
+    expect(kinds(t)).toEqual(["reconcilePrefetch"]);
+  });
+
+  it("clears the scheduled auto-retry when phase transitions into ready", () => {
+    const t = deriveAuthTransition(input({ authPhase: "connecting" }), payload(), LIVE);
+    expect(kinds(t)).toEqual(["clearScheduledAutoRetry", "maybeAutoSync", "reconcilePrefetch"]);
+  });
+});
+
+describe("deriveAuthTransition — sync invalidation & account pointer", () => {
+  it("forces sync idle and releases active work when login is required mid-sync", () => {
+    const t = deriveAuthTransition(
+      input({ syncStatus: "syncing", syncJobKind: "bootstrap" }),
+      payload({ sessionState: "logged_out", authState: "logged_out" }),
+      LIVE,
+    );
+    expect(t.patch.syncStatus).toBe("idle");
+    expect(t.patch.syncJobKind).toBe("none");
+    expect(t.effects[0]?.kind).toBe("releaseActiveWork");
+  });
+
+  it("does not move the account pointer on the snapshot-push path", () => {
+    const t = deriveAuthTransition(
+      input({ activeAccountId: "acct-A" }),
+      payload({ userId: "acct-B", accountContextId: "acct-B" }),
+      PUSH,
+    );
+    expect(t.patch.activeAccountId).toBe("acct-A");
+    // no hydration off the push path; the follow-up checkAuth owns the move.
+    expect(kinds(t)).not.toContain("hydrate");
+    expect(kinds(t)).toContain("clearScheduledAutoRetry");
+  });
+});
+
+describe("deriveAuthTransition — lastSyncAt max-merge", () => {
+  it("never regresses lastSyncAt below the current value", () => {
+    const { patch } = deriveAuthTransition(
+      input({ lastSyncAt: 5000 }),
+      payload({ lastSyncAt: 1000 }),
+      LIVE,
+    );
+    expect(patch.lastSyncAt).toBe(5000);
+  });
+
+  it("advances lastSyncAt when the payload is newer", () => {
+    const { patch } = deriveAuthTransition(
+      input({ lastSyncAt: 1000 }),
+      payload({ lastSyncAt: 5000 }),
+      LIVE,
+    );
+    expect(patch.lastSyncAt).toBe(5000);
+  });
+});
+
+describe("deriveAuthTransition — interaction edges", () => {
+  it("emits auth capture before the terminal hydrate when connecting into an unloaded cache", () => {
+    const t = deriveAuthTransition(
+      input({ bookmarksLoaded: false }),
+      payload({ hasUser: true, hasAuth: false, sessionState: "unknown", authState: "stale" }),
+      LIVE,
+    );
+    const ks = kinds(t);
+    expect(ks.indexOf("startAuthCapture")).toBeGreaterThanOrEqual(0);
+    expect(ks.indexOf("startAuthCapture")).toBeLessThan(ks.indexOf("hydrate"));
+    // hydrate is terminal — nothing runs after it.
+    expect(ks.at(-1)).toBe("hydrate");
+    expect(ks).not.toContain("maybeAutoSync");
+    expect(ks).not.toContain("reconcilePrefetch");
+    expect(t.patch.bootGeneration).toBe(4);
+  });
+
+  it("releases active work but keeps syncStatus 'syncing' on a connecting push without hydration", () => {
+    const t = deriveAuthTransition(
+      input({ syncStatus: "syncing", syncJobKind: "bootstrap" }),
+      payload({ hasUser: true, hasAuth: false, sessionState: "unknown", authState: "stale" }),
+      LIVE,
+    );
+    expect(t.effects[0]?.kind).toBe("releaseActiveWork");
+    // needLoginWhileSyncing is false (phase is connecting, not need_login) → sync facts unchanged.
+    expect(t.patch.syncStatus).toBe("syncing");
+    expect(t.patch.syncJobKind).toBe("bootstrap");
+  });
+
+  it("does not auto-sync after reauth recovery even when the recovery also hydrates", () => {
+    const t = deriveAuthTransition(
+      input({ syncStatus: "reauthing", bookmarksLoaded: false }),
+      payload(),
+      LIVE,
+    );
+    const hydrate = t.effects.find((e) => e.kind === "hydrate");
+    expect(hydrate?.kind).toBe("hydrate");
+    if (hydrate?.kind === "hydrate") {
+      expect(hydrate.allowAutoSync).toBe(false);
+    }
+    expect(t.patch.syncStatus).toBe("idle");
+    expect(t.patch.syncJobKind).toBe("none");
+  });
+});

--- a/src/stores/auth-transition.ts
+++ b/src/stores/auth-transition.ts
@@ -1,0 +1,219 @@
+/**
+ * Pure derivation of an auth/session transition for the runtime store.
+ *
+ * `deriveAuthTransition` takes the runtime's current read-subset plus a
+ * normalized auth payload and returns a `patch` (the single set of store facts
+ * to write) together with an ORDERED list of `effects` the shell must run, in
+ * array order, after applying the patch. It performs no I/O, reads no store,
+ * touches no clock — the returned `{ patch, effects }` is the entire test
+ * surface for the auth phase machine, the account/IDB-pointer asymmetry, the
+ * hydration decision, the lastSyncAt max-merge, and reauth recovery.
+ *
+ * Effect ordering is load-bearing: the shell executes effects left-to-right
+ * with no reordering, filtering, or dedup. A `hydrate` effect is terminal —
+ * `hydrateCurrentAccount` itself performs the post-hydrate auto-sync and
+ * prefetch reconcile, so no further effects follow it.
+ */
+
+import type {
+  ApiCapability,
+  ApiCapabilityState,
+  AuthPhase,
+  AuthState as SessionAuthState,
+  Bookmark,
+  SessionState,
+  SyncStatus,
+} from "../types";
+import type { SyncJobKind } from "./runtime-store";
+import { AUTH_QUICK_CHECK_MS } from "../lib/constants/timing";
+
+export interface AuthPayload {
+  hasUser: boolean;
+  hasAuth: boolean;
+  authState: SessionAuthState;
+  sessionState: SessionState;
+  userId: string | null;
+  accountContextId: string | null;
+  bookmarksApi: ApiCapabilityState;
+  detailApi: ApiCapabilityState;
+  lastSyncAt: number;
+}
+
+/** The read-subset of RuntimeState the derivation depends on. */
+export interface AuthTransitionInput {
+  authPhase: AuthPhase;
+  activeAccountId: string | null;
+  bookmarksLoaded: boolean;
+  detailedIdsLoaded: boolean;
+  bookmarks: Bookmark[];
+  detailedTweetIds: Set<string>;
+  syncStatus: SyncStatus;
+  syncJobKind: SyncJobKind;
+  bootGeneration: number;
+  lastSyncAt: number;
+}
+
+/** The exact set of store facts the transition writes. */
+export interface AuthTransitionPatch {
+  authPhase: AuthPhase;
+  authState: SessionAuthState;
+  sessionState: SessionState;
+  capability: ApiCapability;
+  activeAccountId: string | null;
+  authRetryDelayMs: number | null;
+  bootGeneration: number;
+  bookmarksLoaded: boolean;
+  detailedIdsLoaded: boolean;
+  bookmarks: Bookmark[];
+  detailedTweetIds: Set<string>;
+  lastSyncAt: number;
+  syncStatus: SyncStatus;
+  syncJobKind: SyncJobKind;
+}
+
+export type AuthTransitionEffect =
+  | { kind: "releaseActiveWork" }
+  | { kind: "clearScheduledAutoRetry" }
+  | { kind: "startAuthCapture"; interactive: boolean }
+  | { kind: "hydrate"; bootGeneration: number; allowAutoSync: boolean }
+  | { kind: "maybeAutoSync" }
+  | { kind: "reconcilePrefetch" };
+
+export interface AuthTransitionOptions {
+  allowHydration: boolean;
+  allowAutoSync: boolean;
+}
+
+export interface AuthTransition {
+  patch: AuthTransitionPatch;
+  effects: AuthTransitionEffect[];
+}
+
+/**
+ * Mirror of the runtime's auth-capture guard: capture is worth starting only
+ * when we have a user but no live auth and aren't already logged in.
+ */
+function shouldStartAuthCapture(payload: AuthPayload): boolean {
+  return !(
+    payload.sessionState === "logged_in" ||
+    payload.hasAuth ||
+    !payload.hasUser
+  );
+}
+
+export function deriveAuthTransition(
+  prev: AuthTransitionInput,
+  payload: AuthPayload,
+  options: AuthTransitionOptions,
+): AuthTransition {
+  const nextAccountId =
+    payload.sessionState === "logged_out" || payload.authState === "logged_out"
+      ? prev.activeAccountId || payload.accountContextId || null
+      : payload.userId || payload.accountContextId || prev.activeAccountId;
+
+  let phase: AuthPhase;
+  let sessionState: SessionState;
+  let authRetryDelayMs: number | null = null;
+
+  if (
+    payload.sessionState === "logged_out" ||
+    payload.authState === "logged_out"
+  ) {
+    phase = "need_login";
+    sessionState = "logged_out";
+  } else if (payload.sessionState === "logged_in") {
+    phase = "ready";
+    sessionState = "logged_in";
+  } else if (!payload.hasUser && !payload.hasAuth) {
+    phase = "need_login";
+    sessionState = "logged_out";
+  } else {
+    phase = "connecting";
+    sessionState = payload.sessionState;
+    authRetryDelayMs = AUTH_QUICK_CHECK_MS;
+  }
+
+  const accountChanged = nextAccountId !== prev.activeAccountId;
+  const needsHydration =
+    options.allowHydration &&
+    (accountChanged || !prev.bookmarksLoaded || !prev.detailedIdsLoaded);
+  const phaseChanged = phase !== prev.authPhase;
+
+  // Invalidate any in-flight sync when the runtime's view of the session
+  // becomes non-ready, or when we're about to re-hydrate against a cleared
+  // cache — otherwise a stale lease keeps writing into a DB we no longer own.
+  const shouldReleaseActiveWork =
+    needsHydration || (prev.syncStatus === "syncing" && phase !== "ready");
+
+  const nextBootGeneration = needsHydration
+    ? prev.bootGeneration + 1
+    : prev.bootGeneration;
+
+  // Snapshot-push path (allowHydration=false) cannot move the IDB pointer, so
+  // it leaves activeAccountId untouched and defers to the follow-up checkAuth.
+  const nextStoreAccountId =
+    accountChanged && !options.allowHydration
+      ? prev.activeAccountId
+      : nextAccountId;
+  const recoveredFromReauth =
+    phase === "ready" && prev.syncStatus === "reauthing";
+  const needLoginWhileSyncing =
+    phase === "need_login" && prev.syncStatus === "syncing";
+
+  const patch: AuthTransitionPatch = {
+    authPhase: phase,
+    authState: payload.authState,
+    sessionState,
+    capability: {
+      bookmarksApi: payload.bookmarksApi,
+      detailApi: payload.detailApi,
+    },
+    activeAccountId: nextStoreAccountId,
+    authRetryDelayMs,
+    bootGeneration: nextBootGeneration,
+    bookmarksLoaded: needsHydration ? false : prev.bookmarksLoaded,
+    detailedIdsLoaded: needsHydration ? false : prev.detailedIdsLoaded,
+    bookmarks: needsHydration ? [] : prev.bookmarks,
+    detailedTweetIds: needsHydration
+      ? new Set<string>()
+      : prev.detailedTweetIds,
+    // Never regress: the SW can push a snapshot after this session already
+    // advanced lastSyncAt.
+    lastSyncAt:
+      payload.lastSyncAt > prev.lastSyncAt
+        ? payload.lastSyncAt
+        : prev.lastSyncAt,
+    syncStatus:
+      needLoginWhileSyncing || recoveredFromReauth ? "idle" : prev.syncStatus,
+    syncJobKind:
+      needLoginWhileSyncing || recoveredFromReauth ? "none" : prev.syncJobKind,
+  };
+
+  const effects: AuthTransitionEffect[] = [];
+  if (shouldReleaseActiveWork) {
+    effects.push({ kind: "releaseActiveWork" });
+  }
+  // An auth/account transition invalidates whatever block window a prior sync
+  // decision set up; a pending long timer would otherwise silence post-login
+  // auto-sync.
+  if (accountChanged || (phaseChanged && phase === "ready")) {
+    effects.push({ kind: "clearScheduledAutoRetry" });
+  }
+  if (phase === "connecting" && shouldStartAuthCapture(payload)) {
+    effects.push({ kind: "startAuthCapture", interactive: false });
+  }
+  if (needsHydration) {
+    effects.push({
+      kind: "hydrate",
+      bootGeneration: nextBootGeneration,
+      allowAutoSync: options.allowAutoSync && !recoveredFromReauth,
+    });
+  } else {
+    if (options.allowAutoSync && !recoveredFromReauth) {
+      effects.push({ kind: "maybeAutoSync" });
+    }
+    effects.push({ kind: "reconcilePrefetch" });
+  }
+
+  return { patch, effects };
+}

--- a/src/stores/runtime-store.ts
+++ b/src/stores/runtime-store.ts
@@ -48,7 +48,6 @@ import {
 import { CS_DB_CLEANUP_AT } from "../lib/storage-keys";
 import type {
   ApiCapability,
-  ApiCapabilityState,
   AuthPhase,
   AuthState as SessionAuthState,
   AuthStatus,
@@ -60,6 +59,7 @@ import type {
   SyncStatus,
 } from "../types";
 import { createPrefetchController } from "./prefetch-controller";
+import { deriveAuthTransition, type AuthPayload } from "./auth-transition";
 
 export type RuntimeMode =
   | "initializing"
@@ -99,18 +99,6 @@ export type FooterState =
 export interface ReaderAvailabilityState {
   offlineMode: boolean;
   canLogin: boolean;
-}
-
-interface AuthPayload {
-  hasUser: boolean;
-  hasAuth: boolean;
-  authState: SessionAuthState;
-  sessionState: SessionState;
-  userId: string | null;
-  accountContextId: string | null;
-  bookmarksApi: ApiCapabilityState;
-  detailApi: ApiCapabilityState;
-  lastSyncAt: number;
 }
 
 interface ActiveSyncController {
@@ -612,16 +600,6 @@ export function createRuntimeStore() {
       }
     };
 
-    const maybeStartAuthCaptureForPayload = (
-      payload: AuthPayload,
-      interactive: boolean,
-    ) => {
-      if (payload.sessionState === "logged_in" || payload.hasAuth || !payload.hasUser) {
-        return;
-      }
-      void startAuthCapture({ interactive }).catch(() => {});
-    };
-
     const applyAuthPayload = async (
       payload: AuthPayload,
       options: {
@@ -629,115 +607,39 @@ export function createRuntimeStore() {
         allowAutoSync: boolean;
       },
     ): Promise<void> => {
-      const state = get();
-      const nextAccountId =
-        payload.sessionState === "logged_out" || payload.authState === "logged_out"
-          ? state.activeAccountId || payload.accountContextId || null
-          : payload.userId || payload.accountContextId || state.activeAccountId;
+      const { patch, effects } = deriveAuthTransition(get(), payload, options);
+      setRuntimeState(patch);
 
-      let phase: AuthPhase;
-      let sessionState: SessionState;
-      let authRetryDelayMs: number | null = null;
-
-      if (payload.sessionState === "logged_out" || payload.authState === "logged_out") {
-        phase = "need_login";
-        sessionState = "logged_out";
-      } else if (payload.sessionState === "logged_in") {
-        phase = "ready";
-        sessionState = "logged_in";
-      } else if (!payload.hasUser && !payload.hasAuth) {
-        phase = "need_login";
-        sessionState = "logged_out";
-      } else {
-        phase = "connecting";
-        sessionState = payload.sessionState;
-        authRetryDelayMs = AUTH_QUICK_CHECK_MS;
+      for (const effect of effects) {
+        switch (effect.kind) {
+          case "releaseActiveWork":
+            stopSync();
+            void releaseActiveLease("skipped");
+            break;
+          case "clearScheduledAutoRetry":
+            clearScheduledAutoRetry();
+            break;
+          case "startAuthCapture":
+            void startAuthCapture({ interactive: effect.interactive }).catch(
+              () => {},
+            );
+            break;
+          case "hydrate":
+            // Terminal: hydrateCurrentAccount runs its own post-hydrate
+            // auto-sync + prefetch reconcile, so no further effects follow.
+            await hydrateCurrentAccount(
+              effect.bootGeneration,
+              effect.allowAutoSync,
+            );
+            return;
+          case "maybeAutoSync":
+            maybeStartAutomaticSync();
+            break;
+          case "reconcilePrefetch":
+            prefetchController.reconcile();
+            break;
+        }
       }
-
-      const accountChanged = nextAccountId !== state.activeAccountId;
-      const needsHydration = options.allowHydration &&
-        (accountChanged || !state.bookmarksLoaded || !state.detailedIdsLoaded);
-      const phaseChanged = phase !== state.authPhase;
-
-      // Invalidate any in-flight sync when the runtime's view of the session
-      // becomes non-ready. Without this, a push snapshot reporting
-      // logged_out / connecting while a sync is mid-flight would leave the
-      // local lease and activeSyncController alive, continuing to write into
-      // a DB the runtime no longer owns.
-      const shouldReleaseActiveWork =
-        needsHydration ||
-        (state.syncStatus === "syncing" && phase !== "ready");
-
-      if (shouldReleaseActiveWork) {
-        stopSync();
-        void releaseActiveLease("skipped");
-      }
-
-      // An auth/account transition invalidates whatever block window a prior
-      // sync decision set up — the account we're talking to may have changed,
-      // and a pending long timer (e.g. 4h fresh_cache) would otherwise silence
-      // the post-login auto-sync. See the guard in maybeStartAutomaticSync.
-      if (accountChanged || (phaseChanged && phase === "ready")) {
-        clearScheduledAutoRetry();
-      }
-
-      const nextBootGeneration = needsHydration
-        ? state.bootGeneration + 1
-        : state.bootGeneration;
-
-      // On the snapshot-push path (allowHydration=false) we can't also call
-      // setActiveAccountId on the DB layer, so leave activeAccountId as-is
-      // and let the follow-up checkAuth be the sole writer that moves the
-      // store + IDB pointer together.
-      const nextStoreAccountId =
-        accountChanged && !options.allowHydration ? state.activeAccountId : nextAccountId;
-      const recoveredFromReauth = phase === "ready" && state.syncStatus === "reauthing";
-
-      setRuntimeState({
-        authPhase: phase,
-        authState: payload.authState,
-        sessionState,
-        capability: {
-          bookmarksApi: payload.bookmarksApi,
-          detailApi: payload.detailApi,
-        },
-        activeAccountId: nextStoreAccountId,
-        authRetryDelayMs,
-        bootGeneration: nextBootGeneration,
-        bookmarksLoaded: needsHydration ? false : state.bookmarksLoaded,
-        detailedIdsLoaded: needsHydration ? false : state.detailedIdsLoaded,
-        bookmarks: needsHydration ? [] : state.bookmarks,
-        detailedTweetIds: needsHydration ? new Set<string>() : state.detailedTweetIds,
-        // Take the max: SW can push a snapshot after Date.now() already advanced
-        // lastSyncAt in this session, and we never want to regress it.
-        lastSyncAt: payload.lastSyncAt > state.lastSyncAt ? payload.lastSyncAt : state.lastSyncAt,
-        syncStatus:
-          phase === "need_login" && state.syncStatus === "syncing"
-            ? "idle"
-            : recoveredFromReauth
-              ? "idle"
-            : state.syncStatus,
-        syncJobKind:
-          (phase === "need_login" && state.syncStatus === "syncing") ||
-          recoveredFromReauth
-            ? "none"
-            : state.syncJobKind,
-      });
-
-      if (phase === "connecting") {
-        maybeStartAuthCaptureForPayload(payload, false);
-      }
-
-      if (needsHydration) {
-        await hydrateCurrentAccount(nextBootGeneration, options.allowAutoSync && !recoveredFromReauth);
-        return;
-      }
-
-      if (options.allowAutoSync && !recoveredFromReauth) {
-        maybeStartAutomaticSync();
-      }
-
-      prefetchController.reconcile();
     };
 
     const runAuthCheck = (): Promise<void> => {


### PR DESCRIPTION
## What

Deepens the runtime store's auth/session handling by extracting the **auth-transition derivation** into a pure module, `src/stores/auth-transition.ts`. `applyAuthPayload` was a ~115-line procedure that interleaved *deciding* the next state with *performing* it: computing the phase ladder, the account/IDB-pointer asymmetry, the hydration decision, the `lastSyncAt` max-merge, reauth recovery — and then firing six ordered side effects against the live store, sync controller, lease, prefetch, and auth-capture.

Now a single pure function owns the decision:

```ts
deriveAuthTransition(prev, payload, { allowHydration, allowAutoSync })
  → { patch, effects }
```

`patch` is the exact set of store facts to write; `effects` is an **ordered** list (`releaseActiveWork`, `clearScheduledAutoRetry`, `startAuthCapture`, `hydrate`, `maybeAutoSync`, `reconcilePrefetch`) the shell runs left-to-right after applying the patch. `applyAuthPayload` shrinks to a thin shell: derive → `setRuntimeState(patch)` → run effects. Net **−98 lines** in `runtime-store.ts`.

## Why

- **The interface is the test surface.** The phase machine, account pointer rules, hydration trigger, `lastSyncAt` merge, and reauth recovery were previously only reachable by driving the whole store through `checkAuth` / snapshot pushes with mocked I/O. They're now exercised directly through `{ patch, effects }` — no store, no clock, no chrome fakes.
- **Locality.** One place decides the transition; the shell only knows *how* to perform each effect, not *when*.
- **Leverage.** `deriveAuthTransition` is a small interface hiding the entire auth state machine; the three callers (`checkAuth`, the bootGeneration-guarded reload, `applyRuntimeSnapshot`) all funnel through it.

## Behavior

**1:1 behavior-preserving.** The derivation is a faithful lift of the original computation; the shell runs the same effects in the same relative order. The only structural change: `stopSync()/releaseActiveLease()` and `clearScheduledAutoRetry()` move from *before* `setRuntimeState` to *after* it. This is unobservable — verified that neither `stopSync` (just `controller.abort()`) nor `releaseActiveLease` (mutates a closure-local lease + async RPC) nor `clearScheduledAutoRetry` (nulls a timer var) writes store state synchronously, and `clearScheduledAutoRetry` still precedes `maybeStartAutomaticSync` (which reads the timer). Confirmed by a 5-lens adversarial equivalence review.

## Tests

New `src/stores/__tests__/auth-transition.test.ts` (21 tests) locks the phase machine (logged_out / `authState==='logged_out'` disjunct / logged_in / no-user-no-auth / connecting+`AUTH_QUICK_CHECK_MS`), the auth-capture guard, hydration (cache reset, bootGeneration bump, terminal — no trailing auto-sync), auto-sync/reconcile ordering, reauth-recovery suppression, mid-sync login invalidation, the snapshot-push account-pointer freeze, the `lastSyncAt` max-merge, and the three trickiest interaction edges (capture-before-terminal-hydrate, release-while-`syncing`-stays-`syncing`, reauth-recovery-no-autosync-on-hydrate-path).

An adversarial 5-lens equivalence review (exhaustive 23,040-combination diff + helper-semantics audit) ruled the refactor **equivalent** to the original with no behavioral divergence. `pnpm typecheck` clean · full suite green (659 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
