### PR TITLE
refactor(sync): single-source reclaim/window constants + pure syncRetryAfterMs

### DIFF
--- a/src/lib/__tests__/sync-block-window.test.ts
+++ b/src/lib/__tests__/sync-block-window.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  asSyncBlockedReason,
+  SYNC_BLOCKED_REASONS,
+  syncRetryAfterMs,
+  type SyncRetryWindowAccount,
+} from "../sync-block-window";
+import {
+  SYNC_AUTO_BACKOFF_MS,
+  SYNC_AUTO_INTERVAL_MS,
+  SYNC_AUTO_RECLAIM_MS,
+  SYNC_LOCK_TTL_MS,
+  SYNC_MANUAL_RECLAIM_MS,
+  SYNC_SEED_BACKOFF_MS,
+} from "../constants/sync-policy";
+
+const NOW = 1_000_000;
+
+const acct = (
+  overrides: Partial<SyncRetryWindowAccount> = {},
+): SyncRetryWindowAccount => ({
+  manualCooldownUntil: 0,
+  rateLimitBackoffUntil: 0,
+  lastAttemptAt: 0,
+  lastSuccessAt: 0,
+  lastFullSyncAt: 0,
+  inFlight: null,
+  ...overrides,
+});
+
+describe("syncRetryAfterMs", () => {
+  it("cooldown returns manualCooldownUntil - now, clamped at 0", () => {
+    expect(
+      syncRetryAfterMs({
+        reason: "cooldown",
+        now: NOW,
+        trigger: "manual",
+        account: acct({ manualCooldownUntil: NOW + 5_000 }),
+      }),
+    ).toBe(5_000);
+    expect(
+      syncRetryAfterMs({
+        reason: "cooldown",
+        now: NOW,
+        trigger: "manual",
+        account: acct({ manualCooldownUntil: NOW - 5_000 }),
+      }),
+    ).toBe(0);
+  });
+
+  it("rate_limited returns rateLimitBackoffUntil - now", () => {
+    expect(
+      syncRetryAfterMs({
+        reason: "rate_limited",
+        now: NOW,
+        trigger: "auto",
+        account: acct({ rateLimitBackoffUntil: NOW + 42_000 }),
+      }),
+    ).toBe(42_000);
+  });
+
+  it("in_flight is trigger-split: manual uses MANUAL_RECLAIM (90s); auto uses LOCK_TTL (12min) and is NOT coupled to the auto reclaim constant", () => {
+    const startedAt = NOW - 10_000;
+    const account = acct({ inFlight: { startedAt } });
+
+    expect(
+      syncRetryAfterMs({ reason: "in_flight", now: NOW, trigger: "manual", account }),
+    ).toBe(Math.max(0, startedAt + SYNC_MANUAL_RECLAIM_MS - NOW));
+
+    const autoWindow = syncRetryAfterMs({
+      reason: "in_flight",
+      now: NOW,
+      trigger: "auto",
+      account,
+    });
+    expect(autoWindow).toBe(Math.max(0, startedAt + SYNC_LOCK_TTL_MS - NOW));
+    // The auto in_flight RETRY window is the hard lease cap, deliberately not
+    // the auto reclaim-eligibility window — they are decoupled on the auto path.
+    expect(autoWindow).not.toBe(
+      Math.max(0, startedAt + SYNC_AUTO_RECLAIM_MS - NOW),
+    );
+  });
+
+  it("in_flight with no inFlight or startedAt===0 returns 0", () => {
+    expect(
+      syncRetryAfterMs({
+        reason: "in_flight",
+        now: NOW,
+        trigger: "manual",
+        account: acct({ inFlight: null }),
+      }),
+    ).toBe(0);
+    expect(
+      syncRetryAfterMs({
+        reason: "in_flight",
+        now: NOW,
+        trigger: "auto",
+        account: acct({ inFlight: { startedAt: 0 } }),
+      }),
+    ).toBe(0);
+  });
+
+  it("auto_backoff picks the SEED window when lastFullSyncAt<=0, else the AUTO window", () => {
+    const lastAttemptAt = NOW - 1_000;
+    expect(
+      syncRetryAfterMs({
+        reason: "auto_backoff",
+        now: NOW,
+        trigger: "auto",
+        account: acct({ lastAttemptAt, lastFullSyncAt: 0 }),
+      }),
+    ).toBe(Math.max(0, lastAttemptAt + SYNC_SEED_BACKOFF_MS - NOW));
+    expect(
+      syncRetryAfterMs({
+        reason: "auto_backoff",
+        now: NOW,
+        trigger: "auto",
+        account: acct({ lastAttemptAt, lastFullSyncAt: NOW - 9_000 }),
+      }),
+    ).toBe(Math.max(0, lastAttemptAt + SYNC_AUTO_BACKOFF_MS - NOW));
+  });
+
+  it("fresh_cache returns lastSuccessAt + AUTO_INTERVAL - now (4h window)", () => {
+    const lastSuccessAt = NOW - 60_000;
+    expect(
+      syncRetryAfterMs({
+        reason: "fresh_cache",
+        now: NOW,
+        trigger: "auto",
+        account: acct({ lastSuccessAt }),
+      }),
+    ).toBe(Math.max(0, lastSuccessAt + SYNC_AUTO_INTERVAL_MS - NOW));
+  });
+
+  it("null account and non-time-bounded reasons return 0 (no NaN, no throw)", () => {
+    for (const reason of ["no_account", "not_ready", "garbage", "cooldown"]) {
+      expect(
+        syncRetryAfterMs({ reason, now: NOW, trigger: "auto", account: null }),
+      ).toBe(0);
+    }
+    for (const reason of ["no_account", "not_ready", "totally_unknown"]) {
+      const out = syncRetryAfterMs({
+        reason,
+        now: NOW,
+        trigger: "manual",
+        account: acct({ manualCooldownUntil: NOW + 5_000 }),
+      });
+      expect(out).toBe(0);
+      expect(Number.isNaN(out)).toBe(false);
+    }
+  });
+});
+
+describe("asSyncBlockedReason / SYNC_BLOCKED_REASONS", () => {
+  it("narrows each of the 5 members to itself", () => {
+    for (const reason of [
+      "in_flight",
+      "cooldown",
+      "rate_limited",
+      "no_account",
+      "not_ready",
+    ]) {
+      expect(asSyncBlockedReason(reason)).toBe(reason);
+    }
+  });
+
+  it("returns null for non-members, including auto_backoff/fresh_cache and empty/nullish", () => {
+    for (const reason of [
+      "auto_backoff",
+      "fresh_cache",
+      "blocked",
+      "",
+      "garbage",
+      null,
+      undefined,
+    ]) {
+      expect(asSyncBlockedReason(reason)).toBeNull();
+    }
+  });
+
+  it("the set contains exactly the 5 SyncBlockedReason members", () => {
+    expect([...SYNC_BLOCKED_REASONS].sort()).toEqual(
+      ["cooldown", "in_flight", "no_account", "not_ready", "rate_limited"].sort(),
+    );
+  });
+});

