### PR TITLE
refactor(today): extract pure planMetadataWrite seam

### DIFF
--- a/src/hooks/useTodayQueue.ts
+++ b/src/hooks/useTodayQueue.ts
@@ -21,8 +21,10 @@ import {
   makeQueueExposure,
   makeTodayQueueKey,
   pickAdditionalTodayReadItems,
+  planMetadataWrite,
   shouldPersistTodayQueueSnapshot,
   toTodayQueueSnapshot,
+  type MetadataWriteOp,
   type TodayQueueHandledItem,
   type TodayQueueHandledReason,
   type TodayQueueItem,
@@ -127,10 +129,6 @@ function nextLocalDate(): string {
 // the active DB without remounting, so each account must be swept when it first
 // becomes active — a single page-load flag would only ever clean the first one.
 const sweptAccountIds = new Set<string>();
-
-function isNeutralMetadata(row: BookmarkQueueMetadata): boolean {
-  return row.intent === "unset" && !row.snoozedUntil;
-}
 
 export function useTodayQueue({
   enabled,
@@ -422,36 +420,25 @@ export function useTodayQueue({
     [db, refresh, state.localDate],
   );
 
-  const writeMetadata = useCallback(
-    async (
-      tweetId: string,
-      patch: Pick<BookmarkQueueMetadata, "intent" | "snoozedUntil">,
-      action: TodayQueueExposureAction,
-    ) => {
-      const existing = await db.getQueueBookmarkMetadataByTweetId(tweetId);
-      const next: BookmarkQueueMetadata = {
-        tweetId,
-        intent: patch.intent ?? existing?.intent ?? "unset",
-        snoozedUntil: patch.snoozedUntil ?? existing?.snoozedUntil ?? null,
-        updatedAt: Date.now(),
-      };
-      if (isNeutralMetadata(next)) {
-        await db.deleteQueueBookmarkMetadata(tweetId);
-      } else {
-        await db.upsertQueueBookmarkMetadata(next);
+  const applyMetadataPlan = useCallback(
+    async (op: MetadataWriteOp) => {
+      const existing = await db.getQueueBookmarkMetadataByTweetId(op.tweetId);
+      const plan = planMetadataWrite(op, existing, Date.now());
+      if (plan.action === "upsert" && plan.row) {
+        await db.upsertQueueBookmarkMetadata(plan.row);
+      } else if (plan.action === "delete") {
+        await db.deleteQueueBookmarkMetadata(op.tweetId);
       }
-      await recordAction(tweetId, action);
+      await recordAction(op.tweetId, plan.exposure);
     },
     [db, recordAction],
   );
 
   const setIntent = useCallback(
     async (tweetId: string, intent: BookmarkIntent) => {
-      const action =
-        intent === "reference" || intent === "act" ? intent : "opened";
-      await writeMetadata(tweetId, { intent, snoozedUntil: null }, action);
+      await applyMetadataPlan({ type: "setIntent", tweetId, intent });
     },
-    [writeMetadata],
+    [applyMetadataPlan],
   );
 
   const clearFeedback = useCallback(async (tweetId: string) => {
@@ -473,13 +460,13 @@ export function useTodayQueue({
 
   const snooze = useCallback(
     async (tweetId: string) => {
-      await writeMetadata(
+      await applyMetadataPlan({
+        type: "snooze",
         tweetId,
-        { intent: "unset", snoozedUntil: nextLocalDate() },
-        "snoozed",
-      );
+        snoozedUntil: nextLocalDate(),
+      });
     },
-    [writeMetadata],
+    [applyMetadataPlan],
   );
 
   const addToTodayQueue = useCallback(
@@ -499,22 +486,25 @@ export function useTodayQueue({
         generatedAt: createdAt,
       });
 
-      // Adding to Today's Read normally wipes the metadata row (snooze + any
-      // reference/act feedback) so the item starts fresh. An auto-pick must not
-      // silently discard a deliberate "read soon" intent the user set, so keep
-      // that one and drop only a stale snooze.
+      // The metadata-row decision (wipe vs preserve a read_soon intent and drop
+      // only a stale snooze) lives in planMetadataWrite; the snapshot append and
+      // its createdAt-stamped "added" exposure below are not metadata facts and
+      // stay inline (recording them here avoids a double exposure).
       const existing = options?.preserveReadSoonIntent
         ? await db.getQueueBookmarkMetadataByTweetId(tweetId)
         : null;
-      if (existing?.intent === "read_soon") {
-        if (existing.snoozedUntil) {
-          await db.upsertQueueBookmarkMetadata({
-            ...existing,
-            snoozedUntil: null,
-            updatedAt: Date.now(),
-          });
-        }
-      } else {
+      const plan = planMetadataWrite(
+        {
+          type: "addToTodayRead",
+          tweetId,
+          preserveReadSoonIntent: options?.preserveReadSoonIntent ?? false,
+        },
+        existing,
+        Date.now(),
+      );
+      if (plan.action === "upsert" && plan.row) {
+        await db.upsertQueueBookmarkMetadata(plan.row);
+      } else if (plan.action === "delete") {
         await db.deleteQueueBookmarkMetadata(tweetId);
       }
       await db.upsertTodayQueueSnapshot(snapshot);

--- a/src/lib/__tests__/plan-metadata-write.test.ts
+++ b/src/lib/__tests__/plan-metadata-write.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { planMetadataWrite } from "../today-queue";
+import type { BookmarkQueueMetadata } from "../../types";
+
+const NOW = 1_700_000_000_000;
+
+function meta(overrides: Partial<BookmarkQueueMetadata> = {}): BookmarkQueueMetadata {
+  return {
+    tweetId: "t1",
+    intent: "unset",
+    snoozedUntil: null,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("planMetadataWrite — setIntent", () => {
+  it("upserts and maps a reference intent to the 'reference' exposure", () => {
+    const plan = planMetadataWrite(
+      { type: "setIntent", tweetId: "t1", intent: "reference" },
+      null,
+      NOW,
+    );
+    expect(plan.action).toBe("upsert");
+    expect(plan.row).toMatchObject({ tweetId: "t1", intent: "reference", snoozedUntil: null, updatedAt: NOW });
+    expect(plan.exposure).toBe("reference");
+  });
+
+  it("keeps an existing snooze when setIntent passes an explicit null (null is treated as absent)", () => {
+    const existing = meta({ intent: "unset", snoozedUntil: "2026-07-01" });
+    const plan = planMetadataWrite(
+      { type: "setIntent", tweetId: "t1", intent: "unset" },
+      existing,
+      NOW,
+    );
+    expect(plan.action).toBe("upsert");
+    expect(plan.row?.snoozedUntil).toBe("2026-07-01");
+    expect(plan.exposure).toBe("opened");
+  });
+
+  it("deletes when the merged row collapses to neutral (unset + no snooze)", () => {
+    const plan = planMetadataWrite(
+      { type: "setIntent", tweetId: "t1", intent: "unset" },
+      meta({ intent: "reference" }),
+      NOW,
+    );
+    expect(plan.action).toBe("delete");
+    expect(plan.row).toBeUndefined();
+    expect(plan.exposure).toBe("opened");
+  });
+
+  it("produces a fresh row on a null existing for a write intent", () => {
+    const plan = planMetadataWrite(
+      { type: "setIntent", tweetId: "t1", intent: "act" },
+      null,
+      NOW,
+    );
+    expect(plan.action).toBe("upsert");
+    expect(plan.row).toMatchObject({ intent: "act", snoozedUntil: null });
+    expect(plan.exposure).toBe("act");
+  });
+
+  it("deletes on a null existing for an unset intent (neutral, no throw)", () => {
+    const plan = planMetadataWrite(
+      { type: "setIntent", tweetId: "t1", intent: "unset" },
+      null,
+      NOW,
+    );
+    expect(plan.action).toBe("delete");
+  });
+});
+
+describe("planMetadataWrite — snooze", () => {
+  it("forces intent unset, sets snoozedUntil, upserts with the 'snoozed' exposure", () => {
+    const plan = planMetadataWrite(
+      { type: "snooze", tweetId: "t1", snoozedUntil: "2026-07-02" },
+      null,
+      NOW,
+    );
+    expect(plan.action).toBe("upsert");
+    expect(plan.row).toMatchObject({ intent: "unset", snoozedUntil: "2026-07-02", updatedAt: NOW });
+    expect(plan.exposure).toBe("snoozed");
+  });
+
+  it("overwrites a prior reference intent to unset (does not inherit it)", () => {
+    const plan = planMetadataWrite(
+      { type: "snooze", tweetId: "t1", snoozedUntil: "2026-07-02" },
+      meta({ intent: "reference" }),
+      NOW,
+    );
+    expect(plan.row?.intent).toBe("unset");
+  });
+});
+
+describe("planMetadataWrite — addToTodayRead", () => {
+  it("preserves a read_soon intent but drops a stale snooze (upsert, intent kept)", () => {
+    const existing = meta({ intent: "read_soon", snoozedUntil: "2026-07-03", updatedAt: 5 });
+    const plan = planMetadataWrite(
+      { type: "addToTodayRead", tweetId: "t1", preserveReadSoonIntent: true },
+      existing,
+      NOW,
+    );
+    expect(plan.action).toBe("upsert");
+    expect(plan.row).toMatchObject({ intent: "read_soon", snoozedUntil: null, updatedAt: NOW });
+    expect(plan.exposure).toBe("added");
+  });
+
+  it("returns 'keep' (no row, no updatedAt re-stamp) for read_soon without a snooze", () => {
+    const existing = meta({ intent: "read_soon", snoozedUntil: null, updatedAt: 5 });
+    const plan = planMetadataWrite(
+      { type: "addToTodayRead", tweetId: "t1", preserveReadSoonIntent: true },
+      existing,
+      NOW,
+    );
+    expect(plan.action).toBe("keep");
+    expect(plan.row).toBeUndefined();
+  });
+
+  it("deletes a non-read_soon row even when preserve is on (preserve only protects read_soon)", () => {
+    const plan = planMetadataWrite(
+      { type: "addToTodayRead", tweetId: "t1", preserveReadSoonIntent: true },
+      meta({ intent: "reference" }),
+      NOW,
+    );
+    expect(plan.action).toBe("delete");
+  });
+
+  it("deletes even a read_soon row when preserve is off (manual add starts fresh)", () => {
+    const plan = planMetadataWrite(
+      { type: "addToTodayRead", tweetId: "t1", preserveReadSoonIntent: false },
+      meta({ intent: "read_soon", snoozedUntil: "2026-07-03" }),
+      NOW,
+    );
+    expect(plan.action).toBe("delete");
+  });
+
+  it("always reports the 'added' exposure across keep / delete / upsert outcomes", () => {
+    const keep = planMetadataWrite(
+      { type: "addToTodayRead", tweetId: "t1", preserveReadSoonIntent: true },
+      meta({ intent: "read_soon" }),
+      NOW,
+    );
+    const del = planMetadataWrite(
+      { type: "addToTodayRead", tweetId: "t1", preserveReadSoonIntent: false },
+      null,
+      NOW,
+    );
+    const upsert = planMetadataWrite(
+      { type: "addToTodayRead", tweetId: "t1", preserveReadSoonIntent: true },
+      meta({ intent: "read_soon", snoozedUntil: "2026-07-03" }),
+      NOW,
+    );
+    expect([keep.action, del.action, upsert.action]).toEqual(["keep", "delete", "upsert"]);
+    expect([keep.exposure, del.exposure, upsert.exposure]).toEqual(["added", "added", "added"]);
+  });
+});

--- a/src/lib/today-queue.ts
+++ b/src/lib/today-queue.ts
@@ -1,14 +1,91 @@
 import type {
   Bookmark,
+  BookmarkIntent,
   BookmarkQueueMetadata,
   ReadingProgress,
   TodayQueueBudgetMinutes,
   TodayQueueExposure,
+  TodayQueueExposureAction,
   TodayQueueSnapshot,
 } from "../types";
 import { estimateReadingMinutes, inferKindBadge } from "./bookmark-utils";
 import { TODAY_QUEUE, TODAY_QUEUE_WEIGHTS } from "./constants/scoring";
 import { sortIndexToTimestamp } from "./time";
+
+/**
+ * Decides the single metadata-row fact (and the exposure to record) for an
+ * intent / snooze / add-to-Today's-Read operation. Pure: `now` is injected and
+ * there is no DB access, so the whole decision — the `??` merge quirk, the
+ * neutral-row collapse, the intent→exposure mapping, and the three-way
+ * read_soon-preserve outcome — is testable without IndexedDB.
+ *
+ * The `keep` action is first-class and distinct from `delete`: it means "touch
+ * nothing" (no upsert, no delete, no updatedAt re-stamp). Callers MUST branch on
+ * `action`, never treat an absent `row` as a delete.
+ */
+export type MetadataWriteOp =
+  | { type: "setIntent"; tweetId: string; intent: BookmarkIntent }
+  | { type: "snooze"; tweetId: string; snoozedUntil: string }
+  | { type: "addToTodayRead"; tweetId: string; preserveReadSoonIntent: boolean };
+
+export interface MetadataWritePlan {
+  action: "upsert" | "delete" | "keep";
+  row?: BookmarkQueueMetadata;
+  exposure: TodayQueueExposureAction;
+}
+
+export function isNeutralMetadata(
+  row: Pick<BookmarkQueueMetadata, "intent" | "snoozedUntil">,
+): boolean {
+  return row.intent === "unset" && !row.snoozedUntil;
+}
+
+export function planMetadataWrite(
+  op: MetadataWriteOp,
+  existing: BookmarkQueueMetadata | null,
+  now: number,
+): MetadataWritePlan {
+  if (op.type === "addToTodayRead") {
+    // Adding to Today's Read normally wipes the metadata row so the item starts
+    // fresh; an auto-pick must not silently discard a deliberate read_soon
+    // intent, so keep that one and drop only a stale snooze.
+    if (op.preserveReadSoonIntent && existing?.intent === "read_soon") {
+      if (existing.snoozedUntil) {
+        return {
+          action: "upsert",
+          row: { ...existing, snoozedUntil: null, updatedAt: now },
+          exposure: "added",
+        };
+      }
+      return { action: "keep", exposure: "added" };
+    }
+    return { action: "delete", exposure: "added" };
+  }
+
+  // setIntent and snooze share the merge: an explicit snoozedUntil:null is
+  // treated as "absent" by the `??` chain, so setIntent does NOT clear an
+  // existing snooze; snooze, by passing intent:"unset", overwrites a prior
+  // reference/act intent.
+  const patch =
+    op.type === "snooze"
+      ? { intent: "unset" as BookmarkIntent, snoozedUntil: op.snoozedUntil }
+      : { intent: op.intent, snoozedUntil: null };
+  const next: BookmarkQueueMetadata = {
+    tweetId: op.tweetId,
+    intent: patch.intent ?? existing?.intent ?? "unset",
+    snoozedUntil: patch.snoozedUntil ?? existing?.snoozedUntil ?? null,
+    updatedAt: now,
+  };
+  const exposure: TodayQueueExposureAction =
+    op.type === "snooze"
+      ? "snoozed"
+      : op.intent === "reference" || op.intent === "act"
+        ? op.intent
+        : "opened";
+  return isNeutralMetadata(next)
+    ? { action: "delete", exposure }
+    : { action: "upsert", row: next, exposure };
+}
 
 export interface TodayQueueItem {
   bookmark: Bookmark;


### PR DESCRIPTION
## What

Deepens the Today's Read metadata-write path into a pure planner, `planMetadataWrite`, in `src/lib/today-queue.ts`. The decision of *what metadata fact to write* for an intent / snooze / add-to-Today's-Read op — the `??` merge, the neutral-row collapse, the intent→exposure mapping, and the three-way read_soon-preserve outcome — was previously scattered across four `async` hook methods (`writeMetadata`, `setIntent`, `snooze`, `addToTodayQueue`), each interleaving that decision with IndexedDB I/O and React state.

Now one pure function owns it:

```ts
planMetadataWrite(op, existing, now) → { action: "upsert" | "delete" | "keep"; row?; exposure }
```

The hook collapses to a uniform applier: read `existing`, call the planner, apply the one DB op (`upsert` | `delete` | no-op), record the one exposure.

## Why

- **The interface is the test surface.** The metadata decision was untestable except past the IndexedDB seam — and the load-bearing read_soon-preserve branch (commit a1cf6b9e) had *zero* coverage. It's now a pure `(op, existing, now) → plan` exercised with `{reason}` literals.
- **`keep` is a first-class action.** The three-way `upsert | delete | keep` is what makes the seam honest: `keep` (touch nothing, no `updatedAt` re-stamp) can't be encoded as `row | null` without either losing the keep/delete distinction (re-introducing the a1cf6b9e bug) or spuriously re-stamping `updatedAt`.
- **Locality + leverage.** One place decides; four call sites shrink to a trivial shell.

## Behavior

**1:1 behavior-preserving.** Verified by a 3-lens adversarial equivalence review (verdict: equivalent) plus the existing real-DB hook tests. Specifically preserved:

- The subtle `?? ` merge: `setIntent`'s explicit `snoozedUntil: null` is treated as *absent*, so an existing snooze survives. (Pinned by a dedicated test so the quirk is visible — if the team wants `setIntent` to clear snooze, that's a separate, explicit decision.)
- `snooze` overwrites a prior reference/act intent to `unset`.
- The neutral-row collapse → `delete`, reusing the same `isNeutralMetadata` predicate (moved from hook-private to an exported lib function — it had a single hook caller).
- `addToTodayQueue` keeps its own `createdAt`-stamped `"added"` exposure inline and does **not** route through the applier — so exactly one `"added"` exposure is recorded (no double-write), and `existing` is still read only when `preserveReadSoonIntent` is set.

## Tests

New `src/lib/__tests__/plan-metadata-write.test.ts` (12 tests): reference/act/unset/read_soon exposure mapping, the snooze-survives-explicit-null merge, neutral collapse, snooze-overwrites-reference, all three read_soon-preserve outcomes (upsert-drop-stale-snooze / keep / delete), preserve-off-deletes-read_soon, the always-`added` exposure invariant, and null-existing handling.

`pnpm typecheck` clean · full suite green (651 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
