### PR TITLE
refactor(today): extract pure deriveTodayCompletionSummary

### DIFF
--- a/src/components/BookmarksList.tsx
+++ b/src/components/BookmarksList.tsx
@@ -25,6 +25,7 @@ import type {
   TodayQueueHandledItem,
   TodayQueueHandledReason,
 } from "../lib/today-queue";
+import { deriveTodayCompletionSummary } from "../lib/today-queue";
 import { useBookmarkSearch } from "../hooks/useBookmarkSearch";
 import { pickTitle, pickSearchSnippet, inferKindBadge } from "../lib/bookmark-utils";
 import { cn } from "../lib/cn";
@@ -523,18 +524,10 @@ function useBookmarksListModel({
     () => handledTodayItems.filter((item) => item.reason !== "action"),
     [handledTodayItems],
   );
-  const todayCompletionSummary = useMemo(() => {
-    const counts = new Map<TodayQueueHandledReason, number>();
-    for (const item of handledTodayItems) {
-      counts.set(item.reason, (counts.get(item.reason) ?? 0) + 1);
-    }
-    return TODAY_COMPLETION_ORDER.flatMap((reason) => {
-      const count = counts.get(reason) ?? 0;
-      return count > 0
-        ? [{ reason, label: TODAY_COMPLETION_LABELS[reason], count }]
-        : [];
-    });
-  }, [handledTodayItems]);
+  const todayCompletionSummary = useMemo(
+    () => deriveTodayCompletionSummary(handledTodayItems, TODAY_COMPLETION_ORDER),
+    [handledTodayItems],
+  );
   const activeSort = activeTab === "today" ? "recent" : sortPreferences[activeTab];
 
   // Map tweetId → progress so search results across all tabs can show their
@@ -913,7 +906,7 @@ function useBookmarksListModel({
                     <span className="font-medium tabular-nums text-foreground/75">
                       {item.count}
                     </span>
-                    {item.label}
+                    {TODAY_COMPLETION_LABELS[item.reason]}
                   </span>
                 ))}
               </div>

--- a/src/lib/__tests__/today-completion-summary.test.ts
+++ b/src/lib/__tests__/today-completion-summary.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { deriveTodayCompletionSummary } from "../today-queue";
+import type { TodayQueueHandledReason } from "../today-queue";
+
+const ORDER: TodayQueueHandledReason[] = ["read", "snoozed", "action", "archived"];
+
+const handled = (...reasons: TodayQueueHandledReason[]) =>
+  reasons.map((reason) => ({ reason }));
+
+describe("deriveTodayCompletionSummary", () => {
+  it("orders entries by the supplied order, not by handled insertion order", () => {
+    const result = deriveTodayCompletionSummary(
+      handled("action", "read", "snoozed"),
+      ORDER,
+    );
+    expect(result.map((entry) => entry.reason)).toEqual(["read", "snoozed", "action"]);
+  });
+
+  it("counts each reason exactly and omits zero-count reasons", () => {
+    const result = deriveTodayCompletionSummary(
+      handled("read", "read", "read", "archived"),
+      ORDER,
+    );
+    expect(result).toEqual([
+      { reason: "read", count: 3 },
+      { reason: "archived", count: 1 },
+    ]);
+  });
+
+  it("returns [] for empty handledItems", () => {
+    expect(deriveTodayCompletionSummary([], ORDER)).toEqual([]);
+  });
+
+  it("ignores reasons absent from the order allow-list and does not mutate inputs", () => {
+    const items = handled("read", "snoozed");
+    const partialOrder: TodayQueueHandledReason[] = ["read"];
+    const first = deriveTodayCompletionSummary(items, partialOrder);
+    const second = deriveTodayCompletionSummary(items, partialOrder);
+    expect(first).toEqual([{ reason: "read", count: 1 }]);
+    // "snoozed" is not allow-listed by partialOrder → dropped, no throw.
+    expect(first).toEqual(second);
+    // inputs untouched across calls.
+    expect(items).toEqual([{ reason: "read" }, { reason: "snoozed" }]);
+  });
+});

--- a/src/lib/today-queue.ts
+++ b/src/lib/today-queue.ts
@@ -748,6 +748,29 @@ export function deriveHandledTodayQueueItems({
   return items;
 }
 
+/**
+ * Tallies handled items into ordered, zero-filtered completion counts for the
+ * done-state chips. `order` is the allow-list AND the display order (data,
+ * injected by the caller) so this stays free of the view's label/icon tables;
+ * a reason absent from `order` is dropped (never throws), and a reason with a
+ * zero tally is omitted so the chips show only what actually happened. Pure.
+ */
+export function deriveTodayCompletionSummary(
+  handledItems: ReadonlyArray<{ reason: TodayQueueHandledReason }>,
+  order: ReadonlyArray<TodayQueueHandledReason>,
+): { reason: TodayQueueHandledReason; count: number }[] {
+  const counts = new Map<TodayQueueHandledReason, number>();
+  for (const item of handledItems) {
+    counts.set(item.reason, (counts.get(item.reason) ?? 0) + 1);
+  }
+  const result: { reason: TodayQueueHandledReason; count: number }[] = [];
+  for (const reason of order) {
+    const count = counts.get(reason) ?? 0;
+    if (count > 0) result.push({ reason, count });
+  }
+  return result;
+}
+
 // Two exposures for the same tweet + action can land in the same millisecond
 // (e.g. queue rebuild plus manual add); a sequence keeps their ids distinct so
 // one row doesn't silently overwrite the other.


### PR DESCRIPTION
## What

Extracts the Today's Read done-state completion tally into a pure function, `deriveTodayCompletionSummary`, in `src/lib/today-queue.ts`. The count-tally + order-projection + zero-filter logic previously sat inline in a `useMemo` inside the ~2000-line `BookmarksList` component, entangled with JSX and the label/order view tables.

```ts
deriveTodayCompletionSummary(handledItems, order) → { reason; count }[]
```

`order` is passed in as **data** (the allow-list *and* the display order), so the lib stays free of view tables — `TODAY_COMPLETION_LABELS` / `TODAY_COMPLETION_ORDER` and the icon JSX deliberately **stay in the component**. The memo collapses to a one-line call; the chip render resolves its label from the same `TODAY_COMPLETION_LABELS` table at render time.

## Why

- **The interface is the test surface.** Turning handled items into ordered, zero-filtered counts was only testable by rendering React. It's now a 2-arg pure function exercised with `{reason}` literals — no Zustand store, no render.
- **Depth, not relocation.** The function hides three behaviors (tally, order-projection, zero-omission) behind a small signature. We stop at the pure derivation and leave the view tables/icons in the component — pulling those into the lib would create a shallow re-export of view strings and drag Phosphor JSX into a data module.

## Behavior

**1:1 behavior-preserving.** The `flatMap`-empty-array form and the `push`-if-`count>0` form are logically identical; ordering, counts, and zero-omission are unchanged. Label resolution moves from the (removed) `item.label` to `TODAY_COMPLETION_LABELS[item.reason]` — the *same* table the old memo sourced `label` from, so the chip copy is byte-identical.

## Tests

New `src/lib/__tests__/today-completion-summary.test.ts` (4 tests): order-projection (display order ≠ handled insertion order), exact counts + zero-omission, empty → `[]`, and the allow-list/purity guarantee (reason absent from `order` dropped without throwing, inputs not mutated).

`pnpm typecheck` clean · full suite green (643 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