--- a/src/lib/constants/sync-policy.ts
+++ b/src/lib/constants/sync-policy.ts
@@ -5,7 +5,16 @@ export const SYNC_MAX_BOOKMARKS_PER_JOB = 250;
 export const SYNC_LOCK_TTL_MS = 12 * 60 * 1000;
 export const SYNC_MANUAL_COOLDOWN_MS = 4_000;
 export const SYNC_MANUAL_RECLAIM_MS = 90_000;
+// Separate knob from SYNC_MANUAL_RECLAIM_MS even though the value matches: an
+// auto reserve reclaims an orphaned in-flight lease (a prior sync tab unloaded
+// before COMPLETE_SYNC) older than this. Kept distinct so tuning the manual
+// reclaim window cannot silently retime orphaned-auto-lease recovery.
+export const SYNC_AUTO_RECLAIM_MS = 90_000;
 export const SYNC_AUTO_BACKOFF_MS = 5 * 60 * 1000;
+// Seed-incomplete (`lastFullSyncAt === 0`) auto-retries are a user reloading to
+// resume the first sync, not unsolicited polling — use a short window so a
+// reload retries instead of waiting out the 5-min poll backoff.
+export const SYNC_SEED_BACKOFF_MS = 30 * 1000;
 export const SYNC_AUTO_INTERVAL_MS = 4 * 60 * 60 * 1000;
 
 export const SYNC_FETCH_BASE_DELAY_MS = 1200;

--- a/src/lib/sw-pure.ts
+++ b/src/lib/sw-pure.ts
@@ -1,4 +1,5 @@
 import type { AuthState } from "../types/auth";
+import { SYNC_MANUAL_RECLAIM_MS } from "./constants/sync-policy";
 
 export interface ParsedGraphqlEndpoint {
   queryId: string;
@@ -233,8 +234,6 @@ export interface SyncAccountLike {
   manualCooldownUntil?: number;
 }
 
-const SYNC_ORCHESTRATOR_MANUAL_RECLAIM_MS = 90_000;
-
 export type SyncBlockedReason =
   | "no_account"
   | "not_ready"
@@ -265,7 +264,7 @@ export function getSyncBlockedReason(
   if (account?.inFlight) {
     const startedAt = Number(account.inFlight.startedAt || 0);
     const lockAge = now - startedAt;
-    if (lockAge < SYNC_ORCHESTRATOR_MANUAL_RECLAIM_MS) {
+    if (lockAge < SYNC_MANUAL_RECLAIM_MS) {
       return "in_flight";
     }
   }

--- a/src/lib/sync-block-window.ts
+++ b/src/lib/sync-block-window.ts
@@ -1,0 +1,83 @@
+import type { SyncBlockedReason } from "../types/sync";
+import {
+  SYNC_AUTO_BACKOFF_MS,
+  SYNC_AUTO_INTERVAL_MS,
+  SYNC_LOCK_TTL_MS,
+  SYNC_MANUAL_RECLAIM_MS,
+  SYNC_SEED_BACKOFF_MS,
+} from "./constants/sync-policy";
+
+export interface SyncRetryWindowAccount {
+  manualCooldownUntil: number;
+  rateLimitBackoffUntil: number;
+  lastAttemptAt: number;
+  lastSuccessAt: number;
+  lastFullSyncAt: number;
+  inFlight: { startedAt: number } | null;
+}
+
+export interface SyncRetryWindowInput {
+  reason: string;
+  now: number;
+  trigger: "auto" | "manual";
+  account: SyncRetryWindowAccount | null;
+}
+
+/**
+ * How long until a blocked reserve may retry, given the reason it was blocked
+ * for. Pure: the caller injects `now` and the already-decided reason. It does
+ * NOT re-derive reason precedence — the two reserve call sites order reasons
+ * differently and each keeps its own order.
+ *
+ * The in_flight window is trigger-split:
+ *   manual → SYNC_MANUAL_RECLAIM_MS (90s); the same constant the manual reclaim
+ *            check uses, so the "can I reclaim now" test and the "retry after"
+ *            answer stay in lockstep on the manual path.
+ *   auto   → SYNC_LOCK_TTL_MS (12min), the hard lease cap. This is deliberately
+ *            NOT SYNC_AUTO_RECLAIM_MS (90s): an auto reserve can reclaim an
+ *            orphaned lease early, but when it is genuinely still in flight it
+ *            answers "retry at the TTL", so the two are not coupled here.
+ */
+export function syncRetryAfterMs(input: SyncRetryWindowInput): number {
+  const { reason, now, trigger, account } = input;
+  if (!account) return 0;
+  if (reason === "cooldown") {
+    return Math.max(0, account.manualCooldownUntil - now);
+  }
+  if (reason === "rate_limited") {
+    return Math.max(0, account.rateLimitBackoffUntil - now);
+  }
+  if (reason === "in_flight" && account.inFlight) {
+    const startedAt = account.inFlight.startedAt;
+    if (!startedAt) return 0;
+    const window =
+      trigger === "manual" ? SYNC_MANUAL_RECLAIM_MS : SYNC_LOCK_TTL_MS;
+    return Math.max(0, startedAt + window - now);
+  }
+  if (reason === "auto_backoff") {
+    const window =
+      account.lastFullSyncAt <= 0 ? SYNC_SEED_BACKOFF_MS : SYNC_AUTO_BACKOFF_MS;
+    return Math.max(0, account.lastAttemptAt + window - now);
+  }
+  if (reason === "fresh_cache") {
+    return Math.max(0, account.lastSuccessAt + SYNC_AUTO_INTERVAL_MS - now);
+  }
+  return 0;
+}
+
+export const SYNC_BLOCKED_REASONS: ReadonlySet<SyncBlockedReason> =
+  new Set<SyncBlockedReason>([
+    "in_flight",
+    "cooldown",
+    "rate_limited",
+    "no_account",
+    "not_ready",
+  ]);
+
+export function asSyncBlockedReason(
+  reason: string | null | undefined,
+): SyncBlockedReason | null {
+  return reason && SYNC_BLOCKED_REASONS.has(reason as SyncBlockedReason)
+    ? (reason as SyncBlockedReason)
+    : null;
+}

--- a/src/service-worker/sync.ts
+++ b/src/service-worker/sync.ts
@@ -21,26 +21,19 @@ import {
   CS_SYNC_ORCHESTRATOR_STATE,
   CS_RUNTIME_STATE_V2,
 } from "./storage-keys-sw";
+import {
+  SYNC_AUTO_BACKOFF_MS,
+  SYNC_AUTO_INTERVAL_MS,
+  SYNC_AUTO_RECLAIM_MS,
+  SYNC_LOCK_TTL_MS,
+  SYNC_MANUAL_RECLAIM_MS,
+  SYNC_SEED_BACKOFF_MS,
+} from "../lib/constants/sync-policy";
+import { syncRetryAfterMs } from "../lib/sync-block-window";
 
 // ── Constants ───────────────────────────────────────────────────
 
 const SYNC_ORCHESTRATOR_VERSION = 1;
-const SYNC_ORCHESTRATOR_LOCK_TTL_MS = 12 * 60 * 1000;
-const SYNC_ORCHESTRATOR_AUTO_BACKOFF_MS = 5 * 60 * 1000;
-// When the seed has never completed (`lastFullSyncAt === 0`), an auto-sync
-// retry represents a user reloading to resume — not unsolicited polling.
-// The 5-minute window is appropriate for incremental polling; it's wrong
-// for seed resume. Use a short window so a reload actually retries.
-const SYNC_ORCHESTRATOR_SEED_BACKOFF_MS = 30 * 1000;
-const SYNC_ORCHESTRATOR_AUTO_INTERVAL_MS = 4 * 60 * 60 * 1000;
-const SYNC_ORCHESTRATOR_MANUAL_RECLAIM_MS = 90_000;
-// An auto-triggered reserve can also reclaim an in-flight lease that's
-// older than this threshold. This recovers from orphaned leases — the
-// previous sync tab closed before its COMPLETE_SYNC could be delivered
-// (MV3 service-worker messaging during tab unload is unreliable). Without
-// reclaim, every reload gets blocked with `in_flight` for up to
-// SYNC_ORCHESTRATOR_LOCK_TTL_MS (12 min). Symmetric with the manual path.
-const SYNC_ORCHESTRATOR_AUTO_RECLAIM_MS = 90_000;
 // Window within which a repeat of the same block reason for the same
 // account is considered noise. Multiple open pages + focus/visibility
 // events fan out into redundant REQUEST_SYNC calls; suppressing the log
@@ -264,7 +257,7 @@ export function createSyncHandlers(deps: SyncDeps = {}): HandlerMap {
    *
    * Block reasons and their retry windows:
    *   no_account / not_ready   — no retry (session issue)
-   *   in_flight                — SYNC_ORCHESTRATOR_LOCK_TTL_MS (12 min hard cap)
+   *   in_flight                — SYNC_LOCK_TTL_MS (12 min hard cap)
    *                              reclaimable early at MANUAL_RECLAIM / AUTO_RECLAIM (90s each)
    *                              for orphaned leases from SW-unload races
    *   rate_limited             — exponential (base 60s, cap 15 min) per-account
@@ -302,54 +295,17 @@ export function createSyncHandlers(deps: SyncDeps = {}): HandlerMap {
         (msg.accountId as string) || sessionSnapshot.accountContextId,
       );
 
-      const retryAfterFor = (
-        reason: string,
-        account: SyncAccountState | null,
-      ): number => {
-        if (!account) return 0;
-        if (reason === "cooldown") {
-          return Math.max(0, account.manualCooldownUntil - now);
-        }
-        if (reason === "rate_limited") {
-          return Math.max(0, account.rateLimitBackoffUntil - now);
-        }
-        if (reason === "in_flight" && account.inFlight) {
-          const startedAt = account.inFlight.startedAt;
-          if (!startedAt) return 0;
-          if (trigger === "manual") {
-            return Math.max(
-              0,
-              startedAt + SYNC_ORCHESTRATOR_MANUAL_RECLAIM_MS - now,
-            );
-          }
-          return Math.max(
-            0,
-            startedAt + SYNC_ORCHESTRATOR_LOCK_TTL_MS - now,
-          );
-        }
-        if (reason === "auto_backoff") {
-          // Match whichever backoff window the block used: seed-incomplete
-          // accounts use the short one, post-seed accounts the 5-min one.
-          const window = account.lastFullSyncAt <= 0
-            ? SYNC_ORCHESTRATOR_SEED_BACKOFF_MS
-            : SYNC_ORCHESTRATOR_AUTO_BACKOFF_MS;
-          return Math.max(0, account.lastAttemptAt + window - now);
-        }
-        if (reason === "fresh_cache") {
-          return Math.max(
-            0,
-            account.lastSuccessAt + SYNC_ORCHESTRATOR_AUTO_INTERVAL_MS - now,
-          );
-        }
-        return 0;
-      };
-
       const returnBlocked = async (
         reason: string,
         account?: SyncAccountState | null,
       ) => {
         const safeAccountKey = accountKey || "__none__";
-        const retryAfterMs = retryAfterFor(reason, account ?? null);
+        const retryAfterMs = syncRetryAfterMs({
+          reason,
+          now,
+          trigger,
+          account: account ?? null,
+        });
         // Suppress log spam when multiple pages (or rapid-fire subscribers)
         // all hit the same block decision in quick succession. The previous
         // decision we persisted tells us whether this is a duplicate.
@@ -407,7 +363,7 @@ export function createSyncHandlers(deps: SyncDeps = {}): HandlerMap {
       // Expired lock TTL
       if (
         account.inFlight &&
-        now - account.inFlight.startedAt >= SYNC_ORCHESTRATOR_LOCK_TTL_MS
+        now - account.inFlight.startedAt >= SYNC_LOCK_TTL_MS
       ) {
         account = { ...account, inFlight: null };
       }
@@ -416,10 +372,10 @@ export function createSyncHandlers(deps: SyncDeps = {}): HandlerMap {
         const leaseAge = now - account.inFlight.startedAt;
         const canReclaimManualLock =
           trigger === "manual" &&
-          leaseAge >= SYNC_ORCHESTRATOR_MANUAL_RECLAIM_MS;
+          leaseAge >= SYNC_MANUAL_RECLAIM_MS;
         const canReclaimAutoLock =
           trigger === "auto" &&
-          leaseAge >= SYNC_ORCHESTRATOR_AUTO_RECLAIM_MS;
+          leaseAge >= SYNC_AUTO_RECLAIM_MS;
         if (canReclaimManualLock || canReclaimAutoLock) {
           // [TOTEM-DIAG] Lease reclaim — the previous sync tab died without
           // completing its run. Clearing the orphaned lease so this one can
@@ -466,7 +422,7 @@ export function createSyncHandlers(deps: SyncDeps = {}): HandlerMap {
       } else if (needsFullSync) {
         if (
           account.lastAttemptAt > 0 &&
-          now - account.lastAttemptAt < SYNC_ORCHESTRATOR_SEED_BACKOFF_MS
+          now - account.lastAttemptAt < SYNC_SEED_BACKOFF_MS
         ) {
           return returnBlocked("auto_backoff", account);
         }
@@ -483,13 +439,13 @@ export function createSyncHandlers(deps: SyncDeps = {}): HandlerMap {
         if (
           lastCompletionWasSuccess &&
           account.lastSuccessAt > 0 &&
-          now - account.lastSuccessAt < SYNC_ORCHESTRATOR_AUTO_INTERVAL_MS
+          now - account.lastSuccessAt < SYNC_AUTO_INTERVAL_MS
         ) {
           return returnBlocked("fresh_cache", account);
         }
         if (
           account.lastAttemptAt > 0 &&
-          now - account.lastAttemptAt < SYNC_ORCHESTRATOR_AUTO_BACKOFF_MS
+          now - account.lastAttemptAt < SYNC_AUTO_BACKOFF_MS
         ) {
           return returnBlocked("auto_backoff", account);
         }

--- a/src/stores/runtime-store.ts
+++ b/src/stores/runtime-store.ts
@@ -45,6 +45,7 @@ import {
   SYNC_MAX_BOOKMARKS_PER_JOB,
   SYNC_MAX_PAGES_PER_JOB,
 } from "../lib/constants/sync-policy";
+import { asSyncBlockedReason } from "../lib/sync-block-window";
 import { CS_DB_CLEANUP_AT } from "../lib/storage-keys";
 import type {
   ApiCapability,
@@ -169,14 +170,6 @@ export interface RuntimeState {
   lastSyncAt: number;
   actions: RuntimeActions;
 }
-
-const SYNC_BLOCKED_REASONS = new Set<SyncBlockedReason>([
-  "in_flight",
-  "cooldown",
-  "rate_limited",
-  "no_account",
-  "not_ready",
-]);
 
 const EMPTY_SET = new Set<string>();
 
@@ -798,9 +791,7 @@ export function createRuntimeStore() {
       }
 
       if (!policy.allow || !policy.mode || !policy.leaseId) {
-        const blockedReason = SYNC_BLOCKED_REASONS.has(policy.reason as SyncBlockedReason)
-          ? (policy.reason as SyncBlockedReason)
-          : null;
+        const blockedReason = asSyncBlockedReason(policy.reason);
         if (trigger === "manual") {
           setRuntimeState({
             syncBlockedReason: blockedReason || "not_ready",


### PR DESCRIPTION
## What

Three small, related consolidations around the sync block-decision, none changing behavior:

1. **Single-source the timing constants.** `SYNC_MANUAL_RECLAIM_MS = 90_000` already lived in `sync-policy.ts`, yet `sync.ts` and `sw-pure.ts` each hardcoded their own `90_000`. Those literals are deleted; both files now import the one constant. Two windows that were inlined only in `sync.ts` are hoisted to `sync-policy.ts` as named constants: `SYNC_AUTO_RECLAIM_MS` and `SYNC_SEED_BACKOFF_MS`.
2. **Extract the retry-window arithmetic** into a pure `syncRetryAfterMs(input)` in a new `src/lib/sync-block-window.ts`. It was a closure (`retryAfterFor`) buried inside `handleSyncPolicyReserve`, only reachable by driving the whole reserve state machine through chrome/IDB mocks. It's now a pure function exercised directly.
3. **Consolidate the reason→`SyncBlockedReason` narrowing.** `runtime-store.ts` kept a private `SYNC_BLOCKED_REASONS` set purely to narrow `policy.reason`. That set + the narrowing move into `sync-block-window.ts` as `asSyncBlockedReason`.

## On `SYNC_AUTO_RECLAIM_MS` (deliberately NOT merged)

`sync.ts` has **two** reclaim knobs that happen to share the value `90_000`: `MANUAL_RECLAIM` (manual reserve reclaim eligibility) and `AUTO_RECLAIM` (auto reserve reclaiming an *orphaned* lease after an MV3 unload race). They are documented as intentionally separate-but-symmetric. This PR keeps them as **two distinct named constants** — collapsing them onto one would mean a future tweak to the manual reclaim window silently retimes orphaned-auto-lease recovery, a single-writer/recovery-cadence change. So the dedup is value-faithful, not name-faithful.

## What is NOT coupled (correcting a tempting but false invariant)

It would be neat to claim "the retry window reads the same constant the reclaim check uses, so they can't drift." That holds **only on the manual path**: manual `in_flight` retry window = `MANUAL_RECLAIM` (90s) = the manual reclaim check. On the **auto path** they already diverge in the existing code — the auto `in_flight` retry window is `SYNC_LOCK_TTL_MS` (12min, the hard lease cap), while auto reclaim eligibility is `AUTO_RECLAIM` (90s). `syncRetryAfterMs` preserves exactly this: the auto window is the TTL and is deliberately *not* coupled to the auto reclaim constant. The test pins this truth rather than the false symmetry.

## Behavior

**1:1 preserving.** `syncRetryAfterMs` is the old `retryAfterFor` body verbatim, with `now`/`trigger` lifted from closure capture to explicit input fields, and the manual/auto `in_flight` branches folded into one `window` ternary (same result). The input type's comparison-read fields (`lastFullSyncAt`, etc.) are **required**, so an absent field can't silently flip the seed-vs-poll window selection. The six renamed references in `sync.ts` resolve to canonical constants of identical value — any missed rename is a compile error (deleted local → undefined identifier), so there is no silent-drift path. `asSyncBlockedReason` is the prior `Set.has ? x : null` narrowing exactly.

## Tests

New `src/lib/__tests__/sync-block-window.test.ts` (10 tests): every window branch (cooldown, rate_limited, the trigger-split `in_flight` incl. the auto≠`AUTO_RECLAIM` decoupling, missing-`startedAt`→0, `auto_backoff` seed vs post-seed, `fresh_cache` 4h), the zero-window/null-account/unknown-reason cases (no NaN, no throw), `asSyncBlockedReason` membership, and set-parity (exactly the 5 members).

`pnpm typecheck` clean · full suite green (653 tests, +10). The existing `sync.ts` reserve tests continue to exercise the wired call site end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
