### PR TITLE
restore: bring back premium-monetization and GTM research into plans/research/

### DIFF
--- a/plans/research/premium-monetization/site/02-the-model.html
+++ b/plans/research/premium-monetization/site/02-the-model.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>The Premium Model & Why It Fits · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html" aria-current="page">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">02 · The Model</div><h1 class="page-title">The Premium Model &amp; Why It Fits</h1><p class="lead">Take Totem from free + open-source to a freemium product with a <span class="hl">$19 one-time "Pro" unlock</span> — without breaking the local-first, no-server, open-source ethos that <em>is</em> the brand. Grounded in a 9-agent deep dive of the actual codebase plus the 2026 payments/extension market. Date: 2026-06-19.</p>
+
+<h2 id="the-four-decisions">The four decisions</h2>
+
+<ol>
+<li><strong>Model: Freemium, one build, runtime-gated.</strong> The free tier stays fully functional forever; Pro is a one-time lifetime unlock. This is the only model the pipeline (single artifact, single CWS listing) and the audience (subscription-averse, anti-DRM) actually support.</li>
+<li><strong>The work is packaging, not building.</strong> <strong>5 of the 6</strong> proposed Pro features already exist and ship for free today — export, deleted-tweet preservation (the hydration engine), advanced search filters, annotations, thread-aware capture. Only <strong>bulk ops</strong> is net-new. The real engineering is a <em>single clean entitlement boundary</em>, not new features.</li>
+<li><strong>Payments: a merchant-of-record</strong> (Lemon Squeezy or Polar) for checkout, so global VAT/tax is handled and there's no Totem billing server. Verify with the <strong>provider's license API</strong>: validate the key <strong>online once at activation</strong>, cache the result locally, and read from that cache thereafter — re-checking quietly in the background and <strong>failing open</strong> so a network blip never locks out a paying user. Only the key + email leave the device; bookmark content never does. The provider also counts devices, so multi-browser activation is capped at a generous limit (~5) with self-serve deactivation.</li>
+<li><strong>The #1 risk is the retroactive paywall.</strong> Totem is already free; bolting a paywall onto existing users generates 1-star reviews. <strong>Grandfather every existing install</strong> (full features, free, forever) and only ever gate <em>new</em> installs. This single move neutralizes the biggest execution risk.</li>
+</ol>
+
+<div class="takeaway"><div class="takeaway-label">CORE BET</div> One artifact, gated at runtime; one-time lifetime price; verify online once and cache (fail-open); never claw back from existing users.</div>
+
+<h2 id="the-premium-model-and-why-this-one">The premium model (and why this one)</h2>
+
+<p>The model is not a preference — it's forced by four hard constraints, two from the code and two from the audience. Each one points the same direction.</p>
+
+<table class="compact">
+<thead><tr><th>Constraint</th><th>What it forces</th></tr></thead>
+<tbody>
+<tr><td>Pipeline is single-artifact (one <code>dist/</code>, one zip, one CWS item, version-pinned)</td><td><strong>One build, entitlement-gated at runtime.</strong> Not separate Free/Pro builds.</td></tr>
+<tr><td>Audience = r/nosurf, r/selfhosted, HN, PKM (subscription-fatigued, anti-DRM, pro-ownership)</td><td><strong>One-time "lifetime" unlock</strong>, Obsidian-Catalyst-style "fund the work," not a subscription.</td></tr>
+<tr><td>Local-first, no Totem server, no telemetry is the pitch</td><td>Verification is a <strong>quick online check at activation</strong>, then <strong>cached and read locally</strong> — no per-launch phone-home; fail-open on outages; bookmarks never leave the device.</td></tr>
+<tr><td>Open-source (code is public on GitHub)</td><td>The check is <strong>patchable by design</strong> — accept it, out-serve the cracker, don't build DRM.</td></tr>
+</tbody>
+</table>
+
+<h3>The 2026 market evidence (first-party)</h3>
+
+<p>The one-time model isn't just on-brand — it converts better for this product category. The first-party signals from 2026:</p>
+
+<ul>
+<li>PaletteGrab got a <strong>60% conversion lift</strong> switching from monthly to one-time.</li>
+<li>MiroMiro got <strong>"5 paying customers in a row"</strong> after adding a lifetime option.</li>
+<li>The consensus from extension builders: <em>"Chrome extensions aren't SaaS apps. They're tools. People prefer to buy tools once."</em></li>
+</ul>
+
+<div class="callout">Subscriptions still win <strong>high-revenue, server-cost</strong> categories — SEO, dev-tools, AI at $5k–200k/mo. But Totem is squarely a low-marginal-cost client utility, the bucket where one-time wins.</div>
+
+<p>Realistic conversion to model against: <span class="hl">1–3% of <em>active</em> users</span> (not installs), at roughly 60–70% checkout completion.</p>
+
+<h3>Pricing</h3>
+
+<ul>
+<li><strong>$19 one-time lifetime</strong> — the GTM-validated number: above the $4.99 utility floor, below the $29 "enterprise-parity" expectation.</li>
+<li><strong>$14 founders price for the first 60 days</strong>, framed honestly ("$14 founders price, rising to $19") — no fake countdowns.</li>
+<li><strong>Never</strong> "2 years of updates." Use "lifetime," no expiry qualifier — the local-first architecture means it genuinely works forever.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">PRICE</div> $19 lifetime, $14 founders for 60 days. Honest framing, no countdown theater, no expiry on "lifetime."</div>
+<nav class="pager"><a class="pager-link prev" href="index.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Making Totem Premium</span></a><a class="pager-link next" href="03-features.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Free vs Pro — Features &amp; Limits</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/03-features.html
+++ b/plans/research/premium-monetization/site/03-features.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Free vs Pro — Features & Limits · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html" aria-current="page">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">03 · Features</div><h1 class="page-title">Free vs Pro — Features &amp; Limits</h1><p class="lead">The split is dictated by one hard rule from the research: <strong>feature-gate genuinely-new value; never claw back a feature existing users already have free.</strong> Because export, search, and annotations <em>already ship free</em>, the plan combines three levers: <span class="hl">grandfathering</span> (existing users keep everything), a free allowance (new users try Pro on their own data), and clean feature gates for genuinely new value.</p>
+
+<h2 id="the-matrix">The matrix</h2>
+
+<table class="compact">
+<thead>
+<tr>
+<th>Capability</th>
+<th>Free tier</th>
+<th>Pro ($19)</th>
+<th>Already built?</th>
+<th>Gate location</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>New-tab reading queue / Today's Read</td>
+<td>full</td>
+<td>yes</td>
+<td>yes</td>
+<td>— (never gate)</td>
+</tr>
+<tr>
+<td>Sync (GraphQL interception → IndexedDB)</td>
+<td>full, no count cap</td>
+<td>yes</td>
+<td>yes</td>
+<td>—</td>
+</tr>
+<tr>
+<td>Reader (threads/articles)</td>
+<td>full</td>
+<td>yes</td>
+<td>yes</td>
+<td>—</td>
+</tr>
+<tr>
+<td>Basic full-text search</td>
+<td>full</td>
+<td>yes</td>
+<td>yes</td>
+<td>—</td>
+</tr>
+<tr>
+<td>Import (re-import a Totem ZIP)</td>
+<td>full</td>
+<td>yes</td>
+<td>yes</td>
+<td>— (keep free: data-portability = trust)</td>
+</tr>
+<tr>
+<td><strong>Library export</strong> (CSV/MD/JSONL ZIP)</td>
+<td>first ~25 items (try-before-buy)</td>
+<td>unlimited, all formats</td>
+<td>yes (<code>quick-export.ts</code>)</td>
+<td><code>ExportModal.handleQuickExport</code></td>
+</tr>
+<tr>
+<td><strong>Per-article export</strong> (Download MD / Print PDF)</td>
+<td>Copy-to-clipboard free (teaser)</td>
+<td>Download MD / PDF</td>
+<td>yes (<code>article-download.ts</code>)</td>
+<td><code>ArticleExportMenu</code> handlers</td>
+</tr>
+<tr>
+<td><strong>Deleted-tweet preservation</strong></td>
+<td>preserves what you've already opened</td>
+<td>auto-preserves your whole library + "kept your copy" badge</td>
+<td>yes (<code>hydration-store.ts</code>)</td>
+<td><code>handleStartFullExport</code> / hydration <code>start()</code></td>
+</tr>
+<tr>
+<td><strong>Advanced search filters</strong> (<code>from: site: min_faves: has: is:</code> …)</td>
+<td>plain text only</td>
+<td>operators</td>
+<td>yes (<code>lib/search/parser.ts</code>)</td>
+<td><code>useBookmarkSearch</code> (gate parsed AST nodes)</td>
+</tr>
+<tr>
+<td><strong>Annotations</strong> (highlights + notes)</td>
+<td>create basic highlights</td>
+<td>notes + annotation <strong>export</strong></td>
+<td>yes (<code>SelectionToolbar</code>, <code>highlights</code> store)</td>
+<td><code>onHighlight</code>/<code>onAddNote</code></td>
+</tr>
+<tr>
+<td><strong>Bulk operations</strong> (multi-select tag/delete/export)</td>
+<td>—</td>
+<td>yes</td>
+<td><span class="tag">NET-NEW</span></td>
+<td>new selection UI + dispatcher</td>
+</tr>
+<tr>
+<td>Future: MCP endpoint, semantic search</td>
+<td>—</td>
+<td>yes</td>
+<td>net-new (roadmap)</td>
+<td>future modules</td>
+</tr>
+</tbody>
+</table>
+
+<h2 id="the-grandfather-rule-non-negotiable-ship-in-the-same-release">The grandfather rule (non-negotiable, ship in the same release)</h2>
+
+<p>On the release that introduces Pro:</p>
+
+<ul>
+<li><code>chrome.runtime.onInstalled</code> with <code>reason === "update"</code> (i.e., the user already had Totem) → stamp a <strong><code>grandfatheredAt</code></strong> entitlement: <strong>full Pro features, free, forever.</strong></li>
+<li><code>reason === "install"</code> (fresh) → free tier with the allowance/gates above.</li>
+</ul>
+
+<div class="callout"><strong><code>onInstalled.reason</code> alone is not enough (adversarial-review correction).</strong> It misfires for exactly the cohort grandfathering protects: a user who uninstalls→reinstalls, or moves to a new machine, fires <code>reason === "install"</code> and would lose grandfathered status.</div>
+
+<p>Add a <strong>secondary "existing user" heuristic</strong> that also runs on <code>install</code>: if the bookmarks IndexedDB store is non-empty (or a pre-Pro settings/growth-state key already exists locally), treat them as grandfathered. The <span class="hl">local-data check is the dependable signal</span>; don't <em>rely</em> on the <code>chrome.storage.sync</code> mirror having landed before the first gate evaluation. Net effect: the change is <em>additive</em> for everyone who already uses Totem (the people who evangelize it), and monetization is limited to genuinely new users — the low-backlash path the research demands.</p>
+
+<div class="takeaway"><div class="takeaway-label">RULE</div> The local IndexedDB bookmarks check — not <code>onInstalled.reason</code>, not the sync mirror — is the dependable "existing user" signal.</div>
+
+<h2 id="why-these-specific-gates">Why these specific gates</h2>
+
+<p><strong>Export</strong> is the <em>primary</em> gate but <span class="hl">not a single call site</span> (adversarial-review correction). The bulk-ZIP path concentrates at one place (<code>ExportModal.tsx:64</code> → <code>runQuickExport(account)</code>), but there are <strong>independent per-article egress paths</strong> in <code>src/components/BookmarkReader.tsx:313-352</code> (copy-Markdown, copy-for-agent, download <code>.md</code>, print/Save-PDF) that bypass <code>ExportModal</code> entirely. <strong>All of them must be gated</strong>, or a free user has a full-library exfiltration path one article at a time. Decide deliberately whether <em>copy-to-clipboard</em> stays free as a teaser — it is a slow leak (copy each article manually); acceptable as a teaser, but call it knowingly. The PKM/Obsidian persona is the willing-to-pay cohort and export is their #1 need.</p>
+
+<p><strong>Deleted-tweet preservation</strong> is the <em>emotional</em> gate (loss aversion): "This tweet was deleted on X. Totem kept your copy." It's already implemented as the hydration engine — it just isn't <em>sold</em> as a feature yet.</p>
+
+<p><strong>Bulk ops</strong> is the only net-new build; it doubles as a fresh, obviously-new capability that nobody can claim was "taken away."</p>
+<nav class="pager"><a class="pager-link prev" href="02-the-model.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">The Premium Model &amp; Why It Fits</span></a><a class="pager-link next" href="04-tech-stack.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Tech Stack — What Is New</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#the-matrix">The matrix</a>
+<a href="#the-grandfather-rule-non-negotiable-ship-in-the-same-release">The grandfather rule (non-negotiable, ship in the same release)</a>
+<a href="#why-these-specific-gates">Why these specific gates</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/04-tech-stack.html
+++ b/plans/research/premium-monetization/site/04-tech-stack.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Tech Stack — What Is New · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html" aria-current="page">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">04 · Stack</div><h1 class="page-title">Tech Stack — What Is New</h1><p class="lead">Totem stays exactly as it is — MV3, React 19, Zustand, IndexedDB/<code>idb</code>, Vite, Astro site. The premium layer adds a <span class="hl">small, deliberately boring</span> surface on top.</p>
+
+<h2 id="the-added-surface">The added surface</h2>
+
+<p>Nothing here replaces the existing stack; each row is a narrow, self-contained addition chosen to preserve the local-first, no-server ethos.</p>
+
+<table>
+<thead>
+<tr><th>Concern</th><th>Choice</th><th>Why</th></tr>
+</thead>
+<tbody>
+<tr>
+<td>Checkout + tax</td>
+<td><strong>Merchant-of-record: Lemon Squeezy</strong> (primary) or <strong>Polar</strong> (cost-optimized)</td>
+<td>MoR remits global VAT/GST, so the solo dev never registers for tax anywhere. No Totem billing server.</td>
+</tr>
+<tr>
+<td>License keys</td>
+<td><strong>Provider-issued license keys</strong> (Lemon Squeezy / Polar)</td>
+<td>The MoR mints and emails the key on a paid order — <strong>no separate signer, no key-management vendor, no private signing key to host.</strong></td>
+</tr>
+<tr>
+<td>License verification</td>
+<td><strong>Online validate</strong> via the provider's license API — once at activation + a quiet periodic background re-check</td>
+<td>Validating <em>data</em> (JSON) is MV3-legal. Result is <strong>cached in <code>CS_ENTITLEMENT</code></strong> and read locally thereafter; <strong>fail-open</strong> on network errors. Only key + email leave the device.</td>
+</tr>
+<tr>
+<td>Device management</td>
+<td>Provider <strong>activation limit (~5)</strong> + self-serve <strong>deactivate</strong> page (its customer portal)</td>
+<td>Resolves multi-browser activation: a real person's few devices are fine; mass key-sharing is capped. Counting requires the online check.</td>
+</tr>
+<tr>
+<td>Entitlement storage</td>
+<td>New SW-owned <code>chrome.storage.local</code> key <code>CS_ENTITLEMENT</code></td>
+<td>Single-writer, reset-surviving, rides the existing reactive snapshot channel. Holds the cached validate result.</td>
+</tr>
+<tr>
+<td>Pricing/license pages</td>
+<td>New static Astro pages on <code>usetotem.xyz</code></td>
+<td>Site is 100% static; pages are static + client <code>&lt;script&gt;</code>, no backend.</td>
+</tr>
+</tbody>
+</table>
+
+<h2 id="no-totem-server">No Totem server</h2>
+
+<p>Checkout, tax, key issuance, and device counting all live with the merchant-of-record. The extension talks to the <strong>provider's</strong> API (one host permission), never to a Totem-run backend. The MoR's <em>secret</em> API key stays server-side and never enters <code>dist/</code> — the validate call a public client makes needs no secret.</p>
+
+<div class="takeaway">
+<div class="takeaway-label">NET EFFECT</div>
+The only network the extension does for licensing is a small <strong>validate</strong> call at activation and an occasional background re-check — never a per-launch phone-home, and never anything touching bookmark data. Verify online, but read from cache and fail open, so an outage can't lock out a buyer.
+</div>
+<nav class="pager"><a class="pager-link prev" href="03-features.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Free vs Pro — Features &amp; Limits</span></a><a class="pager-link next" href="05-payments.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Payment Gateway — The Decision</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/05-payments.html
+++ b/plans/research/premium-monetization/site/05-payments.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Payment Gateway — The Decision · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html" aria-current="page">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">05 · Payments</div><h1 class="page-title">Payment Gateway — The Decision</h1><p class="lead">Native Chrome Web Store payments died <strong>Feb 1, 2021</strong>, so an external processor is mandatory. The choice is not just "who takes the smallest cut" — it is which option keeps Totem <span class="hl">server-free, privacy-safe, and resilient to provider outages</span>.</p>
+
+<h2 id="the-contenders-2026-facts">The contenders (2026 facts)</h2>
+
+<table class="striped">
+<thead>
+<tr><th>Option</th><th>Fee on a $19 sale</th><th>Merchant of Record? (tax handled)</th><th>License API</th><th>Fits local-first + OSS?</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Lemon Squeezy</strong></td><td>5% + 50&cent; (~$1.45)</td><td>yes</td><td>most mature (validate/activate/deactivate, key-only, cacheable)</td><td>yes (Stripe-acquisition transition is the one watch-item)</td></tr>
+<tr><td><strong>Polar</strong></td><td>5%+50&cent; free / 3.8%+40&cent; on Pro plan</td><td>yes</td><td>public validate endpoint, <strong>safe for public clients</strong></td><td>yes; cheapest, OSS-positioned; younger; online-only validate</td></tr>
+<tr><td><strong>ExtensionPay</strong></td><td>5% + Stripe 2.9%+30&cent; (~8% all-in)</td><td><strong>no</strong> (you owe tax)</td><td>email magic-link, <strong>no key</strong>; <code>getUser()</code> phones home every check</td><td>no &mdash; not MoR, hard runtime dependency on extensionpay.com</td></tr>
+<tr><td>Raw Stripe</td><td>2.9%+30&cent;</td><td>no</td><td>build it yourself + server</td><td>no &mdash; defeats "minimal server / tax handled"</td></tr>
+<tr><td>Gumroad</td><td>10%+50&cent; (~$2.40)</td><td>yes</td><td>verify API</td><td>highest fee, "creator marketplace" feel</td></tr>
+</tbody>
+</table>
+
+<h2 id="recommendation">Recommendation</h2>
+
+<div class="callout"><strong>Lemon Squeezy as merchant-of-record (primary), Polar as the cost-optimized alternative</strong> &mdash; and use the provider's license-key API for verification: validate the key online once at activation, cache the result locally, fail open, with a generous device limit.</div>
+
+<h3>Why MoR, not ExtPay</h3>
+
+<p>ExtPay is the <em>fastest</em> to wire and the most extension-native, but it (a) is <strong>not</strong> a merchant of record, so you still owe VAT in every country, and (b) makes <strong>every</strong> paid check a live <code>getUser()</code> call to <code>extensionpay.com</code> with <strong>no documented offline cache</strong> &mdash; so a network failure can throw on a routine launch. The MoR's license API is better on both axes: it removes the tax burden, and you call <strong>validate</strong> <em>once at activation</em>, then run from a local cache and only re-check occasionally in the background. <span class="hl">You verify online, but you don't depend on the network being up on every launch.</span></p>
+
+<h3>Why online validate (not a fully-offline signed key)</h3>
+
+<p>We deliberately accept one online check. It is the simplest path, it is what makes <strong>device management</strong> possible (something has to count activations), and it lets the provider revoke a refunded or charged-back key. MV3 allows it cleanly: validating a key returns <strong>JSON data</strong>, not remote code. The cost &mdash; a host permission and a reworded store description &mdash; is small. We do <strong>not</strong> ship an on-device signature verifier, a license-signing vendor, or a private signing key; the provider issues and validates the key.</p>
+
+<h3>The rule that keeps it resilient &mdash; cache + fail-open</h3>
+
+<p>Validate online at activation &rarr; write <code>isPro</code> to <code>CS_ENTITLEMENT</code> &rarr; read from that cache on every launch. Re-validate quietly in the background (e.g. weekly) to catch refunds. If a re-check can't reach the network, <strong>keep Pro on</strong> (fail-open, with a grace window) &mdash; never revoke a paying user because their Wi-Fi blipped or the provider had a hiccup. "Online verification" means <em>check when we can, trust the saved answer otherwise</em> &mdash; not <em>gate every launch on a live call</em>.</p>
+
+<h3>Multi-device activation</h3>
+
+<p>A purely offline key can't be counted (nothing knows how many browsers hold it). Because verification is <strong>online</strong>, the provider <em>is</em> that shared counter: set a generous <strong>activation limit (~5)</strong>, expose <strong>activate / deactivate</strong> so a user can free a slot from the customer portal (the fix for the reinstall-burns-a-slot complaint), and send a device id on activate. An <strong>unlimited</strong> limit ("use on all your browsers") is a defensible zero-friction alternative for a $19 honest-audience tool &mdash; you just accept that a key <em>could</em> be shared, the same way the open-source build can already be patched.</p>
+
+<div class="takeaway"><div class="takeaway-label">BRAND PROMISE, PRECISELY</div> Not "works offline, nothing can shut down," but the truthful version: <span class="hl">no Totem server to run &mdash; the provider handles checkout, tax, and licensing; your bookmarks never leave your device; Pro is verified by a quick online check, then cached and read locally.</span> Cached entitlements ride out a short provider outage &mdash; relevant given the Lemon-Squeezy&rarr;Stripe transition watch-item.</div>
+
+<h2 id="the-honest-stance-publish-it-it-converts-for-this-audience">The honest stance (publish it &mdash; it converts for this audience)</h2>
+
+<p>Open-source + client-side means a determined user can patch out the check. <strong>Don't fight it.</strong> Ship this copy in the README and the upgrade screen:</p>
+
+<blockquote>Totem is open source. You <em>could</em> patch out the Pro check &mdash; the code is right there. We're not going to fight you with DRM that makes the app worse for everyone. Pro is $19 once; it funds the export, search, and deleted-tweet preservation work. If it's useful, buy it. If you genuinely can't, the free tier is fully functional forever.<span class="cite"> - Totem upgrade screen / README</span></blockquote>
+
+<p>For a $19 lifetime tool, the cracker's "service" (untrusted patched build, re-patch every update, no support) is worse than paying. For the privacy/HN/self-hosted audience, the <em>absence</em> of DRM is a trust signal, not a weakness. (Gabe Newell's "piracy is a service problem" &mdash; sourced in <code>rs-license-arch.md</code>.)</p>
+<nav class="pager"><a class="pager-link prev" href="04-tech-stack.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Tech Stack — What Is New</span></a><a class="pager-link next" href="06-license.html"><span class="pager-eyebrow">Next</span><span class="pager-title">License &amp; Entitlement Architecture</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#the-contenders-2026-facts">The contenders (2026 facts)</a>
+<a href="#recommendation">Recommendation</a>
+<a href="#the-honest-stance-publish-it-it-converts-for-this-audience">The honest stance (publish it — it converts for this audience)</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/06-license.html
+++ b/plans/research/premium-monetization/site/06-license.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>License & Entitlement Architecture · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html" aria-current="page">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">06 · License</div><h1 class="page-title">License &amp; Entitlement Architecture</h1><p class="lead">A paid unlock has to survive resets, account switches, and offline launches while never violating the MV3 ban on remote code. The architecture leans on seams that already exist: a service-worker trust boundary, a reactive snapshot channel, and a cached online-validate result.</p>
+
+<h2 id="5-1-end-to-end-flow">5.1 End-to-end flow</h2>
+
+<p>From the buyer's click to the gated feature flipping on, seven stages carry the license key through purchase, validation, caching, and propagation.</p>
+
+<pre><code>1. PURCHASE   Buyer clicks "Upgrade — $19 lifetime" in the extension
+              → opens usetotem.xyz/pricing → MoR hosted checkout
+              (Lemon Squeezy / Polar = merchant of record; card + VAT handled)
+                    │
+2. ISSUE      On paid order, the MoR mints a license key and emails it
+              to the buyer + shows it on usetotem.xyz/upgrade/success.
+              (No separate signer; the provider owns issuance.)
+                    │
+3. ACTIVATE   Buyer returns to extension. Three layered paths:
+              (a) one-click: success page → externally_connectable → onMessageExternal
+              (b) deep link: chrome-extension://&lt;id&gt;/newtab.html?license=&lt;key&gt;
+              (c) paste-a-key fallback in Settings (always shipped)
+                    │
+4. VALIDATE   Service worker calls the provider's validate/activate endpoint
+              ONCE with { key, instanceId }. Receives JSON { valid, plan, ... }.
+              Counts toward the device limit. MV3-safe (remote DATA, not code).
+                    │
+5. PERSIST    SW writes CS_ENTITLEMENT to chrome.storage.local
+              { isPro, plan, email, order, instanceId, validatedAt } + raw key.
+              Stamped into RuntimeSnapshot.
+                    │
+6. PROPAGATE  CS_RUNTIME_STATE_V2 change → chrome.storage.onChanged →
+              applyRuntimeSnapshot → Zustand → useIsPro() → every open
+              tab/reader flips to Pro on the same event-loop tick.
+                    │
+7. GATES      Export / preservation / bulk / filters / annotations read isPro
+              FROM THE CACHE on each launch (no network). A quiet background
+              re-validate (~weekly) catches refunds; it FAILS OPEN — a failed
+              re-check never revokes Pro, so an outage can't lock out a buyer.</code></pre>
+
+<h2 id="5-2-where-the-entitlement-lives-resolving-the-storage-tension">5.2 Where the entitlement lives — resolving the storage tension</h2>
+
+<p>The research surfaced two candidate patterns. <strong>Use the SW-owned one as authoritative</strong>; it's what makes payment "work flawlessly" across reset and account-switch and is reactive everywhere.</p>
+
+<h3>Authoritative — SW-owned write</h3>
+
+<p>The SW writes <span class="hl"><code>CS_ENTITLEMENT</code></span> (<code>"totem_entitlement"</code>) to <code>chrome.storage.local</code>, declared in <code>src/service-worker/storage-keys-sw.ts</code> → the existing <code>storage-invariants.test.ts</code> makes the SW the <em>only</em> writer for free. The SW is the right owner because it's the trust boundary and the thing that runs the validate call and caches its result.</p>
+
+<h3>Reset-surviving</h3>
+
+<p>Keep <code>CS_ENTITLEMENT</code> <strong>out of both reset lists</strong> in <code>src/lib/reset.ts</code> (mirror how auth headers are deliberately preserved). "Reset app" and account-switching must never revoke a paid unlock — it's a <strong>device-global, account-independent</strong> fact, not a per-account one. <strong>Never</strong> store it in IndexedDB (account-scoped and wiped) or the per-account sync orchestrator map.</p>
+
+<h3>Reactive — the ~6 wiring points</h3>
+
+<p>The <code>CS_RUNTIME_STATE_V2 → onChanged → applyRuntimeSnapshot</code> channel already exists and the propagation is <strong>automatic</strong>, but the snapshot is deserialized <strong>field-by-field</strong> (not spread), so <code>isPro</code> needs <strong>~6 explicit wiring points</strong> — minimal, but not "free":</p>
+
+<ol>
+<li>Add the field to <code>RuntimeSnapshotData</code> (<code>src/types/messages.ts</code>).</li>
+<li>Populate it in <code>buildRuntimeSnapshot</code> (<code>src/service-worker/auth.ts</code>).</li>
+<li>Read it in <code>normalizeAuthPayloadFromSnapshot</code>.</li>
+<li>Add it to the <code>AuthPayload</code> interface.</li>
+<li>Set it in <code>applyAuthPayload</code>.</li>
+<li>Expose <code>useIsPro()</code> in <code>src/stores/selectors.ts</code>.</li>
+</ol>
+
+<div class="callout">Keep <code>applyRuntimeSnapshot</code>'s <code>allowHydration:false</code> guard. An <code>isPro</code> flip must never trigger a sync or re-hydration.</div>
+
+<h3>Optional cross-device follow</h3>
+
+<p>Additionally mirror to a new <code>chrome.storage.sync</code> key (also SW-written, also off the reset list) so the unlock follows the user to a new machine without re-pasting. The local key stays authoritative.</p>
+
+<blockquote>The simpler "clone <code>useTheme.ts</code> into <code>usePro.ts</code> over <code>chrome.storage.sync</code>" pattern (from the UI report) is a fine MVP shortcut for the UI read, but the <em>writer</em> must be the SW after verification — a bare synced boolean is trivially forgeable and is wiped on reset. Use the snapshot/<code>useIsPro()</code> read path, SW-owned write.<span class="cite"> - UI report</span></blockquote>
+
+<h2 id="5-3-mv3-compliance-the-load-bearing-constraint">5.3 MV3 compliance — the load-bearing constraint</h2>
+
+<p>MV3 bans <strong>remotely-hosted code</strong>, not remote <strong>data</strong> — and license validation is squarely the allowed kind.</p>
+
+<ul>
+<li><span class="tag">VERIFIED</span> <strong>Data fetch</strong> (call the provider's validate endpoint → receive JSON <code>{ valid, plan, ... }</code>) → fetching <em>data</em>, explicitly allowed. This is the path we ship.</li>
+<li><span class="tag">VERIFIED</span> The validate result only <strong>toggles a local flag</strong>; it never returns code to run.</li>
+</ul>
+
+<p>What you must <strong>never</strong> do: fetch a JS "validator" or a script that <em>implements</em> a Pro feature and <code>eval</code>/import it. All Pro feature logic ships in the package and is merely <em>toggled</em> by <code>isPro</code>.</p>
+
+<div class="takeaway"><div class="takeaway-label">WHY ONE BUILD</div> This is why "one build, runtime-gated" is also the compliant design — every feature is in the bundle, and only the <code>isPro</code> flag decides whether it runs.</div>
+<nav class="pager"><a class="pager-link prev" href="05-payments.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Payment Gateway — The Decision</span></a><a class="pager-link next" href="07-system-changes.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Internal System Changes — File by File</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#5-1-end-to-end-flow">5.1 End-to-end flow</a>
+<a href="#5-2-where-the-entitlement-lives-resolving-the-storage-tension">5.2 Where the entitlement lives — resolving the storage tension</a>
+<a href="#5-3-mv3-compliance-the-load-bearing-constraint">5.3 MV3 compliance — the load-bearing constraint</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/07-system-changes.html
+++ b/plans/research/premium-monetization/site/07-system-changes.html
@@ -1,0 +1,253 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Internal System Changes — File by File · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html" aria-current="page">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">07 · System</div><h1 class="page-title">Internal System Changes — File by File</h1><p class="lead">This is the heart of "how the whole system changes." Nothing here is large; the architecture already has the seams.</p>
+
+<h2 id="new-files">New files</h2>
+
+<p>Six net-new modules. Most clone an existing sibling so they inherit the project's handler-map and component conventions rather than inventing new ones.</p>
+
+<table class="striped">
+<thead>
+<tr><th>File</th><th>Purpose</th><th>Clone from</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><code>src/service-worker/entitlement.ts</code></td>
+<td>SW handlers: <code>ACTIVATE_LICENSE</code>, <code>VALIDATE_LICENSE</code>, <code>GET_ENTITLEMENT</code>. Calls the provider validate/activate API, caches the result to <code>CS_ENTITLEMENT</code>, re-persists snapshot; runs the background re-check with fail-open.</td>
+<td>sibling of <code>auth.ts</code>/<code>sync.ts</code> handler maps</td>
+</tr>
+<tr>
+<td><code>src/lib/license/validate.ts</code></td>
+<td>Thin <code>validateLicense(key, instanceId)</code> &rarr; entitlement | null by <code>fetch</code>-ing the provider's validate/activate endpoint and normalizing the JSON. Pure data, no embedded secret. Unit-testable (mock fetch).</td>
+<td>&mdash;</td>
+</tr>
+<tr>
+<td><code>src/hooks/usePro.ts</code> (or <code>useEntitlement.ts</code>)</td>
+<td>UI read of <code>isPro</code> (prefer reading the <code>useIsPro()</code> selector; <code>useTheme.ts</code> shape if you keep a direct storage read).</td>
+<td><code>src/hooks/useTheme.ts</code></td>
+</tr>
+<tr>
+<td><code>src/components/ProGate.tsx</code></td>
+<td><code>&lt;ProGate isPro onUpgrade&gt;</code> + <code>requirePro(isPro, action, onUpsell)</code>. Renders children when Pro; lock-badge + intercept when free.</td>
+<td>&mdash;</td>
+</tr>
+<tr>
+<td><code>src/components/UpgradeModal.tsx</code></td>
+<td>The single upsell surface (benefits list + <code>&lt;Button href={CHECKOUT_URL}&gt;</code> + paste-a-key field).</td>
+<td><code>src/components/OnboardingModal.tsx</code></td>
+</tr>
+<tr>
+<td><code>src/components/ProNudge.tsx</code></td>
+<td>One-time, dismissible, post-activation bottom banner. Suppressed when <code>isPro</code>.</td>
+<td><code>src/components/ReviewPrompt.tsx</code></td>
+</tr>
+</tbody>
+</table>
+
+<h2 id="edited-files-extension">Edited files (extension)</h2>
+
+<p>The seams already exist; each edit is small. Two carry traps worth flagging up front: the storage-key invariant test must be edited by hand, and the per-article egress handlers live in <code>BookmarkReader.tsx</code>, not where you'd expect.</p>
+
+<table class="striped">
+<thead>
+<tr><th>File</th><th>Change</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><code>src/service-worker/storage-keys-sw.ts</code></td>
+<td>Add <code>CS_ENTITLEMENT = "totem_entitlement"</code>. <strong>Also</strong> add the constant + its string to the hardcoded <code>SW_OWNED_KEY_NAMES</code>/<code>SW_OWNED_KEY_STRINGS</code> arrays in <code>src/lib/__tests__/storage-invariants.test.ts:71-87</code> &mdash; declaring the key does <strong>not</strong> auto-enroll it in the single-writer enforcement.</td>
+</tr>
+<tr>
+<td><code>src/types/messages.ts</code></td>
+<td>Add <code>isPro</code>/<code>entitlement</code> to <code>RuntimeSnapshotData</code>; add <code>ACTIVATE_LICENSE</code>/<code>VALIDATE_LICENSE</code>/<code>GET_ENTITLEMENT</code> to the <code>MessageRequest</code> union.</td>
+</tr>
+<tr>
+<td><code>src/service-worker/auth.ts</code></td>
+<td><code>buildRuntimeSnapshot</code> reads <code>CS_ENTITLEMENT</code> &rarr; snapshot; <code>persistRuntimeStateV2</code> includes it with safe defaults.</td>
+</tr>
+<tr>
+<td><code>src/service-worker/index.ts</code></td>
+<td>Merge <code>entitlementHandlers</code>; add <code>onInstalled</code> grandfather stamp (<code>reason==="update"</code> &rarr; grandfathered Pro); optional <code>onMessageExternal</code> for site&rarr;extension one-click.</td>
+</tr>
+<tr>
+<td><code>src/stores/runtime-store.ts</code></td>
+<td>Add <code>isPro</code> to <code>RuntimeState</code> + <code>createInitialState</code>; set it in <code>applyAuthPayload</code>; read in <code>normalizeAuthPayloadFromSnapshot</code>.</td>
+</tr>
+<tr>
+<td><code>src/stores/selectors.ts</code></td>
+<td>Add <code>useIsPro()</code>.</td>
+</tr>
+<tr>
+<td><code>src/lib/storage-keys.ts</code></td>
+<td>(If using a sync mirror) add <code>SYNC_PRO</code> to <code>CHROME_SYNC_KEYS</code>.</td>
+</tr>
+<tr>
+<td><code>src/lib/reset.ts</code></td>
+<td>Keep <code>CS_ENTITLEMENT</code> (and <code>SYNC_PRO</code>) <strong>out</strong> of the reset key lists; add a comment next to the auth-preservation note.</td>
+</tr>
+<tr>
+<td><code>src/lib/growth-state.ts</code></td>
+<td>Add a <code>pro</code> namespace (<code>nudgePromptedAt</code>/<code>nudgeDismissedAt</code>) + <code>shouldShowProNudge()</code> predicate (set-once idiom).</td>
+</tr>
+<tr>
+<td><code>src/components/ExportModal.tsx</code></td>
+<td>Wrap <code>handleQuickExport</code> (<code>:60</code>) + <code>handleStartFullExport</code> (<code>:78</code>) in <code>requirePro</code>; pass <code>isPro</code> into <code>IdleView</code> for the free-allowance cap + lock styling.</td>
+</tr>
+<tr>
+<td><code>src/components/BookmarkReader.tsx:313-352</code> (handlers live here, <strong>not</strong> in <code>TweetContent.tsx</code>)</td>
+<td>Gate the <strong>four</strong> per-article egress handlers &mdash; copy-MD (<code>:313</code>), copy-for-agent (<code>:327</code>), download-MD (<code>:338</code>), print/PDF (<code>:352</code>) &mdash; all call <code>src/lib/export/article-download.ts</code> directly. Keeping the two clipboard copies free is a <em>teaser</em> but also a slow full-library leak; gate download+print at minimum.</td>
+</tr>
+<tr>
+<td><code>src/hooks/useBookmarkSearch.ts</code></td>
+<td>When the parsed AST contains operator nodes and <code>!isPro</code> &rarr; route to upsell (keep plain text free).</td>
+</tr>
+<tr>
+<td><code>src/components/reader/SelectionToolbar.tsx</code></td>
+<td>Gate <code>onAddNote</code> (and/or advanced highlight) for free users.</td>
+</tr>
+<tr>
+<td><code>src/components/SettingsModal.tsx</code></td>
+<td>New "Totem Pro" section above Storage/Export (<code>:374</code>): free &rarr; "Upgrade" (<code>accent-soft</code> Button); Pro &rarr; <code>Badge variant="accent"&gt;PRO&lt;/Badge&gt;</code> + "Manage license" + paste-key field.</td>
+</tr>
+<tr>
+<td><code>src/components/NewTabHome.tsx</code></td>
+<td>(Optional) small always-visible "Upgrade" entry beside the gear (<code>:1086</code>).</td>
+</tr>
+<tr>
+<td><code>src/App.tsx</code></td>
+<td>Call <code>usePro()</code> at <code>:410-411</code> (both route apps); add <code>upgradeOpen</code> to <code>NewTabRouteState</code>; render <code>&lt;UpgradeModal&gt;</code>/<code>&lt;ProNudge&gt;</code> beside <code>ExportModal</code>/<code>ImportModal</code> (<code>:708-732</code>); thread <code>isPro</code> down as a prop.</td>
+</tr>
+<tr>
+<td><code>src/lib/constants/growth.ts</code></td>
+<td>Add <code>PRICING_URL = https://usetotem.xyz/pricing?utm_source=extension&amp;utm_medium=upgrade&amp;utm_campaign=pro</code>.</td>
+</tr>
+</tbody>
+</table>
+
+<div class="takeaway"><div class="takeaway-label">EGRESS CORRECTION</div> The per-article export handlers are in <code>BookmarkReader.tsx:313-352</code>, not <code>TweetContent.tsx</code>. All four call <code>src/lib/export/article-download.ts</code> directly &mdash; gate download + print at minimum.</div>
+
+<h2 id="deleted-tweet-preservation-the-one-data-layer-tweak">Deleted-tweet preservation &mdash; the one data-layer tweak</h2>
+
+<p>The hydration engine already classifies and caches deleted/protected tweets (<code>hydration-store.ts</code>, <code>detailsStatus:"unavailable"</code>, <code>unavailableReason:"deleted"</code>). To turn it into a <em>sellable preservation</em> feature, two small policy changes in <code>src/db/</code> + <code>src/api/parsers.ts</code>:</p>
+
+<ol>
+<li><strong>Preserve-on-tombstone:</strong> today the error path <em>throws before caching</em>, so the fix is an <strong>added</strong> cache-write on the unavailable branch (not merely a no-clobber guard): when a later <code>FETCH_TWEET_DETAIL</code> returns a tombstone, keep the previously-cached <code>focalTweet</code>/thread and stamp <code>detailsStatus:"unavailable"</code> rather than dropping the row or overwriting with null.</li>
+<li><strong>Exempt preserved rows</strong> from the <code>cleanupOldTweetDetails</code> retention sweep (which currently deletes by <code>fetchedAt</code> regardless of status) for Pro users.</li>
+</ol>
+
+<p>(Media is hot-linked from <code>*.twimg.com</code>, not blobbed &mdash; text/thread/metadata preservation needs <strong>no new fetch</strong>; true media-byte preservation would be a later, separate feature.)</p>
+
+<h2 id="manifest-build-changes">Manifest &amp; build changes</h2>
+
+<h3><code>public/manifest.json</code></h3>
+
+<ul>
+<li><strong>Add the provider API origin as a host permission.</strong> Prefer <strong><code>optional_host_permissions</code></strong> (request at upgrade time via <code>chrome.permissions.request</code>, so free users never grant it); fall back to <code>host_permissions</code> if the activation flow needs it unconditionally. If you tighten CSP, add an explicit <code>connect-src 'self' https://x.com &lt;provider-api&gt;</code>. Keep <code>script-src 'self'</code> untouched (never add a payment SDK <code>&lt;script&gt;</code>).</li>
+<li><strong>One-click activation (optional):</strong> for site&rarr;extension hand-off add <code>externally_connectable: { "matches": ["https://usetotem.xyz/*"] }</code> + an <code>onMessageExternal</code> handler &mdash; <strong>both are greenfield</strong> (neither exists today). The site only <em>hands over the key</em>; the SW still <strong>validates it with the provider</strong> before granting Pro, so entitlement is never granted on the site's say-so alone. The paste-a-key fallback is always shipped.</li>
+<li><strong>Reword <code>description</code> (required):</strong> the readiness script pins the description string <strong>exactly</strong>, including the literal "no server" phrasing. Validating online makes a network call, so reword to something true under this design &mdash; e.g. "no Totem account; your bookmarks stay on your device" &mdash; and change it in <strong>three places at once</strong>: the manifest, <code>expected.description</code> in <code>verify-cws-featured-readiness.mjs</code>, and the dashboard listing/privacy packet. Budget for this; it is not optional under online validation.</li>
+</ul>
+
+<h3>Build (<code>vite.config.ts</code>, <code>src/vite-env.d.ts</code>)</h3>
+
+<p>The provider's <strong>validate endpoint URL</strong> (and any publishable product/store id) can be injected via the existing <code>define</code> mechanism (same pattern as <code>__TOTEM_APP_VERSION__</code>) or committed as a constant &mdash; these are public, <strong>no secret ever enters <code>dist/</code></strong> (the MoR's secret API key stays server-side and is never needed for a public validate call).</p>
+
+<div class="callout"><span class="tag">NO NEW CRYPTO DEP</span> Because there is no on-device signature verification, <code>@noble/ed25519</code> is <strong>not</strong> added &mdash; and the <code>@noble/hashes</code> 2.x SHA-512 wiring trap that the earlier offline design hit simply does not apply.</div>
+
+<h3>Release pipeline</h3>
+
+<ul>
+<li><strong><code>scripts/verify-cws-featured-readiness.mjs</code></strong> hard-pins the exact permissions, host_permissions (must be exactly <code>["https://x.com/*"]</code>), name, description, and screenshot set &mdash; <strong>loosen it</strong> for any new host/permission/description or <code>cws:featured:preflight</code> (and the release flow) will fail. It does <strong>not</strong> check <code>content_security_policy</code> or <code>externally_connectable</code>, so those pass silently. This is the single most important repo-mechanical gotcha.</li>
+<li>Update <code>PUBLISH.md</code> + the dashboard packet with permission justifications + the privacy disclosure.</li>
+<li>(Optional, wise) add a grep guard in <code>scripts/package-extension.mjs</code> asserting no private-key-looking strings leaked into <code>dist/</code> before zipping.</li>
+</ul>
+
+<h2 id="site-changes-apps-site-stays-100-static">Site changes (<code>apps/site/</code>, stays 100% static)</h2>
+
+<p>The Astro site is <code>output:"static"</code> with no adapter/functions &mdash; it <strong>can't</strong> host a license endpoint, and it <strong>shouldn't</strong> (that would be a Totem server). It only needs static pages + client <code>&lt;script&gt;</code>:</p>
+
+<table class="striped">
+<thead>
+<tr><th>New page</th><th>Path</th><th>Template</th><th>Notes</th></tr>
+</thead>
+<tbody>
+<tr>
+<td>Pricing</td>
+<td><code>src/pages/pricing.astro</code></td>
+<td><code>export-format/v1.astro</code> or a <code>SiteApp.tsx</code> island</td>
+<td>Indexable. "Buy" links out to MoR hosted checkout. Add <code>"pricing"</code> to <code>SitePageKey</code>.</td>
+</tr>
+<tr>
+<td>Success / license delivery</td>
+<td><code>src/pages/upgrade/success.astro</code></td>
+<td><code>uninstall-feedback.astro</code></td>
+<td><code>noindex</code>; MoR <code>success_url</code> lands here; client <code>&lt;script&gt;</code> reads <code>location.search</code>, shows key + copy + "activate in Totem" deep-link. Exclude from sitemap.</td>
+</tr>
+<tr>
+<td>Manage license</td>
+<td><code>src/pages/manage-license.astro</code></td>
+<td><code>uninstall-feedback.astro</code></td>
+<td>Paste-key / check-status; links to MoR customer portal. No backend.</td>
+</tr>
+</tbody>
+</table>
+
+<p>Also: centralize new URLs in <code>src/react/site-content.ts</code> <code>SITE_LINKS</code>; the build-time UTM/<code>ref</code> decoration in <code>rehype-blog-links.mjs</code> auto-tags blog&rarr;pricing and blog&rarr;checkout links (keep it). Update <code>index.astro</code>'s <code>SoftwareApplication</code> JSON-LD <code>offers</code> (currently <code>price:"0"</code>, <code>isAccessibleForFree:true</code>) to reflect free + $19 tiers.</p>
+<nav class="pager"><a class="pager-link prev" href="06-license.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">License &amp; Entitlement Architecture</span></a><a class="pager-link next" href="08-compliance.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Chrome Web Store Compliance</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#new-files">New files</a>
+<a href="#edited-files-extension">Edited files (extension)</a>
+<a href="#deleted-tweet-preservation-the-one-data-layer-tweak">Deleted-tweet preservation — the one data-layer tweak</a>
+<a href="#manifest-build-changes">Manifest & build changes</a>
+<a href="#site-changes-apps-site-stays-100-static">Site changes (apps/site/, stays 100% static)</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/08-compliance.html
+++ b/plans/research/premium-monetization/site/08-compliance.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Chrome Web Store Compliance · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html" aria-current="page">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">08 · Store</div><h1 class="page-title">Chrome Web Store Compliance</h1><p class="lead">Native Chrome Web Store payments died <strong>Feb 1 2021</strong> — an external processor is now mandatory, and every item below exists to keep the listing compliant once Pro ships.</p>
+
+<h2 id="the-checklist">The checklist</h2>
+
+<ul>
+<li>Checkout happens <strong>off-extension</strong> (web/MoR-hosted), not a fake-native in-extension purchase.</li>
+<li>License validation returns <strong>JSON/signed data only</strong> — no fetched JS/WASM, no <code>eval</code>. Declare <strong>remote code = No</strong> (true).</li>
+<li>All Pro feature <em>logic</em> ships in the package; the license result only flips local flags ("full functionality discernible from submitted code").</li>
+<li>Pro features stay within the <strong>single purpose</strong> (read/search/export your X bookmarks). Don't add an unrelated second product.</li>
+<li><strong>Privacy practices tab:</strong> update data-collected to include <strong>PII (email) + auth info (license key)</strong>; per-permission justifications; the 3 Limited-Use certifications.</li>
+<li><strong>Privacy policy</strong> on <code>usetotem.xyz</code> discloses: the <strong>license key + email + a device id</strong> are sent to <code>&lt;MoR&gt;</code> for validation at activation and on an occasional background re-check; not sold, not used for ads; <strong>bookmark content never transmitted</strong>. Keep the "no analytics/telemetry, no third-party tracking" claims true alongside this one scoped license call.</li>
+<li>Store listing states <strong>free core + optional one-time Pro unlock</strong> and lists Pro features (Deceptive-Installation-Tactics rule: don't advertise a headline feature then reveal at point-of-use that it's paid without prior disclosure).</li>
+<li><span class="tag">ADVERSARIAL-REVIEW FLAG</span> <strong>Featured screenshots disclose Pro.</strong> The readiness script pins the screenshot set, and <code>04-export-twitter-bookmarks-markdown-csv-notion.png</code> literally advertises export — gating export while a featured screenshot sells it is the exact "advertise-then-paywall" pattern §266 prohibits. Mitigation: the <strong>free export allowance</strong> (export your first ~25) keeps the screenshot <em>truthful</em> (export genuinely works free), and the listing copy must label unlimited export / preservation / bulk as Pro. Re-shoot or annotate the screenshot if it implies unlimited export is free.</li>
+<li>When activation arrives via <code>onMessageExternal</code> from the site, the SW still <strong>validates the key with the provider</strong> before granting Pro — never grant entitlement on the page's message alone (a reviewer reading site&rarr;extension entitlement-granting as remote control is a rejection vector).</li>
+<li>New host permission (if any) scoped narrowly (never <code>&lt;all_urls&gt;</code>), justified in the dashboard, ideally <code>optional_host_permissions</code>.</li>
+</ul>
+
+<div class="callout">Native CWS payments died <strong>Feb 1 2021</strong> — external processor is mandatory.</div>
+<nav class="pager"><a class="pager-link prev" href="07-system-changes.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Internal System Changes — File by File</span></a><a class="pager-link next" href="09-paywall-ux.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Paywall UX — Moments, Copy, Anti-Patterns</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/09-paywall-ux.html
+++ b/plans/research/premium-monetization/site/09-paywall-ux.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Paywall UX — Moments, Copy, Anti-Patterns · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html" aria-current="page">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">09 · UX</div><h1 class="page-title">Paywall UX — Moments, Copy, Anti-Patterns</h1><p class="lead">The paywall is the conversion surface, but for this audience it is also a trust surface. Frame Pro as <span class="hl">funding the work, not ransoming a feature</span> — and every moment, every line of copy, and every thing you refuse to do follows from that frame.</p>
+
+<h2 id="the-reference-model-obsidian-catalyst">The reference model — Obsidian Catalyst</h2>
+
+<p>The model to copy is <strong>Obsidian Catalyst</strong>: "your data stays local, the app is free, Pro is a one-time unlock that funds the work." Pro is framed partly as <em>support</em>, not feature ransom. For the subscription-fatigued, anti-DRM, pro-ownership audience (r/nosurf, r/selfhosted, HN, PKM), the absence of coercion is itself the sell.</p>
+
+<div class="callout">Frame Pro partly as support, not feature ransom. The pitch is "fund the export, search, and deleted-tweet preservation work" — not "pay to unlock what we are holding hostage."</div>
+
+<h2 id="upgrade-moments-ranked-by-intent">Upgrade moments — ranked by intent</h2>
+
+<p>Each moment fires <strong>once</strong>, <strong>contextually</strong>, is <strong>dismissible</strong>, and only after the user has felt the value. Ordered from highest to lowest intent:</p>
+
+<ol>
+<li><strong>At export, after a free preview</strong> (primary). Let free users export or preview the first ~25 of <em>their own</em> bookmarks, then: <em>"Export all 3,412 &rarr; Unlock Pro ($14 founders / $19)."</em> Highest intent.</li>
+<li><strong>When a deleted tweet is opened</strong> (secondary, emotional): <em>"This tweet was deleted on X. Totem kept your copy. Pro preserves every deleted bookmark automatically."</em></li>
+<li><strong>On a bulk op</strong> — they have already invested effort selecting.</li>
+<li><strong>On advanced filter use</strong> — show filters lock-badged.</li>
+<li><strong>On first note / annotation.</strong></li>
+</ol>
+
+<p>Plus one quiet, persistent <strong>"Upgrade / Support Totem"</strong> entry in Settings. <span class="hl">Never auto-popup on new-tab load; never re-prompt a dismissed context.</span></p>
+
+<h2 id="copy-that-converts-here">Copy that converts here</h2>
+
+<ul>
+<li><strong>Headline the model, not the price:</strong> <em>"Totem Pro — one-time unlock. No subscription. Ever."</em></li>
+<li><strong>Pre-empt "no server, why pay?":</strong> <em>"You're paying for the work, not infrastructure. Totem stays free and open source; Pro funds development. Your data never leaves your machine."</em></li>
+<li><strong>Reassure on the check:</strong> <em>"Verified by a one-time online license check (email + key only). Your bookmarks never leave your device."</em></li>
+<li><strong>Ownership:</strong> <em>"Buy once, use on up to 5 of your browsers."</em> (or "all your browsers" if you ship an unlimited device limit).</li>
+</ul>
+
+<h2 id="anti-patterns-that-nuke-goodwill">Anti-patterns that nuke goodwill</h2>
+
+<p>These are the <span class="tag">DON'T</span> list — each one specifically corrodes trust with this audience:</p>
+
+<ul>
+<li>Nagging after dismissal.</li>
+<li>Clawing back currently-free features (&rarr; grandfather instead).</li>
+<li>Card-required "free trials."</li>
+<li>Fake scarcity / countdown.</li>
+<li>Surprise paywall with no prior disclosure.</li>
+<li>Any telemetry creep.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">DATA</div> Upgrade-prompt copy that lists the value proposition converts <strong>~4x</strong> a bare alert — 2% &rarr; 8% in real first-party data.</div>
+<nav class="pager"><a class="pager-link prev" href="08-compliance.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Chrome Web Store Compliance</span></a><a class="pager-link next" href="10-rollout.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Phased Rollout &amp; Open Decisions</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#the-reference-model-obsidian-catalyst">The reference model — Obsidian Catalyst</a>
+<a href="#upgrade-moments-ranked-by-intent">Upgrade moments — ranked by intent</a>
+<a href="#copy-that-converts-here">Copy that converts here</a>
+<a href="#anti-patterns-that-nuke-goodwill">Anti-patterns that nuke goodwill</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/10-rollout.html
+++ b/plans/research/premium-monetization/site/10-rollout.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Phased Rollout & Open Decisions · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html" aria-current="page">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">10 · Rollout</div><h1 class="page-title">Phased Rollout &amp; Open Decisions</h1><p class="lead">The build order is deliberately sequenced so the load-bearing, low-visibility work lands before anything user-facing, and the minimum sellable release ships as early as possible. What follows is the phased rollout, then the genuine forks where your preference decides the outcome.</p>
+
+<h2 id="phased-rollout-do-these-in-order">Phased rollout — do these in order</h2>
+
+<h3>Phase 0 — Decisions &amp; accounts (no code)</h3>
+<p>Pick the merchant-of-record (Lemon Squeezy vs Polar). Create the $19 product plus the $14 founders coupon, <strong>enable license keys</strong>, and set the <strong>activation/device limit</strong> (~5). Note the provider's validate endpoint URL. Write the privacy-policy update and the "honest stance" copy.</p>
+
+<h3>Phase 1 — The entitlement spine (ship dark)</h3>
+<p><code>CS_ENTITLEMENT</code> + <code>entitlement.ts</code> + <code>validateLicense</code> + the snapshot field + <code>useIsPro()</code> + the grandfather stamp on <code>onInstalled</code>. No gates yet, no UI. Test that <code>isPro</code> propagates reactively and survives reset/account-switch. This is the <span class="hl">load-bearing, low-visibility work</span>.</p>
+
+<h3>Phase 2 — The gate + the one feature</h3>
+<p><code>&lt;ProGate&gt;</code> / <code>requirePro</code> / <code>UpgradeModal</code> / <code>usePro</code>. Gate <strong>export</strong> only — the cleanest, highest-intent surface — with the free-allowance and grandfathering in place. Paste-a-key activation in Settings. Ship the site <code>pricing</code> / <code>success</code> / <code>manage-license</code> pages plus the MoR checkout.</p>
+<div class="takeaway"><div class="takeaway-label">MILESTONE</div> This is the minimum sellable release.</div>
+
+<h3>Phase 3 — The emotional gate</h3>
+<p>Wire deleted-tweet preservation (the two data-layer tweaks) and its "kept your copy" moment. Add the per-article export, advanced-filter, and annotation gates — all already-built features, behind the same wrapper.</p>
+
+<h3>Phase 4 — Net-new value</h3>
+<p>Build <strong>bulk operations</strong> — the only net-new feature — a clearly-new Pro capability nobody can claim was taken away. Then the <code>ProNudge</code>, the time-boxed founders-price banner, and analytics on the success page.</p>
+
+<h3>Phase 5 — Optional hardening</h3>
+<p>Tune the device limit and the background re-check cadence; add a "deactivate this device" affordance inside the extension (mirrors the provider portal) for the reinstall case; surface refund/chargeback revocation gracefully — the provider already revokes, so keep the re-check fail-open so a <em>network</em> failure never looks like a revocation.</p>
+
+<h2 id="open-decisions-for-you">Open decisions for you</h2>
+<p>These are genuine forks where your preference matters — everything else above is a recommendation I'd ship as-is.</p>
+
+<ol>
+<li><strong>MoR:</strong> Lemon Squeezy (most mature license API, Stripe-transition watch) vs Polar (cheaper, OSS-positioned, younger). Both are fine; pick on whether maturity or cost/ethos weighs more.</li>
+<li><strong>Device limit:</strong> the exact activation cap — <strong>~5 with self-serve deactivate</strong> (recommended: kills mass key-sharing, never bites a real user) vs <strong>unlimited</strong> ("buy once, use on all your browsers," zero friction, accepts key-sharing). And whether to expose deactivate inside the extension or only via the provider's portal.</li>
+<li><strong>Free export allowance:</strong> the exact N (25 is the research default) and whether per-article <em>Copy-to-clipboard</em> stays free as a teaser (recommended yes).</li>
+<li><strong>Annotations / advanced-search free vs Pro:</strong> the GTM doc gates them; the retroactive-paywall risk argues for keeping the <em>currently-shipping</em> versions free for everyone and gating only <em>export of</em> annotations + <em>new</em> filter operators. Worth a deliberate call.</li>
+</ol>
+<nav class="pager"><a class="pager-link prev" href="09-paywall-ux.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Paywall UX — Moments, Copy, Anti-Patterns</span></a><a class="pager-link next" href="11-adversarial-review.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Adversarial Review — What the Red-Team Caught</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/11-adversarial-review.html
+++ b/plans/research/premium-monetization/site/11-adversarial-review.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Adversarial Review — What the Red-Team Caught · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html" aria-current="page">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">11 · Red-Team</div><h1 class="page-title">Adversarial Review — What the Red-Team Caught</h1><p class="lead">
+  Before this plan was finalized, an independent adversarial reviewer re-checked every load-bearing code claim against the live repository and red-teamed the strategy. It confirmed most of the architecture and forced <span class="hl">three concrete corrections</span> — all already folded into the chapters above. This chapter records what it found, so the reasoning is auditable.
+</p>
+
+<h2 id="confirmed-against-the-live-code">Confirmed against the live code</h2>
+<ul>
+  <li><strong>Entitlement storage</strong> — <code>src/service-worker/storage-keys-sw.ts</code> exists and the single-writer invariant is enforced by <code>src/lib/__tests__/storage-invariants.test.ts</code>. (Caveat: the test arrays are hardcoded, so a new key must also be added there to be enforced.)</li>
+  <li><strong>Reactive channel</strong> — the <code>CS_RUNTIME_STATE_V2 → onChanged → applyRuntimeSnapshot</code> path is real; an added snapshot field propagates to every tab.</li>
+  <li><strong>Reset survival</strong> — <code>src/lib/reset.ts</code> has explicit key lists and already preserves auth keys deliberately; <code>CS_ENTITLEMENT</code> can be kept out of them.</li>
+  <li><strong>Deleted-tweet preservation</strong> — <code>TweetDetailCache</code> in <code>src/types/index.ts</code> already carries <code>detailsStatus</code>/<code>unavailableReason</code>; the hydration store already classifies deleted vs protected. The "already built" claim holds.</li>
+  <li><strong>Build pins &amp; static site</strong> — <code>scripts/verify-cws-featured-readiness.mjs</code> really hard-pins permissions, hosts, description, and screenshots; <code>apps/site/astro.config.mjs</code> is <code>output:"static"</code> with no adapter, so it cannot host a license endpoint.</li>
+</ul>
+
+<h2 id="corrected-before-shipping">Corrected before shipping</h2>
+
+<h3>1 · Export is not a single gate</h3>
+<p>The bulk-ZIP path concentrates at <code>ExportModal.tsx:64</code>, but <code>src/components/BookmarkReader.tsx:313-352</code> has four independent per-article egress handlers (copy-Markdown, copy-for-agent, download <code>.md</code>, print/PDF) that bypass <code>ExportModal</code> entirely. The "copy stays free as a teaser" idea is therefore a slow full-library leak — a knowing trade-off, not an oversight. All four handlers must be gated; the file is <code>BookmarkReader.tsx</code>, not <code>TweetContent.tsx</code>.</p>
+
+<h3>2 · "Fully offline, nothing can shut down" was an overclaim</h3>
+<p>The original plan leaned on <strong>offline Ed25519-signed keys</strong> so the extension would make zero license network calls. The review flagged two problems: the brand line "nothing can shut down" only ever held <em>post-activation</em> (checkout and issuance still need the provider online), and — more decisively — a fully-offline key <span class="hl">cannot be counted</span>, so there is no way to manage multi-device activation. The design was therefore changed to <strong>online-validate-then-cache</strong>: validate once at activation, cache the result, read locally, and re-check quietly in the background with <strong>fail-open</strong>. This is simpler (no signer, no key-management vendor, no <code>@noble/ed25519</code> dependency and its SHA-512 wiring trap), it enables the device limit, and it lets the provider revoke a refunded key — at the cost of one host permission and a reworded store description.</p>
+
+<h3>3 · Grandfathering by install-reason misfires</h3>
+<p><code>chrome.runtime.onInstalled</code> with <code>reason === "install"</code> fires for uninstall→reinstall and new-machine cases, so reason alone strips grandfathered status from exactly the engaged users it is meant to protect. Add a secondary heuristic that also runs on install: treat a non-empty bookmarks IndexedDB store (or a pre-Pro settings key) as proof of an existing user.</p>
+
+<h2 id="top-strategy-risks-the-plan-now-weights-explicitly">Top strategy risks the plan now weights explicitly</h2>
+<table class="compact">
+  <thead><tr><th>Risk</th><th>Mitigation in the plan</th></tr></thead>
+  <tbody>
+    <tr><td>"Nothing can shut down" / fully-offline overclaim</td><td>Design changed to online-validate-then-cache with fail-open; brand promise reworded to "no Totem server; bookmarks stay on-device; verified by a quick online check, then cached" (Ch. 4–5).</td></tr>
+    <tr><td>One-click activation puts the site in the trust chain</td><td><code>onMessageExternal</code> must still validate the key with the provider; paste-a-key is the zero-trust-chain fallback (Ch. 7–8).</td></tr>
+    <tr><td>Gating currently-free search/annotations</td><td>Flagged as an open decision; lean toward keeping today's versions free and gating only new operators + annotation export (Ch. 10).</td></tr>
+    <tr><td>Featured export screenshot vs paywall</td><td>The free export allowance keeps the pinned screenshot truthful; listing copy must label unlimited export as Pro (Ch. 8).</td></tr>
+  </tbody>
+</table>
+
+<div class="takeaway">
+  <div class="takeaway-label">Bottom line</div>
+  The architecture survived scrutiny; the three corrections are mechanical, not structural. The plan ships with them already incorporated.
+</div>
+<nav class="pager"><a class="pager-link prev" href="10-rollout.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Phased Rollout &amp; Open Decisions</span></a><a class="pager-link next" href="appendix-a-data-sync.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Data, Sync &amp; Entitlement Storage</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#confirmed-against-the-live-code">Confirmed against the live code</a>
+<a href="#corrected-before-shipping">Corrected before shipping</a>
+<a href="#top-strategy-risks-the-plan-now-weights-explicitly">Top strategy risks the plan now weights explicitly</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-a-data-sync.html
+++ b/plans/research/premium-monetization/site/appendix-a-data-sync.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Data, Sync & Entitlement Storage · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html" aria-current="page">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix A</div><h1 class="page-title">Data, Sync &amp; Entitlement Storage</h1><p class="lead">A codebase deep-dive into the IndexedDB schema, the end-to-end sync/interception flow, the durable-state writer-ownership model, the reactive SW&rarr;UI snapshot push, and the exact integration points where a new <code>isPro</code>/license/entitlement fact would live. All file paths are absolute; line numbers cite the code as read.</p>
+
+<h2 id="orientation-for-the-entitlement-designer">Orientation for the entitlement designer</h2>
+
+<p>Two distinct durable substrates exist: account-scoped <strong>IndexedDB</strong> (bookmark/detail/progress/highlight data, written by the runtime) and <strong>chrome.storage</strong> (auth + sync orchestrator + runtime snapshot), governed by a hard "single writer per fact" rule split across two key files.</p>
+
+<p>The architecture already ships a purpose-built <span class="hl">reactive SW&rarr;UI broadcast channel</span>: the service worker writes a <code>RuntimeSnapshot</code> to <code>chrome.storage.local[CS_RUNTIME_STATE_V2]</code>, and every open page picks it up via <code>chrome.storage.onChanged</code> (<code>src/runtime/RuntimeProvider.tsx:96-100</code>). An <code>isPro</code> field can ride this exact channel to be reactive everywhere (SW plus every new-tab/reader page) with zero new plumbing.</p>
+
+<div class="callout">A license/entitlement is a device-global, account-independent fact. It does <strong>not</strong> belong in IndexedDB (wiped on reset, account-scoped) and does <strong>not</strong> belong in the SW-owned sync orchestrator state (account-scoped, wiped on reset). The cleanest home is a new dedicated <code>chrome.storage</code> key with a single declared writer.</div>
+
+<h2 id="indexeddb-schema">IndexedDB schema</h2>
+
+<h3>Databases (account-scoped)</h3>
+
+<p>File: <code>src/db/index.ts</code>; names in <code>src/lib/storage-keys.ts:1-3</code> and <code>src/lib/constants/db.ts</code>.</p>
+
+<ul>
+<li>Default DB: <code>totem</code> (<code>IDB_DATABASE_NAME</code> / <code>DB_NAME</code>).</li>
+<li>Account DB: <code>totem_acct_&lt;accountId&gt;</code> (<code>IDB_ACCOUNT_DATABASE_PREFIX</code> = <code>"totem_acct_"</code>, joined in <code>getDbNameForAccount</code>, <code>src/db/index.ts:119-122</code>).</li>
+<li>Legacy DB: <code>xbt</code> (<code>LEGACY_IDB_DATABASE_NAME</code>), migrated forward on first open (<code>migrateLegacyDatabaseIfNeeded</code>, <code>src/db/index.ts:385-425</code>).</li>
+<li><code>DB_VERSION = 9</code> (<code>src/lib/constants/db.ts:5</code>). The whole schema is created/upgraded in one <code>upgrade()</code> callback (<code>src/db/index.ts:135-277</code>).</li>
+<li>Account selection: <code>setActiveAccountId(accountId)</code> (<code>src/db/index.ts:124-133</code>) flips a module-level <code>activeDbName</code>; <strong>every</strong> read/write goes through <code>getDb()</code> which opens whatever <code>activeDbName</code> currently points at (<code>src/db/index.ts:443-463</code>). The runtime must call <code>setActiveAccountId</code> before any read (enforced convention; see <code>hydrateCurrentAccount</code>, <code>src/stores/runtime-store.ts:549-554</code>).</li>
+</ul>
+
+<h3>Object stores (9 total)</h3>
+
+<p>Schema interface <code>XBookmarksDbSchema</code>, <code>src/db/index.ts:31-101</code>:</p>
+
+<table class="compact">
+<thead><tr><th>Store</th><th>keyPath</th><th>Indexes</th><th>Value type</th></tr></thead>
+<tbody>
+<tr><td><code>bookmarks</code></td><td><code>id</code></td><td><code>tweetId</code>, <code>sortIndex</code>, <code>createdAt</code>, <code>screenName</code> (= <code>author.screenName</code>)</td><td><code>Bookmark</code></td></tr>
+<tr><td><code>tweet_details</code></td><td><code>tweetId</code></td><td><code>fetchedAt</code></td><td><code>TweetDetailCache</code></td></tr>
+<tr><td><code>reading_progress</code></td><td><code>tweetId</code></td><td><code>lastReadAt</code></td><td><code>ReadingProgress</code></td></tr>
+<tr><td><code>highlights</code></td><td><code>id</code></td><td><code>tweetId</code>, <code>createdAt</code></td><td><code>Highlight</code></td></tr>
+<tr><td><code>saved_searches</code></td><td><code>id</code></td><td><code>sortOrder</code>, <code>createdAt</code></td><td><code>SavedSearch</code></td></tr>
+<tr><td><code>search_index</code></td><td><code>id</code></td><td>&mdash;</td><td><code>{ id, json, savedAt }</code> (serialized MiniSearch index, key <code>"minisearch-v1"</code>)</td></tr>
+<tr><td><code>today_queue_snapshots</code></td><td><code>key</code></td><td><code>localDate</code>, <code>generatedAt</code></td><td><code>TodayQueueSnapshot</code></td></tr>
+<tr><td><code>bookmark_queue_metadata</code></td><td><code>tweetId</code></td><td><code>intent</code>, <code>updatedAt</code></td><td><code>BookmarkQueueMetadata</code> (intent + snooze)</td></tr>
+<tr><td><code>today_queue_exposures</code></td><td><code>id</code></td><td><code>tweetId</code>, <code>localDate</code>, <code>createdAt</code></td><td><code>TodayQueueExposure</code></td></tr>
+</tbody>
+</table>
+
+<p>Note: ARCHITECTURE.md &sect;11 lists only the first four; the actual code has 9. The extra five (<code>saved_searches</code>, <code>search_index</code>, the today-queue trio) are real and relevant to several Pro features (advanced search filters &rarr; <code>saved_searches</code>/<code>search_index</code>; queue intent &rarr; <code>bookmark_queue_metadata</code>).</p>
+
+<h3>What a saved-post ("bookmark") record contains</h3>
+
+<p><code>Bookmark</code> interface, <code>src/types/index.ts:151-174</code>. This is rich and is the single biggest asset for the <span class="hl">deleted-tweet preservation Pro feature</span> &mdash; the full text and metadata are already persisted locally:</p>
+
+<ul>
+<li>Identity/order: <code>id</code>, <code>tweetId</code>, <code>sortIndex</code> (X's opaque cursor string), <code>createdAt</code> (ms epoch), <code>bookmarked</code> (boolean &mdash; stays <code>true</code> until unbookmarked; never deleted on unbookmark, just flipped).</li>
+<li>Content: <code>text</code> (full tweet text), <code>tweetKind</code> (<code>tweet|reply|quote|repost|thread|article</code>), <code>tweetDisplayType</code>, <code>inReplyToTweetId</code>, <code>inReplyToScreenName</code>, <code>isThread</code>.</li>
+<li><strong>Author</strong> (<code>Author</code>, <code>src/types/index.ts:44-56</code>): <code>name</code>, <code>screenName</code>, <code>profileImageUrl</code>, <code>verified</code>, optional <code>bio</code>, <code>followersCount</code>, <code>followingCount</code>, <code>website</code>, <code>createdAt</code>, <code>bannerUrl</code>, <code>affiliate</code>.</li>
+<li><strong>Metrics</strong> (<code>Metrics</code>, lines 58-64): <code>likes</code>, <code>retweets</code>, <code>replies</code>, <code>views</code>, <code>bookmarks</code>.</li>
+<li><strong>Media</strong> (<code>Media[]</code>, lines 66-73): <code>type</code> (<code>photo|video|animated_gif</code>), <code>url</code> (image), <code>videoUrl</code>, <code>width</code>, <code>height</code>, <code>altText</code>. URLs point at <code>*.twimg.com</code> (CSP <code>img-src</code>/<code>media-src</code> in <code>public/manifest.json</code> allow only twimg + self &mdash; so media is hot-linked, not blobbed locally; see Sync section).</li>
+<li><strong>URLs / cards</strong> (<code>TweetUrl[]</code>, lines 84-89): <code>url</code>, <code>displayUrl</code>, <code>expandedUrl</code>, optional <code>card</code> (<code>LinkCard</code>: title/description/imageUrl/domain/cardType).</li>
+<li><strong>Quote / repost / article</strong>: <code>quotedTweet</code> (<code>QuotedTweet</code>), <code>retweetedTweet</code>, <code>article</code> (<code>ArticleContent</code>: full <code>plainText</code>, <code>title</code>, <code>coverImageUrl</code>, <code>contentBlocks</code>, <code>entityMap</code> &mdash; i.e. the entire long-form X Article body).</li>
+<li>Convenience flags: <code>hasImage</code>, <code>hasVideo</code>, <code>hasLink</code>.</li>
+</ul>
+
+<h3>Detail cache &mdash; the reader payload (most important for "deleted-tweet preservation")</h3>
+
+<p><code>TweetDetailCache</code>, <code>src/types/index.ts:176-183</code>:</p>
+
+<pre><code>interface TweetDetailCache {
+  tweetId: string;
+  fetchedAt: number;
+  focalTweet: Bookmark | null;
+  thread: ThreadTweet[];              // thread-aware capture already exists
+  detailsStatus?: "ok" | "unavailable";
+  unavailableReason?: "deleted" | "protected" | "parse_failed" | "unknown";
+}</code></pre>
+
+<ul>
+<li><code>thread: ThreadTweet[]</code> (<code>src/types/index.ts:134-149</code>) is the <strong>already-captured thread structure</strong> &mdash; each thread tweet carries its own author/media/urls/article/quoted/retweeted + <code>inReplyToTweetId</code>. So "thread-aware capture" as a Pro feature is, at the data layer, <strong>already done</strong>; it is fetched and cached whenever a tweet is opened in the reader or warmed by the prefetch controller.</li>
+<li><code>detailsStatus</code> / <code>unavailableReason</code> fields <strong>exist in the type</strong> but the parser (<code>parseTweetDetailPayload</code>, <code>src/api/parsers.ts:1231-1265</code>) does <strong>not currently set them</strong> &mdash; it returns <code>{ focalTweet, thread }</code> only. <code>unwrapTweet</code> returns <code>null</code> for <code>TweetTombstone</code>/<code>TweetUnavailable</code> (<code>src/api/parsers.ts:111-120</code>) but the surrounding code doesn't yet stamp <code>unavailableReason: "deleted"</code>.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">SMALLEST PRO HOOK</div> When a future <code>FETCH_TWEET_DETAIL</code> returns a tombstone, <strong>keep the previously-cached <code>focalTweet</code></strong> instead of overwriting, and set <code>detailsStatus: "unavailable"</code>. The retention sweep already exists (<code>cleanupOldTweetDetails</code>, <code>src/db/index.ts:1206-1226</code>, default <code>DETAIL_CACHE_RETENTION_MS</code>) and would need to <em>exempt</em> Pro-preserved rows.</div>
+
+<h3>Other store value shapes</h3>
+
+<ul>
+<li><code>ReadingProgress</code> (<code>src/types/index.ts:193-205</code>): <code>tweetId</code>, <code>openedAt</code>, <code>lastReadAt</code>, <code>scrollY</code>, <code>scrollHeight</code>, <code>completed</code>, <code>reopenCount</code>.</li>
+<li><code>Highlight</code> (<code>src/types/index.ts:207-218</code>): <code>id</code>, <code>tweetId</code>, <code>sectionId</code>, <code>startOffset</code>, <code>endOffset</code>, <code>selectedText</code>, <code>note</code> (annotations Pro feature lives here), <code>color</code>, <code>createdAt</code>, <code>type</code> (<code>highlight|note</code>).</li>
+<li><code>SavedSearch</code> (<code>src/types/index.ts:227-233</code>): <code>id</code>, <code>name</code>, <code>query</code>, <code>createdAt</code>, <code>sortOrder</code>.</li>
+<li><code>BookmarkQueueMetadata</code> (lines 259-264): <code>tweetId</code>, <code>intent</code> (<code>unset|read_soon|reference|act</code>), <code>snoozedUntil</code>, <code>updatedAt</code>.</li>
+</ul>
+
+<h3>IDB is wiped on reset and is account-scoped</h3>
+
+<p><code>clearAllLocalData</code> / <code>clearTransientStores</code> / <code>deleteBookmarksByTweetIds</code> (<code>src/db/index.ts:537-632</code>) and the full <code>resetLocalData</code> (<code>src/lib/reset.ts:135-210</code>, deletes the default DB + every <code>totem_acct_*</code> DB). <strong>Conclusion: do not store the license here.</strong> A user who hits "Reset app" or switches accounts must not lose their lifetime unlock.</p>
+
+<h2 id="sync-flow-end-to-end">Sync flow end-to-end</h2>
+
+<h3>Two content scripts (manifest)</h3>
+
+<p><code>public/manifest.json</code> registers two content scripts on <code>https://x.com/*</code> at <code>document_start</code>:</p>
+
+<ol>
+<li><code>content/detect-user.js</code> (ISOLATED world) &mdash; source <code>src/content/detect-user.ts</code>. Reads the <code>twid</code> cookie &rarr; writes <code>totem_user_id</code> + <code>totem_account_context_id</code> to <code>chrome.storage.local</code> (<code>src/content/detect-user.ts:21-44</code>); relays MAIN-world <code>postMessage</code> bookmark-mutation + query-id messages to the SW (lines 56-85).</li>
+<li><code>content/mutation-hook.js</code> (<strong>MAIN world</strong>) &mdash; <code>public/content/mutation-hook.js</code>. This is hand-written JS (not built from TS). It monkey-patches <code>XMLHttpRequest.prototype.open/send</code> and <code>window.fetch</code> (lines 98-133) to detect <code>CreateBookmark</code>/<code>DeleteBookmark</code> calls and <code>postMessage</code>s <code>{operation, tweetId}</code> to the ISOLATED script. It also scrapes X's JS bundles for GraphQL <code>queryId</code>s (<code>discoverQueryIds</code>, lines 135-202) and posts <code>{type:"query_ids", ids}</code>.</li>
+</ol>
+
+<div class="callout"><strong>Key nuance:</strong> the MAIN-world hook only observes <em>mutations</em> (create/delete), not the bookmark/timeline GraphQL <em>responses</em>. The actual bookmark/detail data is fetched by the <strong>service worker itself</strong>, replaying captured auth headers. So "intercepting GraphQL responses" in this codebase means: SW captures <em>auth headers</em> from real browsing (webRequest), then the SW makes its own authenticated GraphQL fetches.</div>
+
+<h3>Auth-header capture (the real interception)</h3>
+
+<p><code>src/service-worker/index.ts:320-391</code>, <code>chrome.webRequest.onSendHeaders</code> on <code>https://x.com/i/api/graphql/*</code>:</p>
+
+<ul>
+<li>Captures <code>authorization</code>, <code>cookie</code>, <code>x-csrf-token</code>, <code>x-client-uuid</code>, <code>x-client-transaction-id</code>, <code>x-twitter-*</code> (<code>CAPTURED_HEADERS</code>, lines 45-55).</li>
+<li>Requires the full "auth trio" + a valid <code>twid</code> before arming <code>totem_auth_headers</code> (lines 351-372) &mdash; this prevents stale-JWT re-login after logout.</li>
+<li>Also harvests X's <code>features</code> query param into <code>totem_features</code> (lines 378-387), reused when the SW builds its own requests.</li>
+<li>Mutation capture: <code>onBeforeRequest</code> (deletes &rarr; immediate event) and <code>onCompleted</code> (creates &rarr; confirmed event) at <code>src/service-worker/index.ts:395-438</code>.</li>
+<li>Auth state also tracked from response status (401/403 &rarr; logged out) at lines 442-456, and from <code>twid</code> cookie removal at lines 463-467.</li>
+</ul>
+
+<h3>SW &rarr; GraphQL fetch &rarr; parse &rarr; persist</h3>
+
+<p>The SW is the API boundary. <code>src/service-worker/api-proxy.ts</code>:</p>
+
+<ul>
+<li><code>FETCH_BOOKMARKS</code> (<code>handleFetchBookmarks</code>, lines 153-222): <code>withQueryId("Bookmarks", &hellip;)</code> builds the URL, <code>buildHeaders(storage)</code> replays captured headers (lines 78-105), fetches <code>https://x.com/i/api/graphql/&lt;queryId&gt;/Bookmarks</code>, returns <code>{ data: json }</code>. On 401/403 it does one silent re-auth retry then <code>markAuthLoggedOut</code>.</li>
+<li><code>FETCH_TWEET_DETAIL</code> (<code>handleFetchTweetDetail</code>, lines 281-365): same pattern for <code>TweetDetail</code>. <strong>This is the call that returns the full thread + author + media + article</strong> that becomes <code>TweetDetailCache</code>.</li>
+<li><code>DELETE_BOOKMARK</code>, <code>FETCH_VIEWER_PROFILE</code> also here.</li>
+</ul>
+
+<p>Parsing happens <strong>runtime-side</strong>, not in the SW. The runtime RPC wrappers live in <code>src/api/core/</code> (<code>bookmarks.ts</code>, <code>posts.ts</code>). <code>fetchTweetDetail</code> (<code>src/api/core/posts.ts:66-90+</code>) sends <code>FETCH_TWEET_DETAIL</code>, then <code>parseTweetDetailPayload</code> (<code>src/api/parsers.ts:1231</code>) turns raw JSON into <code>TweetDetailContent</code>, and <strong>upserts it into IDB</strong> via <code>upsertTweetDetailCache</code> (<code>src/api/core/posts.ts:1</code> imports it). Bookmark pages are parsed by the bookmark parsers and persisted via <code>upsertBookmarks</code> in the sync loop.</p>
+
+<h3>The sync loop (runtime side)</h3>
+
+<p><code>src/stores/runtime-store.ts</code> <code>sync()</code> (lines 775-1031):</p>
+
+<ol>
+<li><code>reserveSyncRun({accountId, trigger, localCount})</code> &rarr; SW decides allow + mode.</li>
+<li>On allow: <code>reconcileBookmarks</code> (<code>src/lib/reconcile.ts</code>) walks pages via <code>fetchBookmarkPage</code>, <code>onPage</code> merges each page into in-memory <code>bookmarks</code> and calls <code>upsertBookmarks(deduped)</code> (lines 887-907).</li>
+<li>On <code>full</code> completion with <code>staleIds</code>, deletes locally-removed bookmarks.</li>
+<li><code>releaseActiveLease(status, errorCode)</code> &rarr; SW <code>COMPLETE_SYNC</code> stamps <code>lastFullSyncAt</code>/cache-summary keys.</li>
+</ol>
+
+<h3>Data that already flows through and is cacheable</h3>
+
+<p>Everything needed to preserve a deleted tweet is <strong>already in the local stores before the tweet is deleted upstream</strong>:</p>
+
+<ul>
+<li>The <code>bookmarks</code> store holds full text/author/media-URLs/article/quote for every saved post.</li>
+<li>The <code>tweet_details</code> store holds the full reader payload + thread once a post has been opened or prefetched (the prefetch controller warms a top-of-list pool &mdash; <code>src/stores/prefetch-controller.ts</code>).</li>
+<li>Media is referenced by <code>*.twimg.com</code> URL, <strong>not</strong> stored as blobs. True "preservation" against X deleting the media would require downloading bytes (a new capability); but text/metadata/thread preservation needs <strong>no new fetch</strong> &mdash; only a policy change: on a later detail fetch that returns a tombstone, <em>don't overwrite</em> the existing cache row, and stamp <code>detailsStatus:"unavailable"</code>/<code>unavailableReason:"deleted"</code> (the fields already exist).</li>
+</ul>
+
+<h2 id="state-model-durable-state-writer-ownership">State model: durable state + writer ownership</h2>
+
+<p>ARCHITECTURE &sect;11/&sect;16 Invariant #1 ("single writer per persisted fact") is enforced at test time (<code>src/lib/__tests__/storage-invariants.test.ts</code>). Three substrates follow.</p>
+
+<h3>chrome.storage.local &mdash; split by writer across two files</h3>
+
+<p><strong>Shared keys</strong> <code>src/lib/storage-keys.ts</code> (read by anyone, written by their owner):</p>
+<ul>
+<li>SW-written: <code>CS_AUTH_HEADERS</code> (<code>totem_auth_headers</code>), <code>CS_AUTH_STATE</code>, <code>CS_AUTH_TIME</code>, <code>CS_USER_ID</code>, <code>CS_ACCOUNT_CONTEXT_ID</code>, <code>CS_VIEWER_PROFILE</code>, <code>CS_BOOKMARK_EVENTS</code>, plus undeclared SW-only strings (<code>totem_graphql_catalog</code>, <code>totem_features</code>, <code>totem_auth_state_at/_reason</code>, <code>totem_auth_diagnostics</code>).</li>
+<li>Runtime-written: <code>CS_DB_CLEANUP_AT</code>, <code>CS_RUNTIME_AUDIT</code>, <code>CS_HYDRATION_SNAPSHOT</code>, <code>CS_GROWTH_STATE</code>.</li>
+<li>Either: <code>CS_BOOKMARK_EVENTS</code> (SW enqueues, runtime acks via <code>ACK_BOOKMARK_EVENTS</code>).</li>
+<li>Broadcast: <code>CS_RESET_EPOCH</code> (<code>reset.ts</code> writes; SW + every page drop IDB handles).</li>
+</ul>
+
+<p><strong>SW-exclusive keys</strong> <code>src/service-worker/storage-keys-sw.ts</code> (non-SW imports forbidden except <code>reset.ts</code> + <code>RuntimeProvider.tsx</code>):</p>
+<ul>
+<li><code>CS_SYNC_ORCHESTRATOR_STATE</code> (<code>totem_sync_orchestrator_state</code>) &mdash; leases, cooldowns, <strong><code>lastFullSyncAt</code></strong>, per-account map.</li>
+<li><code>CS_RUNTIME_STATE_V2</code> (<code>totem_runtime_state_v2</code>) &mdash; the full <code>RuntimeSnapshot</code>.</li>
+<li><code>CS_LAST_SYNC</code>, <code>CS_LAST_SOFT_SYNC</code>, <code>CS_SOFT_SYNC_NEEDED</code> &mdash; cache-summary timestamps.</li>
+</ul>
+
+<p>Enforcement: <code>ALLOWED_WRITERS = ["service-worker/"]</code> for SW-owned keys; <code>ALLOWED_IMPORTERS = ["service-worker/", "lib/reset.ts", "runtime/RuntimeProvider.tsx"]</code> for the SW key file (<code>src/lib/__tests__/storage-invariants.test.ts:98-149</code>).</p>
+
+<h3>chrome.storage.sync &mdash; cross-device, survives reinstall on the same Google profile</h3>
+
+<p><code>src/lib/storage-keys.ts:70-76</code>: <code>SYNC_SETTINGS</code> (<code>totem_settings</code>) and <code>SYNC_THEME</code> (<code>totem_theme</code>). Read/written by <code>useSettings</code> (<code>src/hooks/useSettings.ts:104-145</code>) and <code>useTheme</code>. This is the <strong>only substrate that survives a reinstall and propagates across the user's devices</strong>. Tradeoff for licensing: convenient for "unlock follows the user," but it is also the easiest for a user to read/edit, and a full reset wipes it (<code>reset.ts:204-205</code>, only on non-<code>keepUserContent</code>).</p>
+
+<h3>Zustand runtime store &mdash; ephemeral, never persisted</h3>
+
+<p><code>src/stores/runtime-store.ts</code>. Holds <code>authPhase</code>, <code>capability</code>, <code>bookmarks</code>, <code>detailedTweetIds</code>, <code>syncStatus</code>, generations, etc. (<code>RuntimeState</code>, lines 154-174). It is a <strong>mirror</strong> of SW-owned facts + IDB contents; it writes IDB and reads everything else. It would be the place an <code>isPro</code> value is <strong>exposed to React</strong>, but never the <strong>owner</strong> of the persisted bit.</p>
+
+<h3>localStorage &mdash; app-local UI prefs only</h3>
+
+<p><code>LOCAL_STORAGE_KEYS</code> (<code>src/lib/storage-keys.ts:16-28</code>): reading tab, sorts, wallpaper, pinned tweets, reader activity, recent searches, export-ready dismissal. Per-device, not synced, wiped on reset. Wrong home for a license (trivially editable, per-device, lost on reset).</p>
+
+<h3>Who should own a new <code>isPro</code> / license fact</h3>
+
+<p>Per "single writer per persisted fact," <code>isPro</code> needs exactly one writer. The recommendation:</p>
+
+<div class="takeaway"><div class="takeaway-label">RECOMMENDED OWNER</div> The <strong>service worker</strong>, writing a new dedicated key <code>CS_ENTITLEMENT</code> (<code>totem_entitlement</code>), declared in <code>src/service-worker/storage-keys-sw.ts</code> so the existing import-boundary test makes the SW the sole writer for free. The value is a small record: <code>{ isPro: boolean, plan: "lifetime"|"founders"|null, licenseKey?: string, source: "gumroad"|"manual"|&hellip;, verifiedAt: number, signature?: string }</code>.</div>
+
+<ul>
+<li><strong>Why the SW:</strong> it is the trust boundary, it already owns the snapshot, and (critically) license <em>verification</em> (a network call to the licensing vendor / a signature check) is naturally a SW responsibility &mdash; the SW already makes authenticated network calls and is the only context that should hold any secret-ish verification logic. Putting the writer in the SW also makes the entitlement <strong>account-independent and reset-surviving by policy</strong>: keep <code>CS_ENTITLEMENT</code> out of <code>CHROME_LOCAL_RESET_KEYS</code> in <code>src/lib/reset.ts</code> (mirror how auth headers are deliberately <em>preserved</em> across reset, <code>reset.ts:30-32</code> comment) so "Reset app" never revokes a paid unlock.</li>
+<li><strong>Physical location: <code>chrome.storage.local</code></strong> (device-local). If you want the unlock to follow the user across devices, <em>additionally</em> mirror a verification token into <code>chrome.storage.sync</code> under a new key &mdash; but treat <code>chrome.storage.local[CS_ENTITLEMENT]</code>, written by the SW after verification, as the authoritative readable fact.</li>
+<li><strong>Do NOT</strong> put it in IDB (account-scoped + wiped) or in the sync orchestrator account map (account-scoped + wiped). It is not a per-account fact.</li>
+</ul>
+
+<p>Because the SW already builds and persists <code>RuntimeSnapshot</code>, the entitlement should also be <strong>stamped into the snapshot</strong> (one new field) so it propagates reactively.</p>
+
+<h2 id="reactive-sw-ui-snapshot-push-can-ispro-ride-it-yes">Reactive SW &rarr; UI snapshot push (can <code>isPro</code> ride it? &mdash; yes)</h2>
+
+<h3>How the push works today</h3>
+
+<p><code>RuntimeSnapshotData</code> (<code>src/types/messages.ts:174-182</code>) is the snapshot shape: <code>sessionState</code>, <code>authPhase</code>, <code>accountContextId</code>, <code>capability</code>, <code>syncPolicy</code>, <code>blockedReason</code>, <code>cacheSummary</code>.</p>
+
+<ul>
+<li>The SW <strong>builds</strong> it in <code>buildRuntimeSnapshot</code> (<code>src/service-worker/auth.ts:364-427</code>) and <strong>persists</strong> it via <code>persistRuntimeStateV2</code> (<code>src/service-worker/auth.ts:429-471</code>) &rarr; writes <code>chrome.storage.local[CS_RUNTIME_STATE_V2]</code>. This persist is called after <strong>every</strong> reservation/completion (<code>src/service-worker/sync.ts:368-371, 509-512, 668-679</code>) and on <code>GET_RUNTIME_SNAPSHOT</code>/<code>SET_ACCOUNT_CONTEXT</code> (<code>src/service-worker/auth.ts:810-815, 843-848</code>).</li>
+<li>Every open page subscribes in <code>src/runtime/RuntimeProvider.tsx:64-105</code>. On a <code>CS_RUNTIME_STATE_V2</code> change (and no concurrent auth-key change), it calls <code>actions.applyRuntimeSnapshot(snapshot)</code> (lines 96-100).</li>
+<li><code>applyRuntimeSnapshot</code> (<code>src/stores/runtime-store.ts:1186-1192</code>) normalizes via <code>normalizeAuthPayloadFromSnapshot</code> and calls <code>applyAuthPayload(&hellip;, { allowHydration:false, allowAutoSync:false })</code> &mdash; it only updates auth/capability/session mirrors; never re-reads IDB, never starts a sync.</li>
+</ul>
+
+<h3>Riding <code>isPro</code> on this channel</h3>
+
+<p>Yes &mdash; this is the intended mechanism and the cleanest gating path:</p>
+
+<ol>
+<li>Add <code>isPro</code> (or a small <code>entitlement</code> object) to <code>RuntimeSnapshotData</code> (<code>src/types/messages.ts:174-182</code>).</li>
+<li>Populate it in <code>buildRuntimeSnapshot</code> (<code>src/service-worker/auth.ts:394-426</code>) by reading <code>CS_ENTITLEMENT</code>, and include it in the safe-defaults in <code>persistRuntimeStateV2</code> (<code>src/service-worker/auth.ts:459-470</code>).</li>
+<li>Mirror it into the Zustand store: add an <code>isPro</code> field to <code>RuntimeState</code> (<code>src/stores/runtime-store.ts:154-174</code>), set it inside <code>applyAuthPayload</code> (lines 695-724) from the normalized payload, and read it in <code>normalizeAuthPayloadFromSnapshot</code> (lines 202-222).</li>
+<li>Expose a <code>useIsPro()</code> selector in <code>src/stores/selectors.ts</code> (alongside <code>useAuthPhase</code>, etc.).</li>
+</ol>
+
+<div class="callout">Result: when the SW verifies a purchase and writes <code>CS_ENTITLEMENT</code> + re-persists the snapshot, <span class="hl">every open new-tab and reader page flips to Pro on the same event-loop tick</span>, exactly like a capability upgrade does today &mdash; no heartbeat wait, no reload. The SW, the UI, and any <code>chrome.storage.onChanged</code> listener all see the same single fact.</div>
+
+<p>One caveat to respect: <code>applyRuntimeSnapshot</code> deliberately uses <code>allowHydration:false</code>. An <code>isPro</code> flip must <strong>not</strong> trigger a re-hydration or sync &mdash; it is purely a capability mirror, so adding it as a snapshot field is safe and consistent with the existing guardrails.</p>
+
+<h2 id="concrete-integration-points-file-paths">Concrete integration points (file paths)</h2>
+
+<h3>(a) Where the entitlement value would be stored (the single writer)</h3>
+<ul>
+<li><strong>Declare the key:</strong> <code>src/service-worker/storage-keys-sw.ts</code> &mdash; add <code>export const CS_ENTITLEMENT = "totem_entitlement";</code>. This automatically makes the SW the only allowed writer and keeps runtime code from writing it (enforced by <code>src/lib/__tests__/storage-invariants.test.ts</code>).</li>
+<li><strong>Write it:</strong> a new SW handler module, e.g. <code>src/service-worker/entitlement.ts</code>, exporting a <code>HandlerMap</code> merged in <code>src/service-worker/index.ts:133-141</code> (alongside <code>authHandlers</code>, <code>syncHandlers</code>, &hellip;). Handlers like <code>ACTIVATE_LICENSE</code> / <code>VERIFY_LICENSE</code> / <code>GET_ENTITLEMENT</code> call <code>chrome.storage.local.set({ [CS_ENTITLEMENT]: &hellip; })</code> after verification. Add the new message types to <code>src/types/messages.ts</code> (<code>MessageRequest</code> union, lines 147-167).</li>
+<li><strong>Reset policy:</strong> in <code>src/lib/reset.ts</code>, keep <code>CS_ENTITLEMENT</code> <strong>out of</strong> <code>CHROME_LOCAL_RESET_KEYS</code> (lines 33-45) so a reset never revokes a paid unlock &mdash; and if you ever do want a "deactivate license" path, make it explicit, not a side effect of reset.</li>
+<li><strong>Optional cross-device mirror:</strong> add a sync key to <code>CHROME_SYNC_KEYS</code> (<code>src/lib/storage-keys.ts:73-76</code>) if the unlock should follow the user; written by the SW too.</li>
+</ul>
+
+<h3>(b) Where it is read by the service worker</h3>
+<ul>
+<li><code>src/service-worker/auth.ts</code> &mdash; <code>buildRuntimeSnapshot</code> (lines 364-427) reads <code>CS_ENTITLEMENT</code> and adds it to the returned snapshot; <code>persistRuntimeStateV2</code> (lines 429-471) includes it with safe defaults.</li>
+<li>Any Pro-gated SW capability (e.g. a future bulk-export proxy, or "don't overwrite cache on tombstone") reads <code>CS_ENTITLEMENT</code> directly in the relevant handler in <code>src/service-worker/api-proxy.ts</code>.</li>
+<li><code>src/api/core/auth.ts</code> <code>getRuntimeSnapshot()</code> (lines 21-33) already returns <code>response.data</code> verbatim, so the new field reaches the runtime with no wrapper change.</li>
+</ul>
+
+<h3>(c) Where it is exposed to React components</h3>
+<ul>
+<li><code>src/stores/runtime-store.ts</code>: add <code>isPro</code> to <code>RuntimeState</code> (lines 154-174) and to <code>createInitialState</code> (lines 355-380); set it in <code>applyAuthPayload</code> (lines 695-724) and read it from the snapshot in <code>normalizeAuthPayloadFromSnapshot</code> (lines 202-222) and from the <code>CHECK_AUTH</code> path in <code>normalizeAuthPayloadFromStatus</code> (lines 224-250) if you also surface it via <code>CHECK_AUTH</code>.</li>
+<li><code>src/runtime/RuntimeProvider.tsx</code>: <strong>no change needed</strong> &mdash; the existing <code>CS_RUNTIME_STATE_V2</code> <code>onChanged</code> branch (lines 96-100) already delivers the snapshot reactively.</li>
+<li><code>src/stores/selectors.ts</code>: add <code>export function useIsPro(): boolean { return useRuntimeStoreBase((s) =&gt; s.isPro); }</code> (mirrors <code>useAuthPhase</code>, lines 53-55). Components (<code>ExportModal.tsx</code>, <code>SettingsModal.tsx</code>, reader <code>ArticleExportMenu.tsx</code>, <code>BookmarksList.tsx</code> bulk-ops, etc.) gate on <code>useIsPro()</code>.</li>
+<li>For non-React surfaces (the reader route, the export library in <code>src/lib/export/*</code>): read the store directly via <code>runtimeStore.getState().isPro</code> (<code>src/stores/runtime-store.ts:1347-1351</code>) or pass the flag in.</li>
+</ul>
+
+<h3>(d) Supporting reference points already in place</h3>
+<ul>
+<li>Settings precedent for a sync-stored, reactively-updated boolean: <code>src/hooks/useSettings.ts</code> (<code>showOpenInTotem</code> etc. over <code>chrome.storage.sync</code> with an <code>onChanged</code> listener).</li>
+<li>Capability-mirror precedent (the exact pattern <code>isPro</code> should copy): <code>ApiCapability</code> in <code>src/types/auth.ts:11-14</code>, flowing snapshot &rarr; store &rarr; selector.</li>
+</ul>
+
+<h2 id="risks-sharp-edges-for-the-entitlement-design">Risks / sharp edges for the entitlement design</h2>
+
+<ol>
+<li><strong>Local-first means client-trusted.</strong> Every substrate here (<code>chrome.storage.local/.sync</code>, IDB, localStorage) is user-readable/editable in DevTools. A purely local <code>isPro:true</code> is trivially forgeable. To match the "no Totem server" ethos while resisting casual piracy, the realistic option is a <span class="hl">signed license token verified by the SW</span> (vendor-issued signature over the license + a public key shipped in the extension). True server-side enforcement contradicts the no-server ethos; design for "honest-majority + raise the effort," not DRM.</li>
+<li><strong>Reset must not revoke.</strong> Default reset wipes <code>chrome.storage.sync</code> and all of IDB. Keep the entitlement key off both reset lists. Document it next to the auth-preservation comment in <code>reset.ts</code>.</li>
+<li><strong>Account switching.</strong> The entitlement is device/user-global, not per-account &mdash; keep it out of the per-account orchestrator map (<code>SyncAccountState</code>, <code>src/service-worker/sync.ts:65-86</code>) and out of account-scoped IDB.</li>
+<li><strong>Snapshot guardrail.</strong> When adding <code>isPro</code> to the snapshot, ensure the <code>applyRuntimeSnapshot</code> path keeps <code>allowHydration:false</code>/<code>allowAutoSync:false</code> (it already does) so an entitlement change never triggers IDB re-reads or syncs.</li>
+<li><strong>The MAIN-world hook is plain JS</strong> (<code>public/content/mutation-hook.js</code>) and is <strong>not</strong> a place to read entitlements &mdash; it has no access to the verified fact and shouldn't.</li>
+</ol>
+
+<h2 id="one-paragraph-mental-model-for-the-entitlement">One-paragraph mental model for the entitlement</h2>
+
+<div class="callout">The license is a <strong>device-global, account-independent, reset-surviving fact</strong> whose single writer is the <strong>service worker</strong> (after verifying a signed token), physically stored in a new <code>chrome.storage.local</code> key (<code>CS_ENTITLEMENT</code>, declared in <code>src/service-worker/storage-keys-sw.ts</code>), stamped into the existing <code>RuntimeSnapshot</code>, and pushed reactively to every UI surface through the already-built <code>CS_RUNTIME_STATE_V2</code> &rarr; <code>chrome.storage.onChanged</code> &rarr; <code>applyRuntimeSnapshot</code> &rarr; Zustand &rarr; <code>useIsPro()</code> channel. IndexedDB stores the <em>content</em> a Pro feature acts on (full bookmark/detail/thread payloads &mdash; already enough to preserve deleted tweets' text and structure with only a cache-overwrite policy change), but never the entitlement itself.</div>
+<nav class="pager"><a class="pager-link prev" href="11-adversarial-review.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Adversarial Review — What the Red-Team Caught</span></a><a class="pager-link next" href="appendix-b-features-export.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Features &amp; Export Surface</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#orientation-for-the-entitlement-designer">Orientation for the entitlement designer</a>
+<a href="#indexeddb-schema">IndexedDB schema</a>
+<a href="#sync-flow-end-to-end">Sync flow end-to-end</a>
+<a href="#state-model-durable-state-writer-ownership">State model: durable state + writer ownership</a>
+<a href="#reactive-sw-ui-snapshot-push-can-ispro-ride-it-yes">Reactive SW → UI snapshot push (can isPro ride it? — yes)</a>
+<a href="#concrete-integration-points-file-paths">Concrete integration points (file paths)</a>
+<a href="#risks-sharp-edges-for-the-entitlement-design">Risks / sharp edges for the entitlement design</a>
+<a href="#one-paragraph-mental-model-for-the-entitlement">One-paragraph mental model for the entitlement</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-b-features-export.html
+++ b/plans/research/premium-monetization/site/appendix-b-features-export.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Features & Export Surface · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html" aria-current="page">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix B</div><h1 class="page-title">Features &amp; Export Surface</h1><p class="lead">A map of every user-facing feature, a deep-dive on Export (the proposed primary Pro gate), and the cost of inserting an entitlement check at each surface. The conclusion is unusual for a monetization effort: almost nothing needs to be built.</p>
+
+<div class="callout">There is <span class="hl">zero gating today</span> — every feature is fully free. Export, the proposed primary Pro gate, is one of the cleanest things in the codebase to wrap: exactly two entry points (a new-tab modal and a per-article reader menu), both routed through <code>App.tsx</code>, both already consuming <code>account</code>/<code>viewerProfile</code>, so an entitlement check slots in with almost no plumbing.</div>
+
+<h2 id="export-today">Export Today</h2>
+
+<h3>Formats currently supported</h3>
+
+<p>Totem has <strong>two distinct export systems</strong>.</p>
+
+<p><strong>A) Library-wide ZIP export</strong> — <code>src/lib/export/quick-export.ts</code>, <code>runQuickExport</code>, lines 561&ndash;776. One ZIP (<code>totem-export-YYYY-MM-DD.zip</code>) bundling <strong>every supported format at once</strong>:</p>
+
+<ul>
+<li><strong>CSV</strong> — <code>bookmarks.csv</code>, 11 columns (<code>quick-export.ts:95&ndash;107</code>, written by <code>bookmarkCsvLine</code>/<code>csvLines</code> <code>:314&ndash;343</code>), BOM-prefixed for Excel.</li>
+<li><strong>Markdown</strong> — <code>readme.md</code> index (<code>buildReadme :215&ndash;263</code>) <strong>plus one <code>.md</code> file per bookmark</strong> under <code>bookmarks/</code> (<code>buildBookmarkMarkdown :192&ndash;213</code>, written in the entries generator <code>:686&ndash;702</code>), rendered through the same <code>articleToMarkdown</code> path as the reader's Copy-Markdown.</li>
+<li><strong>JSONL</strong> — canonical re-importable data under <code>data/*.jsonl</code>: <code>bookmarks-&lt;year&gt;.jsonl</code> (sharded by year), <code>details.jsonl</code>, <code>highlights.jsonl</code>, <code>reading-progress.jsonl</code>, <code>today-queue-snapshots.jsonl</code>, <code>bookmark-queue-metadata.jsonl</code>, <code>today-queue-exposures.jsonl</code> (<code>:620&ndash;684</code>).</li>
+<li><strong>manifest.json</strong> — version, account id-hash, per-file SHA-256 checksums, counts, shard map (<code>:704&ndash;750</code>).</li>
+<li><strong>Zip mechanism</strong> — <strong>not</strong> <code>client-zip</code>. It uses a <strong>custom streaming zip</strong> in <code>src/lib/export/stream-zip.ts</code> (<code>makeZipEntriesStream</code>, consumed at <code>quick-export.ts:753</code>). Output streams straight to disk via the <strong>File System Access API</strong> (<code>window.showSaveFilePicker</code> &rarr; <code>createWritable</code> &rarr; <code>pipeTo</code>, <code>openWritable :284&ndash;301</code>), with a <code>Blob</code> + anchor-click fallback (<code>downloadBlob :303&ndash;312</code>) when the API is absent.</li>
+</ul>
+
+<p><strong>B) Per-article export</strong> (reader) — <code>src/lib/export/article-download.ts</code> + <code>src/components/reader/ArticleExportMenu.tsx</code>. Four actions on a single focal article/thread:</p>
+
+<ul>
+<li><strong>Copy for Agent</strong> (<code>articleToAgentMarkdown</code>), <strong>Copy Markdown</strong> (<code>articleToMarkdown</code>) &rarr; clipboard (<code>article-download.ts:62&ndash;80</code>).</li>
+<li><strong>Download Markdown</strong> &rarr; single <code>.md</code> Blob download (<code>downloadArticleMarkdown</code>/<code>downloadMarkdownFile :82&ndash;107</code>).</li>
+<li><strong>Print / Save PDF</strong> &rarr; renders print HTML into a hidden iframe and calls <code>window.print()</code> (<code>printArticleAsPdf :109&ndash;197</code>).</li>
+</ul>
+
+<h3>How export is triggered (entry points)</h3>
+
+<p>Only <strong>two</strong> UI entry points exist.</p>
+
+<ol>
+<li><strong><code>ExportModal</code></strong> (<code>src/components/ExportModal.tsx</code>). Opened from two places, both setting <code>exportOpen</code> in <code>App.tsx</code>:
+<ul>
+<li><code>NewTabHome</code> "Export" affordance &rarr; <code>onOpenExport</code> (<code>App.tsx:684</code>).</li>
+<li><code>SettingsModal</code> "Export" button &rarr; <code>onExport</code> (<code>App.tsx:706</code>; button at <code>SettingsModal.tsx:64,101</code>).</li>
+</ul>
+The modal offers <strong>Quick/Basic export</strong> (download ZIP now) and <strong>Full export</strong> (background-hydrate missing content first, then download). The click path: <code>handleStart</code> &rarr; <code>handleQuickExport</code> &rarr; <code>runQuickExport(account)</code> (<code>ExportModal.tsx:60&ndash;88</code>). Full export instead calls <code>getHydrationStore().getState().start()</code> (<code>:78&ndash;80</code>).</li>
+<li><strong><code>ArticleExportMenu</code></strong> (<code>src/components/reader/ArticleExportMenu.tsx</code>), rendered inside the reader's <code>ActionBar</code> (<code>src/components/reader/TweetContent.tsx:221&ndash;228</code>, props plumbed from <code>articleExport</code>). This is the per-article path (B above).</li>
+</ol>
+
+<h3>Code path: click &rarr; data read &rarr; file produced (ZIP)</h3>
+
+<pre><code>ExportModal.handleStart (ExportModal.tsx:82)
+  &rarr; handleQuickExport (:60)
+    &rarr; runQuickExport(account)  (quick-export.ts:561)
+        &rarr; openWritable(filename)                         // FS Access API or blob fallback (:284)
+        &rarr; Promise.all([
+            collectBookmarkMarkdownFiles(),              // iterateBookmarks() over IndexedDB (:457)
+            collectDetailSummary(),                      // iterateTweetDetails() (:413)
+            collectHighlightIds(), collectReadingProgressIds()
+          ])
+        &rarr; entries() async generator yields StreamZipEntry per file (:599)
+            // readme.md, bookmarks.csv, data/*.jsonl, bookmarks/*.md, manifest.json
+            // each text entry hashed via createSha256Hex (:372 hashingTextEntry)
+        &rarr; makeZipEntriesStream(entries())  (stream-zip.ts, :753)
+        &rarr; pipeTo(writable)  OR  new Response(stream).blob() &rarr; downloadBlob (:754&ndash;759)
+    &rarr; setQuickState({ phase: "done", result })           // counts shown in DoneView</code></pre>
+
+<p>All reads are local IndexedDB iterators (<code>src/db/index.ts</code>: <code>iterateBookmarks</code>, <code>iterateTweetDetails</code>, <code>getTweetDetailCache</code>, etc.). No network, no server — consistent with the local-first ethos.</p>
+
+<h3>Is there any gating today?</h3>
+
+<p><strong>No.</strong> The only preconditions anywhere are functional, not commercial:</p>
+
+<ul>
+<li><code>runQuickExport</code> requires a non-null <code>account</code> (<code>ExportModal.tsx:61</code>, <code>canExport = bookmarkCount &gt; 0 &amp;&amp; account !== null</code> <code>:157</code>). <code>account</code> is derived from <code>viewerProfile</code> in <code>App.tsx:713&ndash;717</code>.</li>
+<li><code>ArticleExportMenu</code> actions are always enabled.</li>
+<li>No <code>isPro</code>, <code>entitlement</code>, <code>license</code>, <code>paywall</code>, <code>upgrade</code>, or <code>checkout</code> symbol exists anywhere in <code>src/</code> or <code>apps/site/src/</code> (grep confirmed — the only "upgrade" hits are IndexedDB schema-version upgrades).</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">CLEAN SLATE</div> The codebase has no monetization machinery at all. Nothing to refactor, nothing to undo — just one boundary to add.</div>
+
+<h2 id="feature-inventory-gate-difficulty">Feature Inventory &amp; Gate Difficulty</h2>
+
+<table class="striped">
+<thead><tr><th>Feature</th><th>Entry-point component / file</th><th>User trigger</th><th>Gate difficulty</th><th>GTM tier</th></tr></thead>
+<tbody>
+<tr><td>New-tab queue / Today's Read</td><td><code>NewTabHome.tsx</code>, <code>useTodayQueue</code> (<code>hooks/useTodayQueue.ts</code>)</td><td>Open new tab</td><td>n/a (don't gate)</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Reading list (Unread / Continue / Read / Today tabs)</td><td><code>BookmarksList.tsx</code></td><td>"Reading" view</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Reader (article/thread render)</td><td><code>BookmarkReader.tsx</code>, <code>reader/TweetContent.tsx</code></td><td>Click a bookmark</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Sync (intercept + IndexedDB)</td><td><code>runtime-store.ts</code> <code>actions.refresh</code>, service worker</td><td>"Sync" button</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Basic in-library search (free text)</td><td><code>useBookmarkSearch.ts</code> &rarr; <code>lib/search.ts</code></td><td>Type in search box (<code>BookmarksList.tsx:301</code>)</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Web search box (Google/Bing/&hellip;)</td><td><code>NewTabHome.tsx:1147</code>, <code>SearchEnginePicker.tsx</code></td><td>Type + Enter</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td><strong>Export — library ZIP (CSV/MD/JSONL)</strong></td><td><code>ExportModal.tsx</code> &rarr; <code>quick-export.ts</code></td><td>Export button &rarr; "Download ZIP"</td><td><strong>Trivial</strong> (1 call site: <code>handleQuickExport</code>)</td><td><span class="tag">PRO</span></td></tr>
+<tr><td><strong>Export — Full export (deleted-tweet preservation)</strong></td><td><code>ExportModal.tsx</code> &rarr; <code>hydration-store.ts</code> <code>start()</code></td><td>"Start full export"</td><td><strong>Trivial</strong> (1 call site: <code>handleStartFullExport :78</code>)</td><td><span class="tag">PRO</span></td></tr>
+<tr><td><strong>Export — per-article (Download MD / Print PDF)</strong></td><td><code>ArticleExportMenu.tsx</code>, <code>article-download.ts</code></td><td>Reader menu</td><td><strong>Trivial</strong> (gate the 4 <code>on*</code> handlers in <code>TweetContent</code>)</td><td><span class="tag">PRO</span> (Copy-MD/Copy-Agent could stay free as a teaser)</td></tr>
+<tr><td>Import (re-import a Totem ZIP)</td><td><code>ImportModal.tsx</code> &rarr; <code>lib/import/run-import.ts</code></td><td>Import button</td><td>Trivial</td><td><span class="tag">FREE</span> (keeps data portability honest)</td></tr>
+<tr><td><strong>Advanced search filters</strong> (<code>from: tag: site: min_faves: has: is: since:</code> &hellip;)</td><td><code>lib/search/parser.ts</code>, <code>lib/search/executor.ts</code></td><td>Type operators in same box</td><td><strong>Medium</strong> (one box; must gate by parsed AST, not the box)</td><td><span class="tag">PRO</span></td></tr>
+<tr><td><strong>Annotations — highlights</strong></td><td><code>reader/SelectionToolbar.tsx</code>, <code>HighlightPopover.tsx</code> &rarr; <code>db.upsertHighlight</code></td><td>Select text &rarr; "Highlight"</td><td>Medium (gate <code>onHighlight</code> in <code>SelectionToolbar</code>)</td><td><span class="tag">PRO</span> (per GTM)</td></tr>
+<tr><td><strong>Annotations — notes</strong></td><td><code>reader/SelectionToolbar.tsx</code>, <code>NotePopover.tsx</code></td><td>Select text &rarr; "Add Note"</td><td>Medium (gate <code>onAddNote</code>)</td><td><span class="tag">PRO</span> (per GTM)</td></tr>
+<tr><td><strong>Bulk ops</strong></td><td><em>does not exist yet</em> (no multi-select anywhere; grep found none in <code>BookmarksList</code>)</td><td>&mdash;</td><td><strong>Hard</strong> (net-new selection UI)</td><td><span class="tag">PRO</span></td></tr>
+<tr><td><strong>Thread-aware capture</strong></td><td>partially exists: <code>hydration-store.ts</code> fetches <code>thread</code>, <code>tweet-export.ts</code> <code>buildSyntheticExportPlainText(includeThread)</code></td><td>implicit via Full export</td><td>Medium</td><td><span class="tag">PRO</span> (couple to Full export)</td></tr>
+<tr><td>Settings / theme / reset / delete-all</td><td><code>SettingsModal.tsx</code></td><td>Settings</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+</tbody>
+</table>
+
+<p><strong>Trivial</strong> = single call-site, value already in scope. <strong>Medium</strong> = call-site exists but must gate by intent (parsed query / specific button) not the whole surface. <strong>Hard</strong> = feature doesn't exist; gate is part of new construction.</p>
+
+<h2 id="proposed-pro-features-exists-vs-net-new">Proposed Pro Features — Exists vs Net-New</h2>
+
+<table class="striped">
+<thead><tr><th>Pro feature</th><th>Already in code?</th><th>File(s) that would host the gate</th></tr></thead>
+<tbody>
+<tr><td><strong>Export (MD/CSV/JSONL/ZIP)</strong></td><td><span class="tag">VERIFIED</span> <strong>EXISTS, complete.</strong> Full multi-format streaming ZIP + per-article MD/PDF.</td><td><code>ExportModal.tsx</code> (<code>handleQuickExport :60</code>); <code>reader/TweetContent.tsx</code> <code>ActionBar</code>/<code>ArticleExportMenu</code> handlers <code>:221</code>. Underlying <code>lib/export/*</code> left ungated.</td></tr>
+<tr><td><strong>Deleted-tweet caching / preservation</strong></td><td><span class="tag">VERIFIED</span> <strong>EXISTS.</strong> The "Full export" hydration engine (<code>src/stores/hydration-store.ts</code>) back-fills <code>TweetDetailCache</code> for every bookmark and explicitly classifies/persists deleted+protected tweets (<code>classifyError :116</code>, <code>cacheUnavailable</code>, <code>detailsStatus: "unavailable"</code>, <code>unavailableReason: "deleted" :132,213</code>). This <em>is</em> the preservation feature; it just isn't framed/sold as one.</td><td><code>ExportModal.tsx:78</code> (<code>handleStartFullExport</code>) and/or <code>hydration-store.ts</code> <code>start() :249</code>.</td></tr>
+<tr><td><strong>Bulk ops</strong></td><td><span class="tag">NET-NEW</span> No multi-select / batch-action UI exists in <code>BookmarksList.tsx</code> or anywhere (<code>bulk</code>/<code>selectAll</code>/<code>checkbox</code> grep is empty in components).</td><td>New code in <code>BookmarksList.tsx</code>; gate at the bulk-action dispatcher you build.</td></tr>
+<tr><td><strong>Advanced search filters</strong></td><td><span class="tag">VERIFIED</span> <strong>EXISTS, complete &amp; impressive.</strong> Full recursive-descent grammar with <code>from/to/tag/site/url/since/until/within/older_than/min_faves/min_retweets/min_replies/has/filter/is/lang</code> + AND/OR/NOT/quotes/parens (<code>lib/search/parser.ts</code>, <code>executor.ts:140&ndash;208</code>). Twitter-compatible aliases too.</td><td><code>useBookmarkSearch.ts</code> (or a wrapper) — detect operator nodes in the parsed AST and gate; keep plain free-text search free.</td></tr>
+<tr><td><strong>Annotations</strong></td><td><span class="tag">VERIFIED</span> <strong>EXISTS.</strong> Highlights (multi-color) and notes are fully built: <code>db.upsertHighlight</code>/<code>getHighlightsByTweetId</code> (<code>db/index.ts:840&ndash;880</code>), <code>SelectionToolbar.tsx</code>, <code>HighlightPopover.tsx</code>, <code>NotePopover.tsx</code>, <code>HighlightColorPicker.tsx</code>. They're even already exported in the ZIP (<code>highlights.jsonl</code>).</td><td><code>reader/SelectionToolbar.tsx</code> <code>onHighlight</code>/<code>onAddNote</code> callbacks <code>:128,131</code>, or the consuming reader component that passes them.</td></tr>
+<tr><td><strong>Thread-aware capture</strong></td><td><span class="tag">VERIFIED</span> <strong>MOSTLY EXISTS.</strong> Threads are fetched by hydration and rendered; export composes full threads (<code>tweet-export.ts:buildSyntheticExportPlainText(thread, includeThread) :152</code>, called with <code>includeThreadInExport: true</code> from <code>quick-export.ts:201</code>).</td><td>Naturally gated together with Full export / library export. No separate gate likely needed.</td></tr>
+</tbody>
+</table>
+
+<div class="takeaway"><div class="takeaway-label">5 OF 6 ALREADY BUILT</div> <span class="hl">5 of 6 proposed Pro features are already built and shipping for free.</span> Only <strong>bulk ops</strong> is net-new. Monetization here is overwhelmingly a <strong>gating/packaging exercise, not a build exercise</strong> — which makes a single clean entitlement boundary the highest-leverage piece of work.</div>
+
+<h2 id="cleanest-spot-for-a-single-reusable-gate">Cleanest Spot for a Single Reusable Gate</h2>
+
+<h3>Recommended pattern</h3>
+
+<p><strong>(a) Entitlement source — mirror <code>useSettings</code>.</strong> Settings already persist via <code>chrome.storage.sync</code> keyed by a constant (<code>useSettings.ts:104&ndash;141</code>, <code>SYNC_SETTINGS</code> from <code>lib/storage-keys.ts</code>), with a live <code>chrome.storage.onChanged</code> subscription. <strong>Clone this exactly</strong> for entitlement: add <code>SYNC_ENTITLEMENT</code> (or <code>LOCAL_ENTITLEMENT</code>) to <code>lib/storage-keys.ts</code>, and a <code>useEntitlement()</code> hook in <code>src/hooks/useEntitlement.ts</code> that reads/normalizes the stored license and re-renders on change. This keeps the proven storage/subscription pattern and stays server-optional (the unlock token is verified once and cached locally — fits the no-server ethos).</p>
+
+<p><strong>(b) Boundary — a <code>&lt;ProGate&gt;</code> component + a <code>requirePro(action)</code> wrapper.</strong> Put both in <code>src/components/ui/ProGate.tsx</code> (alongside <code>Modal</code>, <code>Button</code>). <code>&lt;ProGate&gt;</code> renders children for Pro users and a locked/upsell affordance otherwise; <code>requirePro(isPro, action, onUpsell)</code> wraps an imperative handler so a free user gets the upsell modal instead of the action. A single shared <code>&lt;UpgradeModal&gt;</code> (sibling of <code>ExportModal</code>/<code>ImportModal</code> in <code>App.tsx:708&ndash;725</code>, opened via a new <code>upgradeOpen</code> flag in <code>newTabRouteReducer :131</code>) gives every gate one consistent surface to point at.</p>
+
+<h3>Why this is the cleanest single insertion point</h3>
+
+<ul>
+<li><strong>Export already concentrates at <code>App.tsx</code>.</strong> <code>ExportModal</code> and <code>ImportModal</code> are both rendered there with <code>viewerProfile</code>/<code>account</code> already in scope (<code>App.tsx:708&ndash;725</code>). Adding <code>upgradeOpen</code> state + an <code>&lt;UpgradeModal&gt;</code> there means <span class="hl">one place owns the upsell surface</span> for the whole new-tab app.</li>
+<li><strong>Two export gates, both trivial.</strong> For the primary gate, wrap <code>handleQuickExport</code> (<code>ExportModal.tsx:60</code>) and <code>handleStartFullExport</code> (<code>:78</code>) with <code>requirePro(...)</code>. The <code>IdleView</code> primary button (<code>:299&ndash;306</code>) can additionally show a lock state by passing <code>isPro</code> down. No change to <code>lib/export/*</code> — the data layer stays clean and testable.</li>
+<li><strong>Reader gate is one prop hop.</strong> The per-article menu handlers are passed as a single <code>articleExport</code> prop object through <code>TweetContent.tsx:221</code>. Wrap those four <code>on*</code> functions (or just <code>onDownloadMarkdown</code>/<code>onPrintPdf</code>) once at the point they're constructed.</li>
+<li><strong>Search &amp; annotations reuse the same hook.</strong> <code>useBookmarkSearch</code> and <code>SelectionToolbar</code> can both call <code>useEntitlement()</code> and route to the same <code>&lt;UpgradeModal&gt;</code> — no second mechanism.</li>
+</ul>
+
+<h3>Concrete first slice (lowest-risk MVP gate)</h3>
+
+<ol>
+<li><code>lib/storage-keys.ts</code>: add <code>SYNC_ENTITLEMENT</code>.</li>
+<li><code>src/hooks/useEntitlement.ts</code>: <code>useEntitlement(): { isPro: boolean }</code> (copy <code>useSettings</code> shape).</li>
+<li><code>src/components/ui/ProGate.tsx</code>: <code>&lt;ProGate&gt;</code> + <code>requirePro()</code>.</li>
+<li><code>App.tsx</code>: add <code>upgradeOpen</code> to <code>NewTabRouteState</code>, render <code>&lt;UpgradeModal&gt;</code> next to <code>ExportModal</code>.</li>
+<li><code>ExportModal.tsx</code>: wrap <code>handleQuickExport</code>/<code>handleStartFullExport</code>; pass <code>isPro</code> into <code>IdleView</code> for lock styling.</li>
+</ol>
+
+<p>That single boundary covers the primary Pro gate (export) and is immediately reusable for full export/preservation, advanced search, and annotations — all of which already exist and just need the same <code>requirePro</code>/<code>&lt;ProGate&gt;</code> wrapper.</p>
+
+<h2 id="key-file-reference">Key File Reference</h2>
+
+<ul>
+<li><strong>Export (library ZIP):</strong> <code>src/lib/export/quick-export.ts</code>, <code>src/lib/export/stream-zip.ts</code>, <code>src/lib/export/tweet-export.ts</code>, <code>src/components/ExportModal.tsx</code></li>
+<li><strong>Export (per-article):</strong> <code>src/lib/export/article-download.ts</code>, <code>src/components/reader/ArticleExportMenu.tsx</code>, <code>src/components/reader/TweetContent.tsx:221</code></li>
+<li><strong>Deleted-tweet preservation:</strong> <code>src/stores/hydration-store.ts</code></li>
+<li><strong>Advanced search:</strong> <code>src/lib/search/parser.ts</code>, <code>src/lib/search/executor.ts</code>, <code>src/hooks/useBookmarkSearch.ts</code></li>
+<li><strong>Annotations:</strong> <code>src/components/reader/SelectionToolbar.tsx</code>, <code>HighlightPopover.tsx</code>, <code>NotePopover.tsx</code>, <code>src/db/index.ts:840&ndash;880</code></li>
+<li><strong>Wiring / proposed gate host:</strong> <code>src/App.tsx:684,706,708&ndash;725</code>; pattern to mirror: <code>src/hooks/useSettings.ts:104&ndash;141</code></li>
+</ul>
+<nav class="pager"><a class="pager-link prev" href="appendix-a-data-sync.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Data, Sync &amp; Entitlement Storage</span></a><a class="pager-link next" href="appendix-c-build-release.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Build &amp; Release Pipeline</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#export-today">Export Today</a>
+<a href="#feature-inventory-gate-difficulty">Feature Inventory & Gate Difficulty</a>
+<a href="#proposed-pro-features-exists-vs-net-new">Proposed Pro Features — Exists vs Net-New</a>
+<a href="#cleanest-spot-for-a-single-reusable-gate">Cleanest Spot for a Single Reusable Gate</a>
+<a href="#key-file-reference">Key File Reference</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-c-build-release.html
+++ b/plans/research/premium-monetization/site/appendix-c-build-release.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Build & Release Pipeline · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html" aria-current="page">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix C</div><h1 class="page-title">Build &amp; Release Pipeline</h1><p class="lead">The exact build, package, and Chrome Web Store release pipeline as it stands today — one artifact, one manifest, one zip — and the precise repo-mechanical changes a Pro/license-check feature would force, including the single preflight script that blocks any new permission. All paths are relative to repo root <code>/Users/ankit/Documents/make/totem</code>.</p>
+
+<h2 id="how-the-extension-is-built-and-packaged-today">How the extension is built and packaged today</h2>
+
+<h3>The single shippable artifact</h3>
+<p>There is exactly <strong>one</strong> shippable extension artifact: <code>release/totem-v&lt;version&gt;.zip</code>, produced from <code>dist/</code>. The <code>dist/</code> shape today:</p>
+<pre><code>dist/
+  manifest.json            # byte-identical copy of public/manifest.json (verified via diff)
+  service-worker.js        # ~48 KB IIFE bundle
+  newtab.html, reader.html # entry HTML
+  assets/
+    main.js (~1 MB), main.css (~120 KB), index.js, open-in-totem.js
+  content/
+    detect-user.js, mutation-hook.js   # copied verbatim from public/content/
+  icons/, wallpapers/, favicon*, rules.json</code></pre>
+<p>Key fact: <code>vite.config.ts</code> sets <strong>no explicit <code>publicDir</code></strong>, so Vite uses its default (<code>public/</code>) and copies everything under <code>public/</code> into <code>dist/</code> unprocessed. That is why <code>dist/manifest.json</code>, <code>dist/rules.json</code>, and <code>dist/content/*.js</code> are byte-identical copies of the <code>public/</code> source — they are static assets, <strong>not</strong> build outputs. <code>service-worker.js</code> and <code>assets/main.js</code> etc. ARE build outputs (Rollup/Vite).</p>
+
+<h3>The build graph (<code>vite.config.ts</code>)</h3>
+<p>Three things are bundled in one <code>vite build</code>:</p>
+<ul>
+<li><strong>Main app</strong> — <code>newtab.html</code> + <code>reader.html</code> as Rollup inputs &rarr; <code>assets/[name].js</code> (ES modules, <code>base: "./"</code> for relative paths inside the extension).</li>
+<li><strong>Service worker</strong> — <code>serviceWorkerPlugin()</code> runs a <em>second</em> nested <code>viteBuild()</code> in <code>closeBundle()</code> that compiles <code>src/service-worker/index.ts</code> &rarr; <code>service-worker.js</code> as a single <strong>IIFE</strong> (MV3 service workers can't be ES modules unless <code>"type":"module"</code> is set in the manifest background block, which it is not — so IIFE is required).</li>
+<li><strong>Content script</strong> — <code>contentScriptPlugin()</code> compiles <code>src/content/open-in-totem.ts</code> &rarr; <code>assets/open-in-totem.js</code> as IIFE. (The MAIN-world <code>mutation-hook.js</code> and <code>detect-user.js</code> are hand-written static files in <code>public/content/</code>, not part of the TS build.)</li>
+<li><strong>Version injection</strong> — <code>define: { __TOTEM_APP_VERSION__: JSON.stringify(appVersion) }</code> reads <code>package.json.version</code> at config-eval time and inlines it as a global. Declared in <code>src/vite-env.d.ts</code>; consumed in <code>src/lib/export/quick-export.ts:35</code>. This is the existing precedent for compile-time constant injection — <span class="hl">the same <code>define</code> mechanism is the cleanest place to inject a license public key.</span></li>
+</ul>
+
+<h3>The full pipeline, command by command</h3>
+<p>From <code>package.json</code> scripts:</p>
+<pre><code>pnpm build:extension   = pnpm typecheck &amp;&amp; vite build      # tsc --noEmit, then build
+pnpm package:extension = pnpm build:extension &amp;&amp; node scripts/package-extension.mjs</code></pre>
+<p><code>scripts/package-extension.mjs</code>:</p>
+<ol>
+<li>Asserts <code>dist/</code> and <code>dist/manifest.json</code> exist (fails if you didn't build).</li>
+<li>Reads <code>version</code> from <code>dist/manifest.json</code>.</li>
+<li><code>zip -r -q release/totem-v&lt;version&gt;.zip .</code> run with <code>cwd: dist</code> (shells out to the system <code>zip</code> binary — a host dependency, not a JS lib).</li>
+</ol>
+<p>So the literal chain is: <strong>typecheck &rarr; vite build &rarr; copy public/&rarr;dist/ &rarr; zip dist/ &rarr; release/totem-v&lt;version&gt;.zip</strong>. Upload to CWS is <strong>manual</strong> (drag-zip into the developer dashboard) per <code>PUBLISH.md</code>; there is no automated CWS upload step. The GitHub release workflow only publishes the zip as a GitHub Release <strong>asset</strong>, not to the Web Store.</p>
+
+<h3>Release orchestration &amp; versioning sync</h3>
+<p>Two-file version sync is enforced in three places:</p>
+<ul>
+<li><code>scripts/check-version-sync.mjs</code> (<code>pnpm release:version:check</code>) — hard-fails if <code>package.json.version !== public/manifest.json.version</code>.</li>
+<li><code>scripts/prepare-release.mjs</code> (<code>pnpm release:prepare</code>) — bumps <strong>both</strong> files together, regenerates <code>CHANGELOG.md</code> from filtered git subjects, then runs <code>release:version:check</code> + <code>package:extension</code>.</li>
+<li><code>scripts/release.mjs</code> (<code>pnpm release</code> / <code>ship</code>) — guards (must be on <code>main</code>, clean tree), runs prepare, commits the 3 files, pushes <code>main</code>, creates+pushes <code>v&lt;version&gt;</code> tag.</li>
+</ul>
+<p>The tag push triggers <code>.github/workflows/release-extension.yml</code>: install &rarr; <code>pnpm test:reliability</code> &rarr; <code>pnpm test</code> &rarr; <code>pnpm verify:workspace</code> &rarr; <code>pnpm release:check</code> (<code>release:version:check</code> + <code>package:extension</code>) &rarr; assert <code>tag == dist/manifest.json.version</code> &rarr; upload <code>release/*.zip</code> to the GitHub Release. CI (<code>ci.yml</code>) runs <code>pnpm ci:verify</code> = <code>test &amp;&amp; build &amp;&amp; verify:workspace &amp;&amp; audit:prod</code> on every PR/push.</p>
+
+<div class="callout"><code>scripts/verify-cws-featured-readiness.mjs</code> (<code>pnpm cws:featured:preflight</code>) is a strict gate that <strong>hard-pins the manifest</strong>: it asserts the exact <code>permissions</code> array <code>[storage, webRequest, declarativeNetRequest, scripting, cookies]</code>, the exact <code>optional_permissions</code> <code>[topSites, favicon, search]</code>, and that <code>host_permissions</code> is <strong>exactly</strong> <code>["https://x.com/*"]</code> with length 1. Any new permission or host added for licensing will fail this preflight until the script is updated — the single most important repo-mechanical blocker to know about.</div>
+
+<h2 id="manifest-implications-of-adding-payments-licensing">Manifest implications of adding payments/licensing</h2>
+<p>Current relevant manifest state (<code>public/manifest.json</code>):</p>
+<ul>
+<li><code>permissions</code>: <code>storage, webRequest, declarativeNetRequest, scripting, cookies</code></li>
+<li><code>host_permissions</code>: <code>["https://x.com/*"]</code> only</li>
+<li>CSP (<code>content_security_policy.extension_pages</code>): <code>script-src 'self'; object-src 'self'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.twimg.com; media-src 'self' https://*.twimg.com</code></li>
+</ul>
+
+<h3>The MV3 "no remotely-hosted code" rule — the core constraint</h3>
+<p>Under MV3, <strong>all executable code must ship inside the package</strong>. License validation therefore must be a <span class="hl">pure data exchange</span>: the extension may <code>fetch()</code> JSON (a license token, an entitlement boolean, a signed receipt) from an endpoint, but it may <strong>not</strong> download and <code>eval</code>/inject any script, and it may <strong>not</strong> load a remote payment-provider SDK <code>&lt;script&gt;</code>. This rules out the common web pattern of dropping in <code>js.stripe.com/v3</code> or a Paddle/Lemon Squeezy overlay script. Two compliant shapes:</p>
+<ul>
+<li><span class="tag">RECOMMENDED</span> <strong>No in-extension checkout.</strong> Checkout happens on the web (a <code>usetotem.xyz/pro</code> page or the provider's hosted checkout, opened in a normal tab). The extension only ever does a <code>fetch()</code> to verify/retrieve an entitlement. The package contains zero payment SDK code. This keeps <code>script-src 'self'</code> untouched and is the cleanest MV3 posture.</li>
+<li><span class="tag">ACCEPTABLE</span> Bundle a provider's <em>client</em> library into <code>assets/main.js</code> at build time (npm dependency, compiled by Vite) and call its REST API. Still data-only at runtime; still <code>script-src 'self'</code>.</li>
+</ul>
+<p><code>script-src</code> should stay <code>'self'</code>. <strong>Do not</strong> add any host to <code>script-src</code>.</p>
+
+<h3>What must change for an outbound license fetch</h3>
+<p>A license check that calls an external endpoint needs <strong>two</strong> manifest additions:</p>
+<ol>
+<li><strong><code>host_permissions</code></strong> — add the license/verify origin, e.g. <code>"https://api.usetotem.xyz/*"</code> (a tiny first-party verify endpoint) or the provider's API origin (e.g. <code>"https://api.lemonsqueezy.com/*"</code>). Without this, <code>fetch()</code> from the extension is blocked by host-permission policy. Prefer a <strong>single, narrow, first-party</strong> origin you control — far easier to justify to reviewers than a third-party payment API, and it lets you swap providers without a manifest change/re-review.</li>
+<li><strong>CSP <code>connect-src</code></strong> — the extension's CSP currently has <strong>no <code>connect-src</code> directive</strong>, so it inherits the default and outbound <code>fetch</code>/XHR is governed by host_permissions plus the default <code>connect-src</code>. To be explicit and safe, add a <code>connect-src</code> listing exactly the verify origin (and keep <code>'self'</code>), e.g.:
+<pre><code>connect-src 'self' https://api.usetotem.xyz;</code></pre>
+Today's <code>fetch</code> to <code>x.com</code> works because <code>https://x.com/*</code> is in <code>host_permissions</code> and there is no restrictive <code>connect-src</code>. Once you add an explicit <code>connect-src</code>, you must list <strong>every</strong> origin the extension talks to (x.com, twimg via img/media already covered, and the new verify origin), or you'll break existing network calls. Safest minimal change: add the <code>host_permissions</code> entry + a <code>connect-src</code> including <code>'self'</code>, <code>https://x.com</code>, and the verify origin.</li>
+<li><strong><code>optional_host_permissions</code></strong> (strongly recommended posture) — instead of a static <code>host_permissions</code> grant, declare the verify origin under <code>optional_host_permissions</code> and request it at runtime only when the user actually upgrades. This keeps the default install footprint identical to today (helps CWS review and user trust), and means free users never grant a payment-related host. Trade-off: slightly more runtime code (<code>chrome.permissions.request</code>).</li>
+</ol>
+
+<h3>Permission additions to avoid</h3>
+<ul>
+<li><strong>Do not</strong> add <code>identity</code> / OAuth unless you truly need Google sign-in for accounts — it contradicts the "no account" ethos and adds review friction. A one-time license key (paste-a-key or deep-link redemption) avoids it entirely.</li>
+<li><strong>Do not</strong> broaden to <code>&lt;all_urls&gt;</code> or wildcard hosts. The narrower the better; <code>verify-cws-featured-readiness.mjs</code> and the local-first story both depend on a tight host list.</li>
+</ul>
+
+<h2 id="build-time-secrets-env-injection">Build-time secrets &amp; env injection</h2>
+
+<h3>Current state</h3>
+<p>There is <strong>no <code>.env</code> anywhere</strong> (confirmed: no <code>.env*</code> files outside node_modules), and <code>.gitignore</code> already ignores <code>*.local</code> and <code>dist</code>/<code>release</code>. The only compile-time constant today is <code>__TOTEM_APP_VERSION__</code>, injected via Vite <code>define</code>. <code>import.meta.env</code> is used only for <code>import.meta.env.DEV</code> test-guards (<code>src/api/core/posts.ts</code>). So there is currently <strong>no env-injection plumbing</strong> — it must be added.</p>
+
+<h3>What a license check needs at build time, and where it lives</h3>
+<p>Critical distinction for a one-time-license model:</p>
+<ul>
+<li>The <strong>provider validate endpoint URL</strong> (and any publishable product/store id) is <strong>non-secret by design</strong> — safe to commit and safe to inline. The shipped design needs no client-side secret at all: the provider's license <strong>validate</strong> endpoint is documented as safe to call from a public client, so the extension sends only the key (the provider's <em>secret</em> API key stays server-side). <em>(An earlier exploration embedded an Ed25519 public key for offline signature verification — see Appendix G's decision note for why that was set aside.)</em></li>
+<li>A <strong>provider publishable key</strong> (e.g. a Stripe/Lemon Squeezy <em>publishable</em> key) is also non-secret and can be inlined, but is only relevant if checkout happens in-extension — which §2.1 recommends against.</li>
+<li>A <strong>provider secret key / signing private key</strong> must <strong>NEVER</strong> be in the extension build. The extension ships to users' machines; anything in <code>dist/</code> is fully readable. The private signing key lives only on the server / in CI secrets for the server, never in this repo's build.</li>
+</ul>
+
+<h3>How to inject it (matching existing patterns)</h3>
+<p>Two viable mechanisms, in order of preference:</p>
+<ol>
+<li><strong>Vite <code>define</code></strong> (matches <code>__TOTEM_APP_VERSION__</code> exactly): add <code>__TOTEM_LICENSE_PUBLIC_KEY__: JSON.stringify(process.env.TOTEM_LICENSE_PUBLIC_KEY ?? &lt;committed-default&gt;)</code> in <code>vite.config.ts</code>, declare it in <code>src/vite-env.d.ts</code>. Because the key is public, the simplest correct choice is to <span class="hl">commit the public key as a constant</span> and skip env entirely — no secret-management surface, reproducible builds, and CI needs no new secrets.</li>
+<li><strong><code>import.meta.env</code> via <code>VITE_</code> prefix</strong> — Vite auto-exposes <code>VITE_</code>-prefixed env vars to client code. Would require adding a <code>.env</code>/<code>.env.production</code> (gitignored) and a CI env var. Only worth it if the injected value is environment-specific (e.g. a staging vs prod verify URL).</li>
+</ol>
+<div class="takeaway"><div class="takeaway-label">MUST NOT ENTER dist/</div> Any private signing key, provider secret API key, webhook signing secret, or admin token. None belong in the extension build — they live in the separate license-server / payment-webhook deployment. If a per-build secret is ever introduced, add it to <code>.gitignore</code> (e.g. <code>.env.production</code>) and to GitHub Actions repo secrets for the build job; <code>release-extension.yml</code> passes no secrets to the build today, so a secret would need an explicit <code>env:</code> block.</div>
+
+<h2 id="cws-review-policy-friction-a-payment-integration-adds">CWS review / policy friction a payment integration adds</h2>
+<p>The repo already has a heavy compliance apparatus (<code>PUBLISH.md</code>, <code>plans/chrome-web-store-listing.md</code>, <code>plans/chrome-web-store-dashboard-update-packet.md</code>, the featured-readiness verifier). Payments add the following on top:</p>
+<ol>
+<li><strong>New permission justifications.</strong> Each added permission/host needs a written justification in the CWS dashboard (the pattern is already established in <code>PUBLISH.md</code> lines 83–94). For a new verify host: <em>"Validates a one-time Pro license by fetching an entitlement token from our own endpoint; no browsing data is sent, only an opaque license key."</em> If using <code>optional_host_permissions</code>, note it is requested only at upgrade time.</li>
+<li><strong>Single-purpose policy.</strong> CWS requires one narrow purpose. Adding <em>payment/account</em> features risks a reviewer reading it as a second purpose. Mitigation: frame Pro as the <strong>same</strong> purpose (reading/searching/exporting your bookmarks) with more capability, not a new product. License redemption is configuration, not a separate feature surface.</li>
+<li><strong>Privacy-practices disclosure update.</strong> The dashboard "Privacy practices" tab (today certifies <em>no data sold, all local</em> — <code>PUBLISH.md</code> 97–104) must be updated: a license check transmits the <strong>license key</strong> (and possibly an extension-instance id) to your endpoint. You must (a) disclose this data flow, (b) keep the "no analytics/telemetry, no third-party tracking" claims true, (c) ensure the privacy policy at <code>usetotem.xyz/privacy/</code> (referenced by <code>verify-cws-featured-readiness.mjs</code>) is updated to describe license validation. The local-first claim in the store description (<code>"no Totem account, no server"</code>) becomes <strong>literally false</strong> the moment a verify endpoint exists — the listing copy and <code>manifest.description</code> (which the preflight pins to an exact string) must be reworded (e.g. "no account required; bookmarks stay on-device" rather than "no server").</li>
+<li><strong>"Paid features must work" / no deceptive behavior.</strong> CWS disallows charging for things that don't function and requires clear disclosure of paid features. The store listing should state Pro is a paid upgrade and what it unlocks.</li>
+<li><strong>Remotely-hosted-code rejection risk.</strong> If any payment-provider <code>&lt;script&gt;</code> or remote SDK is loaded, near-automatic rejection. Keep it data-only.</li>
+</ol>
+<p><strong>Pipeline additions required:</strong></p>
+<ul>
+<li>Update <code>scripts/verify-cws-featured-readiness.mjs</code> to allow the new host/permission (otherwise <code>cws:featured:preflight</code> and the release flow that depends on a clean manifest will fail).</li>
+<li>Update <code>PUBLISH.md</code> permission-justification list and the dashboard packet doc with the new entries.</li>
+<li>Update the privacy policy page + the pinned <code>manifest.description</code> / listing copy.</li>
+<li>Add a build-time check (optional but wise) asserting no secret-looking strings (private keys) leaked into <code>dist/</code> before zipping — a grep guard in <code>package-extension.mjs</code>.</li>
+</ul>
+
+<h2 id="one-build-runtime-gated-vs-separate-free-pro-builds">One build (runtime-gated) vs separate Free/Pro builds</h2>
+<div class="takeaway"><div class="takeaway-label">RECOMMENDATION</div> ONE build, entitlement-gated at runtime. Strongly.</div>
+<p>Reasoning grounded in the current pipeline:</p>
+<ol>
+<li><strong>The pipeline is architecturally single-artifact.</strong> Versioning (<code>check-version-sync</code>, <code>prepare-release</code>), packaging (<code>package-extension.mjs</code> reads one <code>dist/manifest.json</code>, produces one <code>totem-v&lt;version&gt;.zip</code>), the release workflow (uploads <code>release/*.zip</code>, validates one tag&harr;manifest version), and the featured-readiness verifier (pins one manifest) all assume exactly one artifact. A second "Pro" build would mean forking version sync, doubling the zip step, duplicating the manifest pin, and managing two CWS listings — a large pipeline rewrite for no user benefit.</li>
+<li><strong>CWS distributes one item.</strong> A free-on-store extension that unlocks Pro is the standard, frictionless model: one listing, one review, one ID (<code>acpkgdfhoaalmnhjifhneghcgfnjkglo</code>, pinned in the verifier). Separate builds imply either two store items (more review surface, confusing) or sideloaded Pro builds (kills the "install from the Web Store" UX and breaks auto-update).</li>
+<li><strong>The gating surface already exists locally.</strong> State lives in Zustand + <code>chrome.storage.local</code> and IndexedDB. An entitlement flag (<code>isPro</code>) fits naturally as another stored value, checked at the boundaries of the Pro features. The Pro-gated capabilities are already discrete modules — export lives entirely in <code>src/lib/export/*</code> (e.g. <code>quick-export.ts</code>, <code>tweet-export.ts</code>, <code>stream-zip.ts</code>, <code>article-to-markdown.ts</code>), so gating is a small set of guard checks, not a build-time code split. There is no per-build code difference to justify two artifacts.</li>
+<li><strong>No secret needs to differ per build.</strong> The license check is an <strong>online validate</strong> call that needs no client-side secret (the provider's secret key stays server-side), so both free and pro users run identical code; the only difference is whether a valid, validated license is cached in storage. Code is identical, entitlement is data.</li>
+<li><strong>Optional-permission hygiene reinforces one build.</strong> With <code>optional_host_permissions</code> for the verify origin, the default install is byte-identical in footprint to today's free experience; the payment host is only requested when a user upgrades. One manifest, one build, graceful free path.</li>
+</ol>
+<div class="callout"><strong>Net:</strong> ship one zip; add an <code>isPro</code> entitlement resolved from a cached online-validate result; gate <code>src/lib/export/*</code> (and the other Pro modules) behind it; do not fork the build/release pipeline.</div>
+
+<h2 id="concrete-change-checklist-if-when-implemented">Concrete change checklist (if/when implemented)</h2>
+<table>
+<thead><tr><th>File / target</th><th>Change</th></tr></thead>
+<tbody>
+<tr><td><code>vite.config.ts</code></td><td>Add <code>__TOTEM_LICENSE_VALIDATE_URL__</code> (+ publishable product/store id) to <code>define</code> (or just commit a constant — these are public; no secret).</td></tr>
+<tr><td><code>src/vite-env.d.ts</code></td><td>Declare the new global.</td></tr>
+<tr><td><code>public/manifest.json</code></td><td>Add verify origin to <code>optional_host_permissions</code> (preferred) or <code>host_permissions</code>; add explicit <code>connect-src 'self' https://x.com https://api.usetotem.xyz</code> to the CSP; reword <code>description</code> away from "no server".</td></tr>
+<tr><td><code>scripts/verify-cws-featured-readiness.mjs</code></td><td>Loosen the manifest pins to permit the new host/permission and the new description string.</td></tr>
+<tr><td><code>PUBLISH.md</code> + <code>plans/chrome-web-store-dashboard-update-packet.md</code></td><td>Add permission justification + privacy disclosure for license validation.</td></tr>
+<tr><td><code>usetotem.xyz/privacy/</code></td><td>Document the license-key data flow.</td></tr>
+<tr><td><code>scripts/package-extension.mjs</code></td><td>(optional) Add a guard grepping <code>dist/</code> for private-key patterns before zipping.</td></tr>
+<tr><td>Dependency</td><td><strong>None.</strong> Online validate is a plain <code>fetch</code> — no on-device crypto, so <code>@noble/ed25519</code> is not added.</td></tr>
+</tbody>
+</table>
+<nav class="pager"><a class="pager-link prev" href="appendix-b-features-export.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Features &amp; Export Surface</span></a><a class="pager-link next" href="appendix-d-site-distribution.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Site &amp; Distribution</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#how-the-extension-is-built-and-packaged-today">How the extension is built and packaged today</a>
+<a href="#manifest-implications-of-adding-payments-licensing">Manifest implications of adding payments/licensing</a>
+<a href="#build-time-secrets-env-injection">Build-time secrets & env injection</a>
+<a href="#cws-review-policy-friction-a-payment-integration-adds">CWS review / policy friction a payment integration adds</a>
+<a href="#one-build-runtime-gated-vs-separate-free-pro-builds">One build (runtime-gated) vs separate Free/Pro builds</a>
+<a href="#concrete-change-checklist-if-when-implemented">Concrete change checklist (if/when implemented)</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-d-site-distribution.html
+++ b/plans/research/premium-monetization/site/appendix-d-site-distribution.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Site & Distribution · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html" aria-current="page">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix D</div><h1 class="page-title">Site &amp; Distribution</h1><p class="lead">The marketing site at <code>apps/site/</code> is a 100% static Astro build deployed to Vercel with no adapter and no server runtime. As shipped it cannot host a license-issuing or verification endpoint — the funnel must lean on a merchant-of-record while the site stays pure static.</p>
+
+<h2 id="site-architecture-build-and-deploy">Site architecture, build, and deploy</h2>
+
+<p>The Astro config at <code>apps/site/astro.config.mjs</code> sets <code>site: "https://usetotem.xyz"</code>, <span class="hl"><code>output: "static"</code> (line 10)</span>, <code>outDir: "../../dist-website"</code> (line 11), <code>trailingSlash: "ignore"</code>, <code>build.format: "directory"</code>, and <code>build.assets: "assets"</code>. Integrations are <code>@astrojs/react</code> (React 19 islands), <code>@astrojs/sitemap</code> (with a <code>filter</code>/<code>serialize</code> that excludes <code>/uninstall-feedback/</code> and sets per-page <code>changefreq</code>/<code>priority</code>), and <code>@tailwindcss/vite</code>. The Markdown pipeline is <code>remark-gfm</code> plus a custom rehype plugin <code>rehypeBlogLinks</code> (see the SEO section), footnotes labeled "Sources", and <code>smartypants: true</code>.</p>
+
+<div class="callout"><strong>No Astro adapter is configured and none is installed.</strong> <code>find src/pages -name "*.ts" -o -name "*.js"</code> returns nothing (no Astro endpoints / API routes); <code>node_modules/@astrojs/vercel</code> is absent; there is no <code>middleware.*</code> file. This is a pure static-site-generator setup.</p></div>
+
+<p>The package <code>apps/site/package.json</code> is named <code>@totem/site</code>, with deps <code>astro ^5.18.2</code>, <code>@astrojs/react ^4.4.2</code>, <code>@astrojs/sitemap</code>, <code>tailwindcss v4</code>, <code>remark-gfm</code>, and <code>unist-util-visit</code>. Scripts: <code>dev</code> / <code>build</code> / <code>preview</code> / <code>check</code> (<code>astro check</code>). It is a workspace package; the root <code>package.json</code> drives it via <code>pnpm build:website</code> (<code>pnpm --filter @totem/site build</code>) and <code>pnpm package:website</code>.</p>
+
+<h3>How pages are authored</h3>
+
+<p>Two patterns live under <code>apps/site/src/pages/</code>. The first is <strong>Astro pages wrapping a shared layout</strong>, each importing <code>BaseLayout.astro</code> and passing SEO props:</p>
+
+<ul>
+<li><code>index.astro</code> — landing; reads root <code>package.json</code> version, pulls 3 recent blog posts via <code>getCollection("blog")</code>, injects <code>SoftwareApplication</code> JSON-LD (currently <code>offers.price: "0"</code>, <code>isAccessibleForFree: true</code> — this JSON-LD will need updating when a paid tier ships), and renders the <code>&lt;LandingPage&gt;</code> React island.</li>
+<li><code>privacy.astro</code> → <code>&lt;PrivacyPage&gt;</code> island; <code>how-it-works.astro</code>; <code>demo.astro</code> → <code>&lt;DemoNewTabApp client:only="react"&gt;</code> with <code>showChrome={false}</code>.</li>
+<li><code>export-format/v1.astro</code> — a fully hand-authored long-form HTML doc page (no React island). <strong>This is the best template to copy for a new <code>/pricing</code> or <code>/manage-license</code> static content page</strong> — it shows the prose/article pattern, the in-page TOC, and <code>BaseLayout</code> SEO wiring.</li>
+<li><code>uninstall-feedback.astro</code> — <strong>the closest existing precedent for a "form" page.</strong> It is a static page with a <code>&lt;form&gt;</code>, a client <code>&lt;script&gt;</code> that assembles a <code>mailto:</code>/Gmail compose URL, and <code>robots="noindex, follow"</code>. It demonstrates an interactive page with no backend (everything client-side or handed off to an external service). A "paste your license key" page would follow exactly this shape.</li>
+</ul>
+
+<p>The second pattern is <strong>content collections</strong> for the blog: <code>src/content.config.ts</code> defines a <code>blog</code> collection via <code>glob({ pattern: "**/*.md", base: "./src/content/blog" })</code> with a Zod schema (<code>title</code>, <code>slug?</code>, <code>description</code>, <code>publishedAt?</code>, <code>draft?</code>, <code>canonicalKeyword?</code>). Markdown files live in <code>src/content/blog/*.md</code> and render through <code>src/pages/blog/[slug].astro</code> (<code>getStaticPaths</code> + <code>render(post)</code>), plus <code>src/pages/blog/index.astro</code> for the list.</p>
+
+<h3>Layout &amp; shared chrome</h3>
+
+<p><code>src/layouts/BaseLayout.astro</code> is the single SEO/HTML shell. Props: <code>title</code>, <code>description</code>, <code>canonical</code>, <code>og</code>, <code>twitter</code>, <code>spaceGrotesk</code>, <code>embedGuardGa</code>, <code>showChrome</code>, <code>page</code>, <code>bodyClass</code>, <code>robots</code>. It renders <code>&lt;head&gt;</code> (fonts via Google Fonts, canonical, OG/Twitter, Organization+WebSite JSON-LD), then conditionally wraps content with <code>SiteHeader</code> + <code>SiteFooter</code> when <code>showChrome</code> is true. It also inlines the Google Analytics (gtag <code>G-VBKV6TVM6W</code>) loader — an <code>embedGuardGa</code> variant suppresses GA inside iframes/<code>?embed</code>.</p>
+
+<p>Under <code>src/components/</code> sit <code>SiteHeader.astro</code>, <code>SiteFooter.astro</code>, <code>Favicon.astro</code>, and <code>BlogPostCta.astro</code>. The header/footer pull all copy and links from <code>src/react/site-content.ts</code>. React islands live in <code>src/react/SiteApp.tsx</code> (exports <code>LandingPage</code>, <code>PrivacyPage</code>, <code>HowItWorksPage</code>) and <code>src/react/demo/</code>. Site copy/config is centralized in <span class="hl"><code>src/react/site-content.ts</code></span> — the single source of truth for <code>SITE_LINKS</code>, <code>SITE_COPY</code>, install URLs, and feature blurbs.</p>
+
+<h3>Build &amp; deploy on Vercel</h3>
+
+<p><code>vercel.json</code> at the repo root sets <code>framework: "astro"</code>, <code>installCommand: "pnpm install --frozen-lockfile"</code>, <strong><code>buildCommand: "pnpm build:website"</code></strong>, <strong><code>outputDirectory: "dist-website"</code></strong>, <code>cleanUrls: true</code>, and <code>trailingSlash: false</code>. There is one redirect: <code>/website/:path*</code> → <code>/:path*</code> (temporary).</p>
+
+<p>Because <code>output: "static"</code> plus no adapter, Vercel serves <code>dist-website/</code> as <strong>static files on the CDN only</strong>. There is no Vercel Functions deployment from this project today. The <code>cleanUrls</code>/redirects/headers in <code>vercel.json</code> are the only "server-ish" config, and they are edge/CDN config, not compute.</p>
+
+<div class="takeaway"><div class="takeaway-label">STATIC-SITE CONSTRAINT</div> The site can serve static HTML/CSS/JS and CDN-level redirects, but it cannot run server endpoints or Vercel Functions as configured. To host a license endpoint <em>here</em> you would need to <code>npm i @astrojs/vercel</code>, set <code>output: "server"</code> or <code>"hybrid"</code>, add <code>adapter: vercel()</code>, and write Astro endpoints under <code>src/pages/api/*.ts</code> — introducing a server runtime, secrets management (signing key), and a DB/KV for license records, which breaks "no Totem server" purity.</div>
+
+<p>The recommended alternative is a <span class="hl">merchant-of-record SaaS</span> (Gumroad / Lemon Squeezy / Polar) that issues and verifies license keys via <em>their</em> API/webhooks, leaving this site static. License <em>verification</em> in the extension can then be a stateless signed-token check or a call to the MoR's verify API from the extension itself.</p>
+
+<h2 id="where-the-purchase-funnel-pages-live">Where the purchase-funnel pages live</h2>
+
+<p>All new pages slot into <code>apps/site/src/pages/</code> and reuse <code>BaseLayout.astro</code> + <code>SiteHeader</code>/<code>SiteFooter</code>. Concrete placement:</p>
+
+<table>
+<thead><tr><th>Page</th><th>File &amp; path</th><th>Reuse / template</th></tr></thead>
+<tbody>
+<tr><td><strong>Pricing</strong></td><td><code>src/pages/pricing.astro</code> → <code>/pricing</code></td><td>New React island in <code>SiteApp.tsx</code> <em>or</em> hand-authored like <code>export-format/v1.astro</code>. Add <code>"pricing"</code> to the <code>SitePageKey</code> union in <code>BaseLayout.astro</code> and the <code>page</code> prop type in <code>SiteHeader.astro</code>/<code>SiteFooter.astro</code>. Add a nav link in <code>SiteFooter.astro</code> (and header CTA copy in <code>site-content.ts</code>).</td></tr>
+<tr><td><strong>Checkout entry</strong></td><td>Usually not a page</td><td>The "Buy" button links out to the MoR hosted checkout (Gumroad/Lemon Squeezy/Polar overlay or hosted page). The button lives on <code>pricing.astro</code> (and optionally a CTA in <code>BlogPostCta.astro</code>). If an overlay widget is used, it is a <code>&lt;script&gt;</code> island on <code>pricing.astro</code>.</td></tr>
+<tr><td><strong>Post-purchase / license delivery</strong></td><td><code>src/pages/upgrade/success.astro</code> → <code>/upgrade/success</code></td><td>Set <code>robots="noindex, follow"</code> like <code>uninstall-feedback.astro</code>. The MoR's <code>success_url</code> redirects here with the license key/token in the query string; a client <code>&lt;script&gt;</code> reads <code>location.search</code>, displays the key, offers "copy" and a deep-link button back into the extension. Pure client-side — no backend.</td></tr>
+<tr><td><strong>Manage license</strong></td><td><code>src/pages/manage-license.astro</code> → <code>/manage-license</code> (or <code>/license</code>)</td><td>Static page with a "paste your key" form + "verify"/"check status" that calls the MoR verify API client-side (or links to the MoR's customer portal). Pattern mirrors <code>uninstall-feedback.astro</code> (static page + client <code>&lt;script&gt;</code>, no server).</td></tr>
+</tbody>
+</table>
+
+<p>Components and layouts to reuse directly:</p>
+
+<ul>
+<li><code>BaseLayout.astro</code> for every page (SEO, OG, GA, header/footer).</li>
+<li><code>BlogPostCta.astro</code> is the model for a reusable "Upgrade to Pro" CTA card — it already does UTM-decorated CTA URLs derived from <code>SITE_LINKS.installUrl</code>.</li>
+<li><code>uninstall-feedback.astro</code> for any <strong>form + client-script, no-backend</strong> page (success page, paste-a-key page).</li>
+<li><code>export-format/v1.astro</code> for <strong>long-form static content</strong> (a detailed pricing/FAQ/feature-comparison page).</li>
+<li>Centralize all new URLs (checkout URL, success URL, manage URL, MoR product IDs) in <code>src/react/site-content.ts</code> under <code>SITE_LINKS</code>, matching the existing <code>chromeWebStoreInstallUrl</code>/<code>installUrl</code> pattern.</li>
+</ul>
+
+<h2 id="extension-site-handoff">Extension ↔ site handoff</h2>
+
+<h3>What exists today (one-directional, marketing-only)</h3>
+
+<p><strong>Site → extension (install):</strong> Everything funnels to the Chrome Web Store. <code>site-content.ts</code> defines <code>chromeWebStoreListingUrl = https://chromewebstore.google.com/detail/acpkgdfhoaalmnhjifhneghcgfnjkglo</code> and <code>chromeWebStoreInstallUrl</code> = that listing + <code>?utm_source=usetotem.xyz&amp;utm_medium=referral&amp;utm_campaign=site_install</code>. <code>installUrl</code> resolves to the CWS install URL (falling back to <code>github.com/nnnkit/totem/releases/latest</code> only if the CWS URL were empty). The header, footer, landing CTAs, and <code>BlogPostCta.astro</code> all link to <code>installUrl</code> with <code>target="_blank"</code>.</p>
+
+<p><strong>Extension → site (only two hard-coded links):</strong></p>
+<ul>
+<li><code>src/lib/constants/growth.ts</code>: <code>PRIVACY_POLICY_URL = https://usetotem.xyz/privacy</code> (rendered in <code>OnboardingModal.tsx</code>), and <code>UNINSTALL_FEEDBACK_URL = https://usetotem.xyz/uninstall-feedback?utm_source=extension&amp;utm_medium=uninstall&amp;utm_campaign=feedback</code>. The uninstall URL is wired via <code>chrome.runtime.setUninstallURL(...)</code> in <code>src/service-worker/index.ts</code> (<code>configureUninstallFeedback</code>, called from <code>registerReleaseFoundationHooks</code>).</li>
+<li><code>src/lib/export/quick-export.ts</code> embeds <code>https://usetotem.xyz/export-format/v1</code> as a doc link inside exported ZIPs.</li>
+</ul>
+
+<p><strong>Install-time behavior:</strong> On <code>chrome.runtime.onInstalled</code> with <code>reason === "install"</code>, the service worker opens an in-extension tab (<code>newtab.html?utm_source=extension&amp;utm_medium=oninstall&amp;utm_campaign=first_launch</code>), <strong>not</strong> the marketing site (<code>openFirstLaunchTab</code> in <code>src/service-worker/index.ts</code>). So there is no existing "open the site from the extension" deep-link beyond privacy/uninstall.</p>
+
+<div class="callout">There is currently <strong>no <code>pricing</code>, <code>license</code>, <code>upgrade</code>, <code>checkout</code>, or payment-provider reference anywhere</strong> in <code>src/</code> or <code>apps/site/src/</code> (confirmed by grep). The only <code>premium_*</code> hit is <code>premium_content_api_read_enabled: false</code> in <code>api-proxy.ts</code>, an X GraphQL feature flag unrelated to Totem monetization. <span class="tag">GREENFIELD</span></div>
+
+<h3>Wiring "upgrade in extension → checkout on site → license back to extension"</h3>
+
+<p>There is no extension custom URL scheme today, so the handoff must use standard web URLs plus a paste-key fallback. Recommended flow:</p>
+
+<ol>
+<li><strong>Upgrade entry (extension):</strong> An "Upgrade to Pro" button in the new-tab UI / settings calls <code>chrome.tabs.create({ url: PRICING_URL })</code> where <code>PRICING_URL = https://usetotem.xyz/pricing?utm_source=extension&amp;utm_medium=upgrade&amp;utm_campaign=pro</code> (add to <code>growth.ts</code>, mirroring <code>UNINSTALL_FEEDBACK_URL</code>). Optionally append the extension's stable install id / a nonce as a query param so the success page can build a return deep link.</li>
+<li><strong>Checkout (site → MoR):</strong> The <code>/pricing</code> "Buy" button opens the MoR hosted checkout. MoR handles payment, tax (merchant-of-record), and license-key generation — no Totem server required.</li>
+<li><strong>License delivery (MoR → site success page):</strong> Configure the MoR <code>success_url = https://usetotem.xyz/upgrade/success</code>. The MoR appends the license key (or order token) to the redirect. The static success page (<code>src/pages/upgrade/success.astro</code>, <code>noindex</code>) reads <code>location.search</code> client-side and shows the key + copy button.</li>
+<li><strong>Return to extension — three layered mechanisms, in preference order:</strong>
+<ul>
+<li><strong>(a) <code>chrome.runtime.sendMessage(EXTENSION_ID, {type:"TOTEM_LICENSE", key})</code> from the web page</strong> — requires adding <code>externally_connectable</code> (with <code>matches: ["https://usetotem.xyz/*"]</code>) to the extension manifest and an <code>onMessageExternal</code> handler. Cleanest one-click activation; the success page JS posts the key straight into the extension.</li>
+<li><strong>(b) Deep-link button</strong> <code>chrome-extension://&lt;id&gt;/newtab.html?license=&lt;key&gt;</code> (or a custom action) that the success page renders; the new-tab boot reads <code>?license=</code> and stores/validates it. Works without <code>externally_connectable</code> but exposes the key in a URL.</li>
+<li><strong>(c) Paste-a-key fallback (always ship this):</strong> a field in extension Settings + the <code>/manage-license</code> page where the user pastes the key manually. The robust, no-coupling path, mirroring the existing <code>uninstall-feedback.astro</code> "static page + client script, no backend" pattern.</li>
+</ul></li>
+<li><strong>Verification (extension):</strong> The service worker calls the MoR's license <strong>validate</strong> API directly (a public, no-secret data call) once at activation, then stores the unlocked state in <code>chrome.storage.local</code> alongside existing runtime/auth keys and reads it locally thereafter, re-checking in the background with fail-open. No Totem backend in the loop — the MoR is the only server, and only the key + email + a device id are sent.</li>
+</ol>
+
+<div class="takeaway"><div class="takeaway-label">MANIFEST NOTE</div> Whichever of (a)/(b) is chosen, the work is on the <strong>extension side</strong> (manifest <code>externally_connectable</code> and/or an <code>onMessageExternal</code>/URL-param handler). The site side stays static — the success/manage pages are ordinary Astro static pages with client <code>&lt;script&gt;</code> glue.</div>
+
+<h2 id="seo-utm-ref-decoration-the-funnel-must-preserve">SEO / UTM / ref decoration the funnel must preserve</h2>
+
+<p>The site already has a consistent attribution scheme; a purchase funnel must not strip it.</p>
+
+<p>The <strong>blog link rehype plugin</strong> at <code>apps/site/src/lib/rehype-blog-links.mjs</code> (registered in <code>astro.config.mjs</code>) rewrites every <code>&lt;a&gt;</code> in blog Markdown at build time:</p>
+<ul>
+<li><strong>Internal links</strong> to <code>usetotem.xyz</code> / <code>www.usetotem.xyz</code> get <code>utm_source=blog</code>, <code>utm_medium=referral</code>, <code>utm_campaign=blog_post</code>, and <code>utm_content=&lt;post-slug&gt;</code>. <strong>Important for the funnel:</strong> a "Buy/Upgrade" link in a blog post pointing at <code>/pricing</code> is auto-decorated with these blog UTMs — desirable, keep it.</li>
+<li><strong>External links</strong> (non-Totem hosts) get <code>utm_source=usetotem.xyz</code>, <code>utm_medium=referral</code>, <code>utm_campaign=blog</code>, <strong>and <code>ref=usetotem.xyz</code></strong>, plus <code>target="_blank"</code> + <code>rel="noopener noreferrer"</code>. The MoR checkout domain (e.g. <code>gumroad.com</code>) is external, so blog links to it are decorated this way automatically.</li>
+</ul>
+
+<p><strong>Hand-built CTA UTM derivation:</strong> <code>BlogPostCta.astro</code> takes the base <code>installUrl</code> and rewrites <code>utm_campaign=site_install</code> → <code>utm_campaign=blog_post_cta&amp;utm_content=&lt;slug&gt;</code>. A Pro CTA card should follow the same derive-from-base pattern so campaigns stay attributable.</p>
+
+<p><strong>Install URL canonical params:</strong> <code>chromeWebStoreInstallUrl</code> carries <code>utm_source=usetotem.xyz&amp;utm_medium=referral&amp;utm_campaign=site_install</code>. Any new "Upgrade" link from the site should use a parallel campaign (e.g. <code>utm_campaign=pricing</code> / <code>pro_upgrade</code>) so funnel analytics separate install vs upgrade.</p>
+
+<p><strong>Extension-originated UTMs:</strong> extension→site links already tag <code>utm_source=extension</code> (<code>utm_medium=uninstall|oninstall|upgrade</code>). Keep the <code>utm_source=extension&amp;utm_medium=upgrade&amp;utm_campaign=pro</code> convention for the new pricing deep-link so in-extension conversions are distinguishable from organic.</p>
+
+<p><strong>Analytics:</strong> GA4 (<code>G-VBKV6TVM6W</code>) is loaded in <code>BaseLayout.astro</code> for every page, so <code>/pricing</code> and <code>/upgrade/success</code> get pageview tracking for free; the funnel should set up GA events/conversions on the success page. (Per the project's local-first stance, GA is on the marketing site, not the extension.)</p>
+
+<p><strong>Sitemap:</strong> the <code>astro.config.mjs</code> sitemap <code>filter</code> excludes <code>/uninstall-feedback/</code>. The <span class="hl"><code>/upgrade/success</code> page should likewise be excluded</span> (and <code>noindex</code>); <code>/pricing</code> should be included (a real indexable page) and will inherit the default <code>priority: 0.8, changefreq: monthly</code>.</p>
+
+<p><strong>Structured data caveat:</strong> <code>index.astro</code>'s <code>SoftwareApplication</code> JSON-LD currently declares <code>offers.price: "0"</code> / <code>isAccessibleForFree: true</code>. When Pro ships, update this (or add an <code>offers</code> array reflecting the free + $19 lifetime tiers) to keep rich-result data truthful.</p>
+
+<h2 id="key-file-references">Key file references</h2>
+
+<table class="compact striped">
+<thead><tr><th>File</th><th>Role</th></tr></thead>
+<tbody>
+<tr><td><code>apps/site/astro.config.mjs</code></td><td>Static output, no adapter, markdown pipeline, sitemap filter.</td></tr>
+<tr><td><code>vercel.json</code> (repo root)</td><td>Vercel build/output config, <code>cleanUrls</code>, redirects (CDN-only, no functions).</td></tr>
+<tr><td><code>apps/site/src/layouts/BaseLayout.astro</code></td><td>Shared SEO/HTML shell + GA; add <code>pricing</code> to <code>SitePageKey</code>.</td></tr>
+<tr><td><code>apps/site/src/react/site-content.ts</code></td><td><code>SITE_LINKS</code> / <code>SITE_COPY</code>, install URLs (add checkout/license URLs here).</td></tr>
+<tr><td><code>apps/site/src/pages/uninstall-feedback.astro</code></td><td>Template for a no-backend form/paste-key page.</td></tr>
+<tr><td><code>apps/site/src/pages/export-format/v1.astro</code></td><td>Template for a long-form static content page.</td></tr>
+<tr><td><code>apps/site/src/components/BlogPostCta.astro</code></td><td>UTM-derived CTA card model.</td></tr>
+<tr><td><code>apps/site/src/lib/rehype-blog-links.mjs</code></td><td>Build-time UTM/<code>ref</code> link decoration (internal + external).</td></tr>
+<tr><td><code>apps/site/src/content.config.ts</code> + <code>src/pages/blog/[slug].astro</code></td><td>Content-collection authoring.</td></tr>
+<tr><td><code>src/lib/constants/growth.ts</code></td><td>Extension's hard-coded site URLs (<code>PRIVACY_POLICY_URL</code>, <code>UNINSTALL_FEEDBACK_URL</code>); add <code>PRICING_URL</code> here.</td></tr>
+<tr><td><code>src/service-worker/index.ts</code></td><td><code>setUninstallURL</code>, <code>onInstalled</code> first-launch tab (opens in-extension newtab, not site), <code>chrome.tabs.create</code> usage; site of any future <code>onMessageExternal</code>/license handoff handler.</td></tr>
+</tbody>
+</table>
+<nav class="pager"><a class="pager-link prev" href="appendix-c-build-release.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Build &amp; Release Pipeline</span></a><a class="pager-link next" href="appendix-e-ui-state-upsell.html"><span class="pager-eyebrow">Next</span><span class="pager-title">UI State &amp; Upsell Surfaces</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#site-architecture-build-and-deploy">Site architecture, build, and deploy</a>
+<a href="#where-the-purchase-funnel-pages-live">Where the purchase-funnel pages live</a>
+<a href="#extension-site-handoff">Extension ↔ site handoff</a>
+<a href="#seo-utm-ref-decoration-the-funnel-must-preserve">SEO / UTM / ref decoration the funnel must preserve</a>
+<a href="#key-file-references">Key file references</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-e-ui-state-upsell.html
+++ b/plans/research/premium-monetization/site/appendix-e-ui-state-upsell.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>UI State & Upsell Surfaces · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html" aria-current="page">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix E</div><h1 class="page-title">UI State &amp; Upsell Surfaces</h1><p class="lead">How to model an <code>isPro</code> entitlement and where to mount Pro upsell UI, grounded entirely in existing Totem patterns. All paths relative to repo root <code>/Users/ankit/Documents/make/totem</code>.</p>
+
+<p>There is currently <strong>no</strong> pro / entitlement / premium / license / paywall code in <code>src/</code>. A grep for <code>isPro|entitlement|premium|license|upgrade|paywall|lifetime|gumroad|founders</code> returns only unrelated hits: <code>capability upgrade</code> in runtime-store tests, an IDB <code>upgrade()</code> migration callback, and a Twitter feature flag <code>premium_content_api_read_enabled</code> in <code>src/service-worker/api-proxy.ts:62</code>. This is a <span class="hl">greenfield surface</span>.</p>
+
+<h2 id="the-existing-pattern-for-a-boolean-user-preference-flag">The existing pattern for a boolean user preference / flag</h2>
+
+<p>There are <strong>two</strong> established persistence patterns. They differ on storage area and on whether the SW owns the value. For <code>isPro</code> we want the <strong>preference pattern</strong>, not the runtime-snapshot pattern.</p>
+
+<h3>Pattern A — Synced user preference (chrome.storage.sync) — the cleanest analog</h3>
+
+<p>This is the model <code>useSettings</code>/<code>useTheme</code> use, and it is the <strong>closest analog to <code>isPro</code></strong>: a user-scoped flag, set rarely, that should follow the user across devices.</p>
+
+<ul>
+<li><strong>Where defined / shape:</strong> <code>src/types/index.ts:283</code> — <code>interface UserSettings { ... }</code> (all booleans like <code>showSearchBar</code>, <code>showOpenInTotem</code> live here). Defaults at <code>src/hooks/useSettings.ts:33</code> (<code>DEFAULT_SETTINGS</code>).</li>
+<li><strong>How persisted:</strong> <code>chrome.storage.sync</code>, under a single namespaced key. Keys are centralized in <code>src/lib/storage-keys.ts</code>:
+  <ul>
+  <li><code>SYNC_SETTINGS = "totem_settings"</code> (<code>storage-keys.ts:70</code>)</li>
+  <li><code>SYNC_THEME = "totem_theme"</code> (<code>storage-keys.ts:71</code>)</li>
+  <li>both enumerated in <code>CHROME_SYNC_KEYS</code> (<code>storage-keys.ts:73</code>)</li>
+  <li>legacy key remap in <code>LEGACY_CHROME_SYNC_KEY_MAP</code> (<code>storage-keys.ts:115</code>)</li>
+  </ul>
+</li>
+<li><strong>How read reactively in components:</strong> a hook with three effects (see <code>src/hooks/useSettings.ts:93-148</code> and the near-identical <code>src/hooks/useTheme.ts:23-106</code>):
+  <ol>
+  <li><code>useState</code> seeded with a hardcoded default.</li>
+  <li>Load-once effect: guard <code>hasChromeStorageSync()</code> (<code>src/lib/chrome.ts:1</code>), then <code>chrome.storage.sync.get({ [KEY]: DEFAULT })</code>, normalize, <code>setState</code>.</li>
+  <li>Cross-context reactivity effect: guard <code>hasChromeStorageOnChanged()</code> (<code>src/lib/chrome.ts:5</code>), subscribe to <code>chrome.storage.onChanged</code>, filter <code>areaName === "sync"</code> and the specific key, re-normalize <code>change.newValue</code>. This is what makes the flag update live across the new-tab page, reader route, and any other open Totem surface without a reload.</li>
+  <li>An <code>updateX</code> setter that optimistically <code>setState</code>s and writes <code>chrome.storage.sync.set({ [KEY]: next })</code> (fire-and-forget <code>.catch(() =&gt; {})</code>).</li>
+  </ol>
+</li>
+<li><strong>Normalization discipline:</strong> every loader runs a <code>normalizeX(value: unknown)</code> pass (<code>useSettings.ts:45</code>, <code>useTheme.ts:17</code>) so a malformed/old stored value can never crash a render. Any <code>isPro</code> reader must do the same.</li>
+<li><strong>Consumed in components:</strong> <code>useSettings()</code> is called once high in the tree (<code>src/App.tsx:411</code> in <code>NewTabRouteApp</code>, <code>src/App.tsx:751</code> in <code>ReaderRouteApp</code>) and the values are threaded down as props (e.g. <code>showSearchBar={settings.showSearchBar}</code> to <code>NewTabHome</code>, <code>src/App.tsx:672</code>). <code>useTheme()</code> is called at <code>App.tsx:410</code>.</li>
+</ul>
+
+<div class="callout"><strong>Storage-area tension for <code>isPro</code>:</strong> <code>chrome.storage.sync</code> is the right <em>ergonomic</em> analog, but it is trivially user-editable and synced by Google, so it is appropriate for an <strong>optimistic UX flag</strong> only. The authoritative entitlement check (license validation) must live behind a verification step, not be trusted purely from synced storage. See the recommended split below: cached flag in storage + verify-on-load.</div>
+
+<h3>Pattern B — One-time / lifecycle growth flags (chrome.storage.local)</h3>
+
+<p><code>src/lib/growth-state.ts</code> is the analog for <strong>"show this once, then never again"</strong> gating — directly relevant to a one-time post-install Pro nudge.</p>
+
+<ul>
+<li><strong>Shape:</strong> <code>interface GrowthState</code> (<code>growth-state.ts:18</code>) with nested <code>onboarding</code>, <code>activation</code>, <code>review</code> namespaces, each holding <code>*At: number | null</code> timestamps (the "set once" idiom: <code>x ?? now</code>, e.g. <code>growth-state.ts:316</code>).</li>
+<li><strong>Persisted:</strong> <code>chrome.storage.local</code> under <code>CS_GROWTH_STATE = "totem_growth_state"</code> (<code>storage-keys.ts:45</code>). Local (not sync) because it's device-lifecycle state.</li>
+<li><strong>Access:</strong> module-level async functions, not a hook. <code>readGrowthState()</code> (<code>growth-state.ts:256</code>) and <code>mutateGrowthState(mutator)</code> (<code>growth-state.ts:244</code>), which does read → mutate → <code>chrome.storage.local.set</code>. Pure reducers (<code>applyBookmarksSynced</code>, <code>applyReaderOpen</code>) and pure predicates (<code>shouldShowReviewPrompt:205</code>, <code>shouldShowOnboarding:213</code>, <code>shouldShowReengagementNudge:227</code>) are exported and unit-tested independently (<code>src/lib/__tests__/growth-state.test.ts</code>).</li>
+<li><strong>Wired into UI imperatively from <code>App.tsx</code>:</strong> e.g. review prompt at <code>App.tsx:805-813</code> (<code>recordReaderOpen → shouldShowReviewPrompt → markReviewPrompted → setState visible</code>), reengagement at <code>App.tsx:614-639</code>. The mark/dismiss handlers sit at <code>App.tsx:928-936</code> and <code>App.tsx:641-650</code>.</li>
+</ul>
+
+<h3>Recommendation for the isPro flag</h3>
+
+<p>Model the <strong>cached</strong> entitlement exactly like <code>useTheme</code> (the simplest single-value hook): one synced key, one normalize function, three effects, one setter. Model the <strong>"have we shown the upsell" / "license verified at"</strong> bookkeeping like <code>growth-state.ts</code> (local, set-once timestamps). Concretely:</p>
+
+<ul>
+<li>Add <code>SYNC_PRO = "totem_pro"</code> to <code>src/lib/storage-keys.ts</code> and to <code>CHROME_SYNC_KEYS</code>.</li>
+<li>Add an entitlement type to <code>src/types/index.ts</code> (e.g. <code>interface ProEntitlement { status: "free" | "pro"; licenseKey: string | null; unlockedAt: number | null; verifiedAt: number | null; }</code>).</li>
+<li>New hook <code>src/hooks/usePro.ts</code> mirroring <code>useTheme.ts</code> line-for-line.</li>
+</ul>
+
+<h2 id="reusable-dialog-modal-primitives-the-modal-template">Reusable Dialog/Modal primitives + the modal template</h2>
+
+<h3>The shared Modal wrapper (use this — do not hand-roll Base UI)</h3>
+
+<p><code>src/components/ui/Modal.tsx</code> wraps <code>@base-ui/react/dialog</code> (<code>Dialog.Root</code> / <code>Dialog.Portal</code> / <code>Dialog.Backdrop</code> / <code>Dialog.Popup</code>) into one component. It already handles: portal, backdrop (<code>bg-black/50</code> passed via <code>className</code>), enter/leave animation via <code>data-[starting-style]</code>/<code>data-[ending-style]</code> (<code>Modal.tsx:47-53</code>), title header + close button (<code>Modal.tsx:59-84</code>), <code>aria-labelledby</code> wiring, backdrop-click and Escape-to-close (<code>onOpenChange</code>, <code>Modal.tsx:40</code>), and a <code>closeDisabled</code> lock for in-progress operations. Props: <code>open</code>, <code>onClose</code>, <code>title</code>, <code>titleId</code>, <code>panelClassName</code>, <code>bodyClassName</code>, <code>closeLabel</code>, <code>closeDisabled</code> (<code>Modal.tsx:7-19</code>).</p>
+
+<p>A Pro modal should pass <code>title="Upgrade to Totem Pro"</code>, <code>titleId="upgrade-title"</code>, <code>className="bg-black/50"</code>, and (optionally) <code>panelClassName="max-w-lg"</code>.</p>
+
+<h3>Best existing templates to clone</h3>
+
+<ul>
+<li><strong><code>src/components/OnboardingModal.tsx</code></strong> — the simplest, closest template for an upsell/paywall sheet: a <code>Modal</code> with prose blocks in bordered <code>rounded border border-border bg-surface</code> cards (<code>OnboardingModal.tsx:34-56</code>) and a right-aligned footer action row mixing <code>ghost</code> / <code>secondary</code> / primary <code>Button</code>s plus an <code>href</code> CTA (<code>OnboardingModal.tsx:71-81</code>). An "Upgrade to Pro" sheet is structurally this plus a feature-benefit list and a primary CTA <code>&lt;Button href={CHECKOUT_URL}&gt;</code>.</li>
+<li><strong><code>src/components/ExportModal.tsx</code></strong> — the template for a <strong>stateful</strong> modal with internal phases. It drives a <code>quickState</code> discriminated union (<code>{ phase: "idle" | "exporting" | "done" | "error" }</code>, <code>ExportModal.tsx:30-34</code>) and renders one of several sub-views (<code>IdleView</code>, <code>DoneView</code>, <code>ErrorView</code>, …) inside a single <code>&lt;Modal&gt;</code> (<code>ExportModal.tsx:105-162</code>). Reuse this if the upgrade flow needs states (e.g. <code>idle → enter-license → verifying → success/error</code>). The radio-card selection block (<code>ExportModal.tsx:200-289</code>) is a ready-made pattern if a pricing modal ever offers tiers (lifetime vs founders).</li>
+<li><strong><code>src/components/ImportModal.tsx</code></strong> — third example of the same stateful-modal idiom.</li>
+</ul>
+
+<h3>Supporting primitives available</h3>
+
+<ul>
+<li><code>src/components/ui/Button.tsx</code> — variants <code>primary | secondary | ghost | destructive | accent-soft</code> (<code>Button.tsx:4-11</code>); the <strong><code>accent-soft</code></strong> variant (<code>bg-accent-surface text-accent</code>) is the natural "Upgrade" CTA tint. Supports <code>href</code> (renders <code>&lt;a target="_blank"&gt;</code> for <code>https://</code> — ideal for an external checkout link, <code>Button.tsx:36-51</code>).</li>
+<li><code>src/components/ui/Badge.tsx</code> — variants <code>accent</code> (filled) and <code>muted</code> (<code>Badge.tsx:3-6</code>). The <code>accent</code> badge is the ready-made <strong>"PRO" lock badge</strong> for gated buttons.</li>
+<li><code>src/components/ui/Popover.tsx</code> (<code>PopoverContent</code> over <code>@base-ui/react/popover</code>) — for an inline "this is a Pro feature" tooltip/popover on a locked control.</li>
+<li><code>src/components/ui/Toast.tsx</code>, <code>Switch.tsx</code>, <code>Select.tsx</code>, <code>Separator.tsx</code> round out the kit.</li>
+</ul>
+
+<h2 id="where-ui-upsell-surfaces-would-mount">Where UI upsell surfaces would mount</h2>
+
+<h3>(a) "Upgrade" entry in Settings — primary surface</h3>
+
+<p><code>src/components/SettingsModal.tsx</code> is a single <code>Modal</code> whose body is a stack of <code>&lt;section className="py-4 first:pt-0 last:pb-0"&gt;</code> blocks separated by <code>divide-y divide-border</code> (<code>SettingsModal.tsx:147</code>). Sections today: Appearance (149), Highlight/Open-in-Totem (193), New Tab (234), Storage (347).</p>
+
+<ul>
+<li><strong>Mount point:</strong> add a new <code>&lt;section&gt;</code> (e.g. "Totem Pro" as the first section, or a dedicated row at the top of Storage right above Export at <code>SettingsModal.tsx:374</code>, since Export/CSV/Markdown is the headline gated feature). Use the same label + sub-label + right-aligned <code>Button</code> row shape already used for Import/Export (<code>SettingsModal.tsx:352-394</code>).</li>
+<li>For a <strong>free</strong> user: a row "Totem Pro — Unlock export formats, deleted-tweet preservation, bulk ops" + an <code>accent-soft</code> <code>Button</code> "Upgrade" that calls a new <code>onOpenUpgrade()</code> prop. For a <strong>pro</strong> user: same row showing a <code>Badge variant="accent"</code> "PRO" and "Manage license".</li>
+<li><strong>Prop wiring:</strong> <code>SettingsModal</code> is fully prop-driven (<code>Props</code> at <code>SettingsModal.tsx:23-35</code>, callbacks like <code>onExport</code>/<code>onImport</code> threaded from <code>App.tsx:705-706</code>). Add <code>isPro: boolean</code> and <code>onOpenUpgrade: () =&gt; void</code> props, pass from <code>App.tsx:693-707</code> (right where <code>onExport</code>/<code>onImport</code> are passed).</li>
+</ul>
+
+<h3>(b) Lock badge on gated buttons + intercepted clicks</h3>
+
+<p>Gated actions and their exact mount points:</p>
+
+<ul>
+<li><strong>Export</strong> — two surfaces:
+  <ul>
+  <li>Settings row "Export your data" <code>Button</code> (<code>SettingsModal.tsx:383-394</code>). The sub-label already literally reads "Download your bookmarks as CSV, Markdown, and JSONL" (<code>SettingsModal.tsx:379</code>) — the headline Pro features. Render a <code>Badge variant="accent"&gt;PRO&lt;/Badge&gt;</code> next to the label and, when <code>!isPro</code>, have the button call <code>onOpenUpgrade()</code> instead of <code>onExport()</code>.</li>
+  <li>New-tab "full export ready" / export entry points in <code>NewTabHome.tsx</code> (the <code>onOpenExport</code> callback is threaded through <code>NewTabHome</code> props at <code>NewTabHome.tsx:93</code>, used at <code>:1331</code>, <code>:1446</code>, <code>:1493</code>). Gating belongs at the <code>onOpenExport</code> boundary in <code>App.tsx:708-719</code> (where <code>&lt;ExportModal&gt;</code> is wired): swap the handler to open the upgrade modal for free users, OR keep the ExportModal open and gate the <em>format</em> choices inside it (the radio cards at <code>ExportModal.tsx:200-289</code> are the place — e.g. "Markdown/CSV" marked PRO).</li>
+  </ul>
+</li>
+<li><strong>Settings header toolbar</strong> — the gear button lives in the new-tab header at <code>NewTabHome.tsx:1086-1095</code> (next to the Sync button <code>:1070-1085</code>). A small "Upgrade" pill or star icon-button could sit beside the gear here for an always-visible entry point. This <code>&lt;header&gt;</code>/toolbar (<code>NewTabHome.tsx:~1060-1097</code>) is the single most visible chrome on the new tab.</li>
+<li><strong>Reader gated features</strong> (annotations, advanced highlight options) — <code>BookmarkReader</code> is rendered at <code>App.tsx:945-978</code>; highlight color is already a prop (<code>defaultHighlightColor</code>, <code>App.tsx:967</code>). Lock badges for annotation/thread-capture features mount inside <code>src/components/reader/</code> controls.</li>
+</ul>
+
+<p>Implement gating with a <code>&lt;ProGate&gt;</code> wrapper so each call site stays a <span class="hl">one-line change</span> and the lock-badge + intercept logic isn't copy-pasted.</p>
+
+<h3>(c) One-time post-install nudge</h3>
+
+<p>Reuse the <code>growth-state.ts</code> set-once idiom and the existing dismissible-banner components verbatim:</p>
+
+<ul>
+<li><strong>Visual template:</strong> <code>src/components/ReviewPrompt.tsx</code> and <code>src/components/ReengagementNudge.tsx</code> — both are <code>fixed inset-x-0 bottom-5 z-40</code> bottom-center cards with a message, a primary action, and an <code>XIcon</code> dismiss button (<code>ReviewPrompt.tsx:9-37</code>, <code>ReengagementNudge.tsx:10-43</code>). A <code>ProNudge</code> would be a copy with copy like "Totem is free forever. Pro unlocks exports + deleted-tweet preservation — $19 lifetime."</li>
+<li><strong>Gating logic:</strong> add a <code>pro</code> namespace to <code>GrowthState</code> (<code>growth-state.ts:18</code>) with <code>nudgePromptedAt</code>/<code>nudgeDismissedAt</code> (mirror <code>review</code>/<code>activation</code> at <code>growth-state.ts:36-41</code>), a <code>shouldShowProNudge(state)</code> predicate next to <code>shouldShowReviewPrompt</code> (<code>growth-state.ts:205</code>), and <code>markProNudgePrompted/Dismissed</code> mirroring <code>growth-state.ts:320-357</code>. Gate on activation (<code>activatedAt !== null</code>) so it only fires for engaged users — never on day one.</li>
+<li><strong>Orchestration mount:</strong> the same <code>App.tsx</code> effect pattern used for review/reengagement (<code>App.tsx:614-639</code> for reengagement; <code>App.tsx:805-813</code> for review). Render the component conditionally next to <code>&lt;ReviewPrompt&gt;</code>/<code>&lt;ReengagementNudge&gt;</code> (<code>App.tsx:726-732</code> and <code>App.tsx:987-992</code>). Crucially, suppress when <code>isPro</code> is true.</li>
+</ul>
+
+<h3>(d) Banner</h3>
+
+<p>For a non-blocking persistent banner, <code>src/components/ui/OfflineBanner.tsx</code> is the in-repo banner pattern. Prefer (a)+(c) over a banner to avoid nagging; a banner is the weakest of the four and should be reserved for a time-boxed founders-price promo.</p>
+
+<h2 id="proposed-usepro-hook-progate-component">Proposed usePro() hook + &lt;ProGate&gt; component</h2>
+
+<p>Both live beside existing analogs and follow their conventions exactly.</p>
+
+<h3>src/hooks/usePro.ts — mirrors src/hooks/useTheme.ts</h3>
+
+<p>Rationale: entitlement is a single user-scoped value that should sync across devices and update live in every open surface — identical requirements to <code>useTheme</code>. Clone its three-effect structure (load-once, <code>onChanged</code> subscription, setter) and its <code>normalizeX(unknown)</code> discipline.</p>
+
+<pre><code>// src/hooks/usePro.ts  (shape only)
+import { useCallback, useEffect, useState } from "react";
+import { hasChromeStorageSync, hasChromeStorageOnChanged } from "../lib/chrome";
+import { SYNC_PRO } from "../lib/storage-keys";          // new key, added to CHROME_SYNC_KEYS
+import type { ProEntitlement } from "../types";          // new type in src/types/index.ts
+
+const DEFAULT_PRO: ProEntitlement = {
+  status: "free", licenseKey: null, unlockedAt: null, verifiedAt: null,
+};
+
+function normalizePro(value: unknown): ProEntitlement { /* same guard style as useTheme.ts:17 */ }
+
+export function usePro() {
+  const [entitlement, setEntitlement] = useState&lt;ProEntitlement&gt;(DEFAULT_PRO);
+
+  // effect 1: chrome.storage.sync.get({ [SYNC_PRO]: DEFAULT_PRO }) → normalize → setState
+  // effect 2: chrome.storage.onChanged (areaName === "sync", key SYNC_PRO) → setState
+  // (verification — license re-check — can be a 3rd effect or a service-worker call;
+  //  keep storage as the optimistic cache, verifiedAt as the trust timestamp.)
+
+  const setEntitlementValue = useCallback((next: ProEntitlement) =&gt; {
+    setEntitlement(next);
+    if (hasChromeStorageSync()) chrome.storage.sync.set({ [SYNC_PRO]: next }).catch(() =&gt; {});
+  }, []);
+
+  return { isPro: entitlement.status === "pro", entitlement, setEntitlement: setEntitlementValue };
+}</code></pre>
+
+<p>Naming note: the task allows <code>useEntitlement()</code>; given the repo's terse domain-named hooks (<code>useSettings</code>, <code>useTheme</code>, <code>useTodayQueue</code>), <strong><code>usePro()</code> returning <code>{ isPro }</code></strong> reads best at call sites. Optionally export a thin <code>useIsPro()</code> selector that returns the boolean only, matching the <code>useShallow</code>/selector ergonomics in <code>src/stores/selectors.ts</code>.</p>
+
+<p>Call it once high in the tree alongside <code>useSettings()</code>/<code>useTheme()</code> at <code>App.tsx:410-411</code> (in both <code>NewTabRouteApp</code> and <code>ReaderRouteApp</code>) and thread <code>isPro</code> down as a prop, exactly as <code>settings.*</code> is threaded today.</p>
+
+<div class="callout"><strong>Storage-area discipline:</strong> Do <strong>not</strong> put <code>isPro</code> in the Zustand <code>runtime-store</code>: that store is the SW-owned auth/sync snapshot (<code>RuntimeState</code>, <code>runtime-store.ts:154</code>) and the codebase deliberately keeps user <em>preferences</em> out of it (<code>storage-keys.ts:47-60</code> and the <code>storage-invariants.test.ts</code> guard).</div>
+
+<h3>&lt;ProGate&gt; — lives beside the gated UI, in src/components/</h3>
+
+<p>A small wrapper that renders children for Pro users, and for free users renders the locked affordance (a <code>Badge variant="accent"&gt;PRO&lt;/Badge&gt;</code> + intercepts click to open the upgrade modal). Keeps every call site a one-liner and centralizes the lock visuals.</p>
+
+<pre><code>// src/components/ProGate.tsx  (shape only; Badge from ui/Badge.tsx, accent variant)
+interface ProGateProps {
+  isPro: boolean;
+  onUpgrade: () =&gt; void;          // opens the Upgrade modal (App.tsx route state, §3a)
+  children: React.ReactNode;      // the real control when unlocked
+  lockedLabel?: string;           // e.g. "Pro feature"
+  showBadge?: boolean;            // render the PRO badge inline
+}
+// if isPro → return &lt;&gt;{children}&lt;/&gt;
+// else → render the same control visually but route onClick → onUpgrade, append &lt;Badge variant="accent"&gt;PRO&lt;/Badge&gt;</code></pre>
+
+<p>Two usage flavors, both already supported by the codebase:</p>
+
+<ol>
+<li><strong>Hard gate</strong> (replace action): wrap the Export button so a free user's click opens the upgrade modal instead of <code>onExport</code> — applied at <code>SettingsModal.tsx:383</code> and at the <code>onOpenExport</code> boundary in <code>App.tsx:708</code>.</li>
+<li><strong>Badge-only hint</strong> (<code>showBadge</code>): annotate a control that stays interactive but surfaces locked sub-options downstream (e.g. the export-format radio cards, <code>ExportModal.tsx:200-289</code>).</li>
+</ol>
+
+<p>The upgrade modal itself (<code>UpgradeModal.tsx</code>, cloned from <code>OnboardingModal.tsx</code>) is opened via the existing route-reducer pattern: add <code>upgradeOpen</code> to <code>NewTabRouteState</code> (<code>App.tsx:117-125</code>), an <code>onOpenUpgrade</code> setter, and render <code>&lt;UpgradeModal open={upgradeOpen} …/&gt;</code> next to <code>&lt;ExportModal&gt;</code>/<code>&lt;ImportModal&gt;</code> at <code>App.tsx:708-725</code>. This is the identical mechanism already used for settings/export/import modals — no new modal-management infrastructure is needed.</p>
+
+<h2 id="summary-of-concrete-files-to-add-touch">Summary of concrete files to add / touch</h2>
+
+<table class="striped">
+<thead><tr><th>Action</th><th>File</th></tr></thead>
+<tbody>
+<tr><td>Add <code>SYNC_PRO</code> key + add to <code>CHROME_SYNC_KEYS</code> + legacy map</td><td><code>src/lib/storage-keys.ts:70,73</code></td></tr>
+<tr><td>Add <code>ProEntitlement</code> type</td><td><code>src/types/index.ts</code> (beside <code>UserSettings:283</code>)</td></tr>
+<tr><td>New <code>usePro()</code> hook (clone <code>useTheme.ts</code>)</td><td><code>src/hooks/usePro.ts</code></td></tr>
+<tr><td>Extend growth state for one-time nudge (set-once idiom)</td><td><code>src/lib/growth-state.ts:18,205,320</code></td></tr>
+<tr><td>New <code>&lt;ProGate&gt;</code> wrapper</td><td><code>src/components/ProGate.tsx</code></td></tr>
+<tr><td>New <code>UpgradeModal</code> (clone <code>OnboardingModal.tsx</code>)</td><td><code>src/components/UpgradeModal.tsx</code></td></tr>
+<tr><td>New <code>ProNudge</code> banner (clone <code>ReviewPrompt.tsx</code>)</td><td><code>src/components/ProNudge.tsx</code></td></tr>
+<tr><td>Add Pro section + gate Export button</td><td><code>src/components/SettingsModal.tsx:374-394</code></td></tr>
+<tr><td>Call <code>usePro()</code>, add <code>upgradeOpen</code> route state, render modals/nudge, thread <code>isPro</code></td><td><code>src/App.tsx:117-125,410-411,693-732,805-813,987-992</code></td></tr>
+<tr><td>Optional always-visible upgrade entry in toolbar</td><td><code>src/components/NewTabHome.tsx:1086-1095</code></td></tr>
+</tbody>
+</table>
+
+<div class="takeaway"><div class="takeaway-label">NET-NEW SURFACE</div> No existing pro/entitlement code — model the cached flag on <code>useTheme</code> (synced, optimistic), the set-once nudge bookkeeping on <code>growth-state.ts</code> (local), keep entitlement out of the SW-owned <code>runtime-store</code>, and verify the license behind a trust timestamp rather than trusting synced storage.</div>
+<nav class="pager"><a class="pager-link prev" href="appendix-d-site-distribution.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Site &amp; Distribution</span></a><a class="pager-link next" href="appendix-f-payments-compared.html"><span class="pager-eyebrow">Next</span><span class="pager-title">Payment Gateways Compared</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#the-existing-pattern-for-a-boolean-user-preference-flag">The existing pattern for a boolean user preference / flag</a>
+<a href="#reusable-dialog-modal-primitives-the-modal-template">Reusable Dialog/Modal primitives + the modal template</a>
+<a href="#where-ui-upsell-surfaces-would-mount">Where UI upsell surfaces would mount</a>
+<a href="#proposed-usepro-hook-progate-component">Proposed usePro() hook + <ProGate> component</a>
+<a href="#summary-of-concrete-files-to-add-touch">Summary of concrete files to add / touch</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-f-payments-compared.html
+++ b/plans/research/premium-monetization/site/appendix-f-payments-compared.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Payment Gateways Compared · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html" aria-current="page">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix F</div><h1 class="page-title">Payment Gateways Compared</h1><p class="lead">Selling a one-time <strong>$19 lifetime</strong> Pro unlock for Totem — a Manifest V3 Chrome extension — to a privacy-conscious, indie-hacker, PKM audience. Solo dev, local-first ethos, open-source extension code, wants minimal ops and global sales tax handled.</p>
+
+<div class="takeaway"><div class="takeaway-label">BOTTOM LINE</div> For a solo dev who wants tax handled and almost no server, the realistic finalists are <strong>Merchant-of-Record (MoR)</strong> providers. <span class="hl">Polar (polar.sh) is the recommended primary pick</span> — cheapest MoR economics, modern license-key API whose <em>validate</em> endpoint is explicitly safe to call from a public client. Lemon Squeezy is the fallback (most mature, but pricier and mid-transition). ExtensionPay is easiest to wire but is <strong>not</strong> an MoR.</div>
+
+<h2 id="comparison-table">Comparison table</h2>
+
+<table class="striped">
+<thead>
+<tr>
+<th>Provider</th>
+<th>Fee (one-time sale)</th>
+<th>MoR? (handles global VAT/GST)</th>
+<th>One-time / lifetime</th>
+<th>License key API</th>
+<th>Offline / client-side validation</th>
+<th>MV3 / JS SDK ease</th>
+<th>Refunds &amp; chargebacks</th>
+<th>Payout requirements</th>
+<th>Key gotchas</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>ExtensionPay (ExtPay)</strong></td>
+<td><strong>5%</strong> at time of charge, no monthly fee; lower/flat rates for high volume by request. Runs on <strong>your own Stripe</strong> underneath (Stripe's 2.9%+30¢ on top, paid to your Stripe).</td>
+<td><strong>No.</strong> Thin layer on your Stripe — <em>you</em> are the MoR and owe sales tax/VAT.</td>
+<td>Yes — monthly, quarterly, yearly, <strong>one-time</strong>.</td>
+<td>No license keys. Identity = <strong>email magic link</strong>; paid status lives on extensionpay.com keyed to extension ID + email.</td>
+<td><strong>No.</strong> <code>getUser()</code> makes a network call to extensionpay.com every time; no documented offline cache.</td>
+<td><strong>Easiest</strong> — built for extensions. <code>ExtPay(id)</code> + <code>startBackground()</code> in SW + <code>getUser()</code>. Needs <code>storage</code> permission + CSP <code>connect-src https://extensionpay.com</code>.</td>
+<td>Handled via your Stripe dashboard (you manage disputes; you eat chargebacks).</td>
+<td>Direct to <strong>your Stripe</strong> account (Stripe payout rules apply).</td>
+<td>Hard runtime dependency on a third-party server; slow JS lib cadence; no tax handling; another origin in the trust chain for an OSS/privacy product.</td>
+</tr>
+<tr>
+<td><strong>Stripe (Payment Links / Checkout)</strong></td>
+<td><strong>2.9% + 30¢</strong> (US card).</td>
+<td><strong>No</strong> (plain Stripe). <em>You</em> are MoR; tax is your problem in every country. (Stripe Tax helps <em>calculate</em> but you still register/remit.)</td>
+<td>Yes.</td>
+<td>No built-in license keys — you build issuance + a validation endpoint yourself (needs a server/edge function + secret).</td>
+<td>Possible but <strong>you must build &amp; host it</strong>; can't safely validate against Stripe from a public client.</td>
+<td>Medium. Payment Link is trivial; reconciling "did this user pay?" needs your own backend + webhooks.</td>
+<td>You manage refunds/disputes; you pay chargeback fees.</td>
+<td>Standard Stripe payouts to your bank.</td>
+<td>Defeats the "minimal server / tax handled" goal. <strong>Stripe Managed Payments</strong> (their MoR) adds <strong>~+3.5%</strong> on top but is the heavyweight path.</td>
+</tr>
+<tr>
+<td><strong>Lemon Squeezy</strong> (Stripe-owned)</td>
+<td><strong>5% + 50¢</strong>; +1.5% intl card, +1.5% PayPal, +0.5% subscription.</td>
+<td><strong>Yes</strong> — full MoR, remits global sales tax/VAT/GST.</td>
+<td>Yes — one-time products + license keys.</td>
+<td><strong>Yes, mature.</strong> Built-in key generation + License API: <code>POST https://api.lemonsqueezy.com/v1/licenses/validate</code> and <code>/activate</code>, <code>/deactivate</code>. Endpoints take the <strong>license key itself (no secret API key)</strong>.</td>
+<td><strong>Yes</strong> — validate/activate callable client-side with just key + instance_id; cache the validated result locally.</td>
+<td>Good. Hosted overlay checkout (<code>lemon.js</code>) or hosted link; webhooks for fulfillment.</td>
+<td>MoR handles it: refunds on your behalf, <strong>$15 dispute fee</strong> + refunded amount deducted from next payout.</td>
+<td><strong>$100 minimum payout</strong>, automated on the 14th &amp; 28th.</td>
+<td><strong>Transition risk:</strong> acquired by Stripe (2024). Feb 2026 = Stripe Managed Payments public preview + migration path for LS merchants; LS still accepts signups but long-term direction is toward Stripe Managed Payments.</td>
+</tr>
+<tr>
+<td><strong>Paddle</strong></td>
+<td><strong>5% + 50¢</strong> (Starter, no monthly fee); custom on Growth/Enterprise.</td>
+<td><strong>Yes</strong> — full MoR; becomes legal seller, handles tax, fraud, chargebacks, refunds.</td>
+<td>Yes.</td>
+<td>License keys <strong>not a first-class built-in</strong> like LS/Polar; typically you provision keys yourself from the webhook. Custom flows via improved 2025–26 API.</td>
+<td>You build your own key storage/validation; feasible but more work.</td>
+<td>Medium. Good hosted + embedded checkout (<code>Paddle.js</code>), strong tax/compliance.</td>
+<td>MoR handles refunds/chargebacks.</td>
+<td>Standard Paddle payout schedule to bank.</td>
+<td>More enterprise-oriented; historically stricter merchant approval/onboarding review; license-key UX weaker than LS/Polar for indie one-time sales.</td>
+</tr>
+<tr>
+<td><strong>Polar (polar.sh)</strong></td>
+<td><strong>Starter (free): 5% + 50¢</strong>; <strong>Pro $20/mo: 3.8% + 40¢</strong>; Growth/Scale lower. +1.5% intl cards; <strong>$15 chargeback</strong>. (Orgs created before May 27, 2026 keep an "Early Member" rate.)</td>
+<td><strong>Yes</strong> — full MoR; takes on global sales-tax liability.</td>
+<td>Yes — define a <strong>one-time</strong> product.</td>
+<td><strong>Yes.</strong> License keys as a product "benefit" (auto-issued on purchase). Validate: <code>POST /v1/customer-portal/license-keys/validate</code> — explicitly "doesn't require authentication and can be safely used on a public client." Server-side variant: <code>/v1/license-keys/validate</code>.</td>
+<td><strong>Yes — best fit.</strong> Public validate endpoint is <em>designed</em> for untrusted clients, so an MV3 extension (or OSS code) can validate without embedding any secret.</td>
+<td>Good. Type-safe <code>@polar-sh/sdk</code> (npm), hosted checkout, webhooks, customer portal.</td>
+<td>MoR handles refunds; <strong>$15 per dispute</strong> regardless of outcome.</td>
+<td>Stripe-backed payouts: <strong>$2/mo active-payout fee + 0.25% + $0.25 per payout</strong>; meet minimum threshold, then on-demand.</td>
+<td>Newer/smaller than LS &amp; Paddle; 2026 pricing moved the free tier to 5%+50¢ unless you pay monthly; payout fees stack on top.</td>
+</tr>
+<tr>
+<td><strong>Gumroad</strong></td>
+<td><strong>10% + 50¢</strong> flat (Discover marketplace = 30%).</td>
+<td><strong>Yes</strong> — full MoR since <strong>Jan 1, 2025</strong> (calculates, collects, remits VAT/GST/sales tax).</td>
+<td>Yes — one-time digital products.</td>
+<td><strong>Yes</strong> — built-in license keys + verify API (<code>/v2/licenses/verify</code>).</td>
+<td>Verify endpoint callable with product_permalink + key (no secret needed); cacheable.</td>
+<td>Low/medium for extensions — checkout is web/overlay, no extension-native SDK; you'd glue email→key→extension manually.</td>
+<td>MoR handles refunds/chargebacks.</td>
+<td><strong>$10 minimum</strong>, weekly payouts (PayPal/direct deposit).</td>
+<td><strong>Highest fee (10%)</strong> — on a $19 sale ~$2.40 vs ~$1.45 (5%+50¢) vs ~$1.16 (Polar Pro 3.8%+40¢). Brand/UX feels creator-marketplace, less "software license."</td>
+</tr>
+</tbody>
+</table>
+
+<h3>MoR head-to-head (Lemon Squeezy vs Paddle vs Polar)</h3>
+<ul>
+<li><strong>All three are true MoRs</strong> — they become the legal seller and remit global VAT/GST/sales tax, so the solo dev never registers for tax anywhere. This is the single biggest reason to pick one of these over raw Stripe/ExtPay.</li>
+<li><strong>Cheapest:</strong> Polar (esp. on a paid monthly plan, 3.8%+40¢) &lt; Lemon Squeezy / Paddle (5%+50¢) &lt; Gumroad (10%+50¢).</li>
+<li><strong>Best license-key DX for a public/OSS client:</strong> <strong>Polar</strong> (auth-free public validate endpoint, stated safe for untrusted clients) and <strong>Lemon Squeezy</strong> (validate/activate take only the key, no secret) tie; <strong>Paddle</strong> trails (roll your own from webhooks).</li>
+<li><strong>Most mature / lowest "will it still exist" risk:</strong> Lemon Squeezy and Paddle. But LS now carries Stripe-acquisition/transition uncertainty (migration path to Stripe Managed Payments announced Feb 2026); Polar carries "young company" risk.</li>
+</ul>
+
+<h2 id="extensionpay-extpay-exact-model">ExtensionPay (ExtPay) — exact model</h2>
+<ul>
+<li><strong>Fee:</strong> <strong>5%</strong> transaction fee at time of charge, no monthly/upfront fee. Lower fees / flat monthly rates for high-volume accounts (email glen@extensionpay.com). It is a <strong>layer on top of Stripe</strong>: funds paid <strong>directly to your own Stripe account</strong>, data stored in Stripe so you can migrate away. All-in cost = <strong>5% (ExtPay) + Stripe's 2.9%+30¢</strong>.</li>
+<li><strong>Not an MoR:</strong> the sale settles into <em>your</em> Stripe, so <strong>you are the merchant of record and owe sales tax/VAT</strong> yourself. The decisive negative vs. LS/Paddle/Polar/Gumroad.</li>
+<li><strong>Payment ↔ user association:</strong> there is <strong>no license key</strong>. Identity is the user's <strong>email via a magic login link</strong>. Paid status stored on extensionpay.com, keyed to your <strong>registered extension ID + the user's email</strong>. On reinstall or new device, the user clicks "log in" → magic-link email → paid features reactivate.</li>
+<li><strong>Paid-status check:</strong> call <code>extpay.getUser()</code>, which <strong>makes a network call to extensionpay.com</strong> and returns <code>user.paid</code> (boolean), <code>user.paidAt</code> (Date|null), <code>user.email</code>, <code>user.plan</code>, plus subscription fields. <strong>No documented offline cache</strong> — <code>getUser()</code> hits the network each time and can throw on network failure. Events: <code>extpay.onPaid.addListener(...)</code> fires on pay or login.</li>
+<li><strong>Must call extensionpay.com? Yes.</strong> The library "only communicates with ExtensionPay.com servers to manage users' paid status." Allow that origin in CSP (<code>connect-src https://extensionpay.com</code>); Firefox may also need <code>https://extensionpay.com/*</code> in permissions; content-script callbacks need a content script matching <code>https://extensionpay.com/*</code>.</li>
+<li><strong>Integration:</strong> <code>ExtPay('your-extension-id')</code>, call <code>extpay.startBackground()</code> once in the service worker, then <code>extpay.getUser()</code> / <code>extpay.openPaymentPage()</code>. Minimum manifest permission is just <code>"storage"</code>.</li>
+<li><strong>Gotchas for Totem:</strong> (1) not local-first — every paid check phones a third-party server; (2) no tax handling; (3) JS lib update cadence slow (server side still maintained); (4) for a <em>one-time lifetime</em> unlock the email-magic-link model means a user with no network can't verify Pro.</li>
+</ul>
+
+<h2 id="recommendation-for-totem">Recommendation for Totem</h2>
+
+<div class="callout"><strong>Primary pick: Polar (polar.sh).</strong> &nbsp;·&nbsp; <strong>Fallback: Lemon Squeezy.</strong></div>
+
+<h3>Why Polar</h3>
+<ol>
+<li><strong>MoR = tax is fully handled.</strong> Solo dev never registers/remits VAT/GST anywhere — Polar is the legal seller. Directly satisfies "minimal ops + tax handled."</li>
+<li><strong>Cheapest of the MoRs.</strong> On a $19 sale: ~$1.16 net fee at Pro (3.8%+40¢) or ~$1.45 at the free 5%+50¢ tier — vs Gumroad's ~$2.40. More margin on a low-price one-time unlock.</li>
+<li><strong>License-key model fits local-first + OSS perfectly.</strong> Polar issues a license key as a purchase benefit, and its <span class="hl">public validate endpoint <code>POST /v1/customer-portal/license-keys/validate</code> requires no authentication and is explicitly documented as safe for public clients</span> (desktop/mobile/extension). The extension can validate the key <strong>without embedding any secret</strong> — essential because Totem's source is public. Validate once, cache "Pro = true" + key in <code>chrome.storage.local</code>/IndexedDB, run offline thereafter, re-check occasionally. No Totem server required.</li>
+<li><strong>Modern, type-safe <code>@polar-sh/sdk</code> + hosted checkout + webhooks.</strong> Minimal integration surface.</li>
+</ol>
+
+<h3>Why not the others as primary</h3>
+<ul>
+<li><strong>ExtPay:</strong> easiest to wire, but <strong>not an MoR</strong> (you owe tax) and forces a <strong>hard runtime dependency on extensionpay.com</strong> for every paid check — antithetical to local-first, and an extra third-party origin in the trust chain for a privacy-positioned OSS product.</li>
+<li><strong>Raw Stripe / Payment Links:</strong> <strong>not an MoR</strong> — tax becomes your problem in every country, and you'd have to build your own license server. Stripe Managed Payments (their MoR) adds ~+3.5%.</li>
+<li><strong>Gumroad:</strong> clean MoR + license keys, but <strong>10%</strong> is the highest fee and the UX reads "creator marketplace," not "software license."</li>
+<li><strong>Paddle:</strong> solid MoR, but weaker first-class license-key DX for indie one-time sales and heavier onboarding.</li>
+</ul>
+
+<h3>Why Lemon Squeezy as fallback (not primary)</h3>
+<p>It's the most battle-tested license API (validate/activate/deactivate, key-only, cacheable) and a true MoR — an excellent fit — but it's <strong>pricier than Polar</strong> (5%+50¢, $100 min payout) and now sits inside <strong>Stripe's MoR transition</strong> (Feb 2026 Managed Payments preview + LS migration path). If Polar's youth/feature-gaps become a problem, LS is the safe, mature swap.</p>
+
+<div class="takeaway"><div class="takeaway-label">PRICING NOTE</div> For the $14 founders / $19 list: all MoR fees scale fine at this price; the per-transaction fixed component (40–50¢) is the bigger relative bite on a sub-$20 product, which again favors Polar's lower fixed fee.</div>
+
+<h2 id="integration-sketch-polar-in-an-mv3-extension">Integration sketch — Polar in an MV3 extension</h2>
+<p><strong>Goal:</strong> sell a one-time $19 "Totem Pro" product in Polar, issue a license key, validate it from the extension with no secret, cache the result locally (local-first).</p>
+
+<h3>A. Polar dashboard (one-time setup, no code)</h3>
+<ul>
+<li>Create org → create a <strong>one-time product</strong> "Totem Pro — $19" ($14 founders coupon).</li>
+<li>Add the <strong>License Key</strong> benefit to the product (auto-issues a key on purchase).</li>
+<li>Grab the <strong>organization ID</strong> (public, used only to scope validation) and a hosted <strong>Checkout Link</strong>.</li>
+</ul>
+
+<h3>B. Selling</h3>
+<p>From the extension's upgrade UI, open the Polar <strong>hosted checkout</strong> in a new tab (<code>chrome.tabs.create({ url: checkoutLink })</code>). Polar collects payment, remits tax as MoR, and emails the buyer their license key + a customer-portal link. No checkout code or PCI surface in the extension.</p>
+
+<h3>C. Entering the key</h3>
+<p>The Pro settings panel has an "Enter license key" input. User pastes the key from the email.</p>
+
+<h3>D. Validation (no secret, public endpoint)</h3>
+<pre><code>// runs in the service worker; no API key embedded — safe for public/OSS code
+async function validateProKey(licenseKey) {
+  const res = await fetch('https://api.polar.sh/v1/customer-portal/license-keys/validate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      key: licenseKey,
+      organization_id: TOTEM_ORG_ID, // public scoping value, not a secret
+    }),
+  });
+  if (!res.ok) return { valid: false };
+  const data = await res.json();           // { status, key, ... }
+  return { valid: data.status === 'granted', data };
+}</code></pre>
+
+<h3>E. Local-first caching (the important part)</h3>
+<ul>
+<li>On a successful validate, store <code>{ pro: true, key, validatedAt }</code> in <code>chrome.storage.local</code> (and mirror the flag into Zustand state). Gate Pro features (MD/CSV/JSONL export, deleted-tweet preservation, bulk ops, advanced filters, annotations, thread capture) on this flag.</li>
+<li>The extension reads the <strong>local flag</strong> on every launch — <strong>fully offline</strong>. It only re-hits Polar's validate endpoint <strong>occasionally</strong> (e.g., once every N days, or on user "Re-check license") to confirm the key wasn't refunded/revoked. A failed network re-check should <strong>not</strong> instantly revoke Pro (grace period) — keeps it local-first and resilient.</li>
+</ul>
+
+<h3>F. manifest.json (MV3) needs</h3>
+<pre><code>{
+  "permissions": ["storage"],
+  "host_permissions": ["https://api.polar.sh/*"]
+}</code></pre>
+<ul>
+<li><code>host_permissions</code> (or a <code>connect-src https://api.polar.sh</code> if you ship an explicit CSP) so the service worker can <code>fetch</code> the validate endpoint.</li>
+<li><code>tabs</code> only if you use <code>chrome.tabs.create</code> for checkout (or just use a normal link / <code>window.open</code>).</li>
+<li>No client secret anywhere — the public validate endpoint + public org ID are the only Polar values in the (public) source.</li>
+</ul>
+
+<h3>G. Where the key lives</h3>
+<p>The <strong>license key string</strong> in <code>chrome.storage.local</code>; the derived <strong><code>pro</code> boolean + validatedAt</strong> alongside it (and in Zustand for runtime). Nothing sensitive, nothing server-side, no Totem backend.</p>
+
+<p><strong>Optional hardening:</strong> add a Polar <strong>webhook</strong> (<code>order.created</code> / <code>benefit_grant.created</code>) to a tiny serverless function only if you later want server-side analytics or to pre-bind keys — <strong>not required</strong> for the core unlock, keeping the no-server ethos intact.</p>
+
+<h2 id="sources">Sources</h2>
+<ul>
+<li>ExtensionPay home (5% fee, Stripe payout, one-time support): <code>https://extensionpay.com/</code></li>
+<li>ExtensionPay — CWS payments replacement / 5% context: <code>https://extensionpay.com/articles/extensionpay-is-the-chrome-web-store-payments-replacement</code></li>
+<li>ExtPay GitHub (library, no-server, methods): <code>https://github.com/Glench/ExtPay</code></li>
+<li>ExtPay README (manifest, getUser network call, magic-link model): <code>https://raw.githubusercontent.com/Glench/ExtPay/master/README.md</code></li>
+<li>Stripe fees + MoR clarification (Managed Payments ~+3.5%): <code>https://dodopayments.com/blogs/stripe-fees-calculator</code> and <code>https://freemius.com/blog/stripe-transaction-fees-real-cost/</code></li>
+<li>Stripe local payment methods pricing: <code>https://stripe.com/pricing/local-payment-methods</code></li>
+<li>Stripe acquires Lemon Squeezy (2024): <code>https://www.lemonsqueezy.com/blog/stripe-acquires-lemon-squeezy</code> and <code>https://techcrunch.com/2024/07/26/stripe-acquires-payment-processing-startup-lemon-squeezy/</code></li>
+<li>Lemon Squeezy 2026 update / Stripe Managed Payments migration path: <code>https://www.lemonsqueezy.com/blog/2026-update</code></li>
+<li>Lemon Squeezy pricing (5%+50¢, surcharges): <code>https://www.lemonsqueezy.com/pricing</code></li>
+<li>Lemon Squeezy License API (validate endpoint, no Authorization header, instance_id): <code>https://docs.lemonsqueezy.com/api/license-api/validate-license-key</code> and <code>https://docs.lemonsqueezy.com/api/license-api/activate-license-key</code></li>
+<li>Lemon Squeezy refunds/chargebacks ($15 dispute fee): <code>https://docs.lemonsqueezy.com/help/payments/refunds-chargebacks</code></li>
+<li>Lemon Squeezy payouts ($100 min, 14th/28th): <code>https://docs.lemonsqueezy.com/help/affiliates-for-merchants/payouts</code></li>
+<li>Paddle fees (5%+50¢ MoR) review: <code>https://dodopayments.com/blogs/paddle-review</code> and <code>https://dev.to/onsen/paddle-review-2026-pros-cons-pricing-explained-4cgk</code></li>
+<li>Polar pricing (tiered 2026, 5%+50¢ free / 3.8%+40¢ Pro): <code>https://polar.sh/resources/pricing</code> and <code>https://dodopayments.com/blogs/polar-sh-review</code></li>
+<li>Polar fees doc (intl +1.5%, $15 chargeback, payout fees): <code>https://polar.sh/docs/merchant-of-record/fees</code></li>
+<li>Polar is an MoR (statement): <code>https://x.com/polar_sh/status/1917551367247241542</code></li>
+<li>Polar license keys benefit + SDK: <code>https://polar.apidocumentation.com/documentation/features/benefits/license-keys</code> and <code>https://www.npmjs.com/package/@polar-sh/sdk</code></li>
+<li>Polar validate endpoint — no auth, safe for public clients: <code>https://polar.sh/docs/api-reference/customer-portal/license-keys/validate</code></li>
+<li>Gumroad fees (10%+50¢) + MoR since Jan 1 2025: <code>https://checkoutpage.com/blog/gumroad-fees</code> and <code>https://www.swell.is/content/gumroad-pricing</code></li>
+<li>Gumroad license keys: <code>https://gumroad.com/help/article/76-license-keys</code></li>
+<li>MoR comparison (Polar vs LS vs Paddle, payouts, chargebacks): <code>https://www.buildmvpfast.com/blog/lemon-squeezy-vs-polar-paddle-merchant-of-record-2026</code> and <code>https://veloxthemes.com/blog/polar-vs-lemonsqueezy-vs-gumroad</code></li>
+</ul>
+<nav class="pager"><a class="pager-link prev" href="appendix-e-ui-state-upsell.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">UI State &amp; Upsell Surfaces</span></a><a class="pager-link next" href="appendix-g-license-arch.html"><span class="pager-eyebrow">Next</span><span class="pager-title">License Architecture &amp; DRM Stance</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#comparison-table">Comparison table</a>
+<a href="#extensionpay-extpay-exact-model">ExtensionPay (ExtPay) — exact model</a>
+<a href="#recommendation-for-totem">Recommendation for Totem</a>
+<a href="#integration-sketch-polar-in-an-mv3-extension">Integration sketch — Polar in an MV3 extension</a>
+<a href="#sources">Sources</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-g-license-arch.html
+++ b/plans/research/premium-monetization/site/appendix-g-license-arch.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>License Architecture & DRM Stance · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html" aria-current="page">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix G</div><h1 class="page-title">License Architecture &amp; DRM Stance</h1><div class="callout"><span class="tag">DECISION UPDATE</span> This appendix is the <strong>raw research</strong> that explored <em>offline</em> Ed25519-signed keys. The project ultimately <strong>did not adopt</strong> that approach: verification is <strong>online-validate-then-cache</strong> via the provider's license API (validate once at activation, cache locally, read offline from cache, re-check in the background with fail-open) — chosen because it is simpler and because it enables multi-device management, which a fully-offline key cannot. See Chapters 4–5 for the shipped design; read the crypto exploration below as the option that was considered and set aside. The "crackable is fine" / anti-DRM stance below still holds.</div>
+
+<p class="lead">How to gate a paid "Pro" tier when the source is public on GitHub, there is no Totem server, and Chrome's MV3 policy forbids remotely-hosted code. The honest answer: the crypto is sound, the gate is patchable, and that is the correct strategy rather than a failure.</p>
+
+<h2 id="the-constraint-stated-honestly-up-front">The constraint, stated honestly up front</h2>
+
+<p>Totem is three things at once, and they collide into one hard truth:</p>
+
+<ul>
+<li><strong>Open-source</strong> — source public on GitHub.</li>
+<li><strong>Local-first</strong> — no Totem server, no account, <code>IndexedDB</code> + <code>chrome.storage.local</code>.</li>
+<li><strong>MV3</strong> — Chrome Web Store policy forbids remotely-hosted <em>code</em>.</li>
+</ul>
+
+<div class="callout">Any client-side-only entitlement check in open-source software can be patched out by a determined user who recompiles the extension. There is no cryptography that fixes this — the public key, the verifier, and the <code>isPro</code> flag all live on the user's machine, in code they can read and edit.</div>
+
+<p>So the goal is <strong>not</strong> "make Pro uncrackable." That is impossible, and chasing it wastes engineering on DRM that the target communities (r/selfhosted, HN, r/privacy) actively distrust. The goal is to <span class="hl">make legitimately paying easier, more pleasant, and more trustworthy than cracking</span> — and keep the honest-buyer experience clean. Lose the rounding-error of users who would never have paid anyway.</p>
+
+<p>This is the canonical "service problem, not a pricing problem" framing from Gabe Newell:</p>
+
+<blockquote>Piracy is almost always a service problem and not a pricing problem... the way to stop piracy is not by selling at a lower price, but by offering a service that's better than what the pirates can provide.<span class="cite"> - Gabe Newell, Valve (Escapist / Slashdot / HN)</span></blockquote>
+
+<p>For a $19 one-time lifetime tool, the cracker's "service" — find a patched build, trust a stranger's binary, re-patch on every update, get no support — is <em>worse</em> than just paying once. <strong>That is the moat, not the crypto.</strong></p>
+
+<h2 id="signed-license-keys-with-offline-verification-the-crypto-layer">Signed license keys with offline verification (the crypto layer)</h2>
+
+<h3>The pattern</h3>
+
+<p>A signed license key is <code>base64(payload) . base64(signature)</code> — a small data object the vendor signs with a <strong>private key</strong> (server / issuance side only) and the client verifies with an <strong>embedded public key</strong>. No secret lives client-side; the public key is safe to ship in the extension bundle. This is exactly how Keygen, Keyforge, Polar, Cryptolens, and the "license key as JWT" pattern all work.</p>
+
+<p>Keygen's canonical description: a signed key is <code>${ENCODED_DATA}.${ENCODED_SIGNATURE}</code>, e.g.</p>
+
+<pre><code>dXNlckBjdXN0b21lci5leGFtcGxl.kANuXAhc8b7rDNgbFBpoSUsmfkM7msQC0tNkeUed4b5W15xF6zxmoV3AYF54zaWFMHznSNY7M9bLloInknvlDw==</code></pre>
+
+<p>The data is base64-encoded plaintext; the signature is produced with the vendor's private Ed25519 key. The client verifies with only the public key, embedded in the application.</p>
+
+<blockquote>Unless a bad actor can break Ed25519 or RSA-2048, writing a keygen is effectively impossible.<span class="cite"> - Keygen, How to Generate Secure License Keys</span></blockquote>
+
+<p>Client verification is a handful of lines (Keygen's own example, Node <code>crypto</code>):</p>
+
+<pre><code>const [encodedData, encodedSignature] = licenseKey.split('.')
+const signature = Buffer.from(encodedSignature, 'base64')
+const data      = Buffer.from(encodedData, 'base64').toString()
+const valid     = crypto.verify(null, Buffer.from(data), publicKey, signature)</code></pre>
+
+<h3>Algorithm choice: Ed25519 (EdDSA), not RSA</h3>
+
+<ul>
+<li>Ed25519 keys/signatures are <strong>tiny</strong> vs RSA (keeps the license string short enough to paste). EdDSA is recommended for new implementations where the JWT/crypto library supports it (Curity — JWT signatures with EdDSA).</li>
+<li>Keygen defaults to Ed25519 when no scheme is set; supports Ed25519 or 2048-bit RSA, optionally AES-256-GCM encryption (Keygen cryptography docs).</li>
+<li>Industry trend: Ed25519 has displaced RSA as the modern default for signatures (DEV — SSH Keys in 2024: Why Ed25519 Replaced RSA).</li>
+</ul>
+
+<h3>Libraries — fits for Totem's existing stack</h3>
+
+<p>The repo already ships <code>@noble/hashes 2.2.0</code> (confirmed in <code>package.json</code>). The natural companions:</p>
+
+<ul>
+<li><strong><code>@noble/ed25519</code></strong> — "Fastest 5KB JS implementation of ed25519 signatures" (paulmillr). API is exactly the detached-signature shape we need:
+<pre><code>import * as ed from '@noble/ed25519';
+const isValid = await ed.verify(signature, message, publicKey); // → boolean</code></pre>
+Inputs accept <code>Uint8Array</code> or hex; verify supports detached signatures natively.</li>
+<li><strong><code>@noble/curves</code></strong> — broader suite (also from paulmillr) if more than ed25519 is ever needed.</li>
+<li><strong>Zero-dep alternative:</strong> the browser-native <code>SubtleCrypto.verify()</code> Web Crypto API supports Ed25519 in modern Chrome (MDN). This avoids adding any dependency at all, but <code>@noble/ed25519</code> is more ergonomic, battle-tested across environments, and pairs with the <code>@noble/hashes</code> already present.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">RECOMMENDATION</div> <code>@noble/ed25519</code> (+ the already-present <code>@noble/hashes</code> for the SHA-512 it needs). ~5 KB, audited, matches the existing dependency philosophy.</div>
+
+<h3>License-as-signed-JWT variant (equivalent, more standard)</h3>
+
+<p>Instead of a bespoke <code>payload.sig</code> format, the same thing can be a <strong>JWT signed with EdDSA (<code>Ed25519</code>) or RS256</strong>: header + payload + signature, verifiable offline with the public key, no server call.</p>
+
+<blockquote>A JWT is a small, signed data object that can be verified without calling a server... your app can verify it offline.<span class="cite"> - Keyforge, How to use JWTs for offline licensing</span></blockquote>
+
+<p>Keyforge issues signed license <strong>tokens (JWTs)</strong> the app verifies locally with no network call, so the app keeps working offline. The payload carries license key id, product id, device identifier, device name, and an <code>exp</code> expiration claim; the signature covers the payload so the user can't modify contents without breaking verification. For Totem the bespoke <code>base64(json).base64(ed25519sig)</code> format is simpler than dragging in a JWT lib, but a JWT is fine if a license vendor emits one natively. <strong>Either is equivalent crypto.</strong> The decision is driven by what the chosen payment vendor produces.</p>
+
+<h3>What to embed in Totem's license payload</h3>
+
+<p>Minimal, copy-paste-friendly JSON, then ed25519-signed:</p>
+
+<pre><code>{
+  "v": 1,
+  "email": "buyer@example.com",
+  "plan": "pro-lifetime",
+  "order": "ls_ord_abc123",
+  "issued": "2026-06-19",
+  "exp": null,            // null = lifetime; or an ISO date for refresh-token style
+  "feat": ["export","preserve","bulk","filters","annotate"]
+}</code></pre>
+
+<p>The "more data you embed, the larger the key" — not a problem since users paste, not type. Embedding the <strong>email</strong> is a deliberate soft anti-piracy nudge: a leaked key is traceable to the buyer, and the extension can display <em>"Licensed to buyer@example.com"</em> — social friction, not technical DRM.</p>
+
+<h2 id="the-fundamental-reality-it-s-crackable-and-that-s-fine">The fundamental reality: it's crackable, and that's fine</h2>
+
+<h3>Why it's unavoidable here</h3>
+
+<p>Open-source + client-only means the verifier, the embedded public key, and the <code>isPro</code> boolean are all in readable code. A determined user can:</p>
+
+<ul>
+<li>delete the verification call and hard-code <code>isPro = true</code>, or</li>
+<li>generate their own keypair, swap the embedded public key, and self-sign keys.</li>
+</ul>
+
+<p>No client-side scheme prevents this. The community even names the trade-off: the way source-available freemium apps "protect" paid features is to keep <strong>premium pieces closed / source-available</strong> while the open core stays public. Standard Notes keeps the app + server open source but ships <strong>some subscription extensions as source-available (closed)</strong> (AlternativeTo); Obsidian sidesteps it entirely by being <strong>proprietary</strong> with paid Sync/Publish (XDA). Totem's whole pitch is auditability, so going closed-source is off the table — which means <span class="hl">accepting leakage is the correct strategy, not a failure.</span></p>
+
+<h3>The pragmatic indie consensus</h3>
+
+<ul>
+<li><strong>Gabe Newell / Valve</strong> — the foundational "piracy is a service problem; out-serve the pirates" thesis, repeatedly cited by indie devs as the reason heavy DRM backfires (Escapist, GamesRadar, TechRadar).</li>
+<li><strong>Indie devs measuring real piracy rates</strong> find a large share of "pirates" would never have paid — fighting them is negative ROI, and even AAA DRM is cracked within a week, so the winning move is a superior experience for buyers (<em>"So 52.45% of People Playing my Indie Game Have Pirated it"</em> — Game Developer; developers who <em>encourage</em> piracy as marketing because non-payers wouldn't convert anyway — PCWorld / Darkwood, TheGamer).</li>
+<li><strong>OSS monetization in practice (2024–2026)</strong> has converged on models that <em>don't</em> depend on un-crackable clients: open-core (paid features companies will pay for), sponsorship (GitHub Sponsors / Open Collective / Patreon), and managed/hosted convenience (awesome-oss-monetization, reo.dev — 7 strategies, Polar). The throughline: <strong>the moat is convenience, trust, support, and ongoing value — not a license check.</strong></li>
+</ul>
+
+<h3>What this means for Totem specifically</h3>
+
+<p>The honest stance to publish, in docs and the buy flow:</p>
+
+<blockquote>Totem is open source. You <em>could</em> patch out the Pro check — the code is right there. We're not going to fight you with DRM that would make the app worse for everyone. Pro is $19 once; it funds the deleted-tweet preservation, export, and search work. If you find it useful, buy it. If you genuinely can't, the free tier is fully functional forever.<span class="cite"> - Proposed Totem stance copy</span></blockquote>
+
+<p>This converts the crackability from a liability into a <strong>brand-aligned trust signal</strong> for exactly the privacy / self-hosted / HN audience Totem is courting — the same audience that distrusts cloud DRM and values auditability above all.</p>
+
+<h2 id="online-activation-vs-fully-offline-vendor-comparison">Online activation vs fully-offline (vendor comparison)</h2>
+
+<h3>The spectrum</h3>
+
+<table class="compact">
+<thead><tr><th>Dimension</th><th>Fully offline (signed key)</th><th>Online activation (API)</th></tr></thead>
+<tbody>
+<tr><td>Network after first entry</td><td>none — pure local crypto</td><td>required each validate (or periodic)</td></tr>
+<tr><td>Revocation speed</td><td>only at token <code>exp</code> / next refresh</td><td>immediate</td></tr>
+<tr><td>Device binding / activation limit</td><td>only what's baked into the signed payload</td><td>enforced server-side, real-time</td></tr>
+<tr><td>Works on plane / offline</td><td>yes</td><td>no (unless cached + grace period)</td></tr>
+<tr><td>Privacy (no phone-home)</td><td>best — nothing leaves device</td><td>each check is a network event</td></tr>
+<tr><td>Fits Totem's "no server" ethos</td><td>perfectly</td><td>mild tension (3rd-party server)</td></tr>
+</tbody>
+</table>
+
+<p>Keyforge's own table captures the trade: offline = no network dependency after activation, <strong>delayed</strong> revocation (until token expiry), works offline, grace period recommended; online = immediate revocation but fails with no connection. The standard hybrid: <strong>first-time activation is online</strong> (exchange the license key for a signed token bound to a device), then <strong>verify offline</strong> thereafter, <strong>refreshing the token in the background</strong> when connectivity returns; use a <strong>grace period</strong> instead of hard lockout on expiry.</p>
+
+<h3>What the vendors give you out of the box</h3>
+
+<p><strong>ExtPay / ExtensionPay</strong> — purpose-built for browser extensions, <em>no server needed</em>, Stripe on the backend. You drop in the open-source <code>ExtPay.js</code>, call <code>extpay.openPaymentPage()</code>, and read paid status via <code>extpay.getUser()</code> → <code>{ paid, paidAt, trialStartedAt, subscriptionStatus }</code>; cross-device via <code>extpay.openLoginPage()</code> (magic-link email); react to purchase via <code>extpay.onPaid.addListener()</code>. It is a <strong>data fetch</strong> to ExtensionPay servers (cached via <code>chrome.storage</code>), <strong>not remote code</strong> — so MV3-safe. It removes the need to build <em>any</em> server. Trade-off: it's <strong>online by design</strong> (<code>getUser</code> is a network call; offline persistence / cache duration are not strongly documented — handle <code>getUser().catch()</code>), and it's a dependency on ExtensionPay's service staying up — a slight tension with Totem's "nothing can shut down" pitch.</p>
+
+<p><strong>Lemon Squeezy license keys</strong> — merchant-of-record (handles VAT / sales tax). Keys are managed via <strong>activate / validate / deactivate</strong> API endpoints with an <strong>instance/activation limit</strong> (bind to N devices), online by default. Online validation, but you can wrap it: activate once, then trust a locally cached/signed result.</p>
+
+<p><strong>Polar license keys</strong> — also merchant-of-record. <strong>Activation limit</strong> per key (e.g. 3 instances), separate <strong>activate/deactivate</strong> calls so users can move machines, <strong>automatic revocation</strong> when a subscription is cancelled, and JSON <strong>conditions</strong> (IP/MAC/version) checked server-side. Caveat: Polar's license validation is <strong>online — every check is a live API call, with no signed offline artifact or built-in grace period</strong> by default (LicenseSeat critique). Good for revocation, bad for "works offline forever."</p>
+
+<p><strong>Keygen / Keyforge</strong> — purpose-built licensing. Both support <strong>signed/encrypted offline license files</strong> verifiable with just your public key (Keygen: Ed25519/RSA, AES-256-GCM optional, tamper-proof embedded snapshot with expiry — designed for air-gapped/offline use). Keyforge issues signed-JWT tokens for offline verify and supports Stripe / Polar / Lemon Squeezy as the payment layer. These give the <strong>best offline story</strong> but add a licensing-vendor dependency.</p>
+
+<h3>Recommendation on the online/offline axis</h3>
+
+<div class="takeaway"><div class="takeaway-label">DECISION (superseded)</div> The research leaned toward offline-verified signed keys. The <strong>shipped decision is online-validate-then-cache</strong> (validate once, cache, read offline from cache, re-check with fail-open) — it gives the same "don't phone home on every launch" resilience while adding device management and provider-side revocation. See Ch. 4–5.</div>
+
+<p>Either way, Totem should <em>not</em> phone home on <em>every</em> launch — that contradicts the local-first, no-telemetry promise. The buyer activates once; thereafter Pro is read from the local cache and only re-checked occasionally in the background, failing open so an outage never revokes access. The online check (vs a fully-offline signed key) is what lets the provider count devices and revoke a refunded/charged-back order — both impossible to do offline.</p>
+
+<h2 id="the-mv3-constraint-data-fetch-remote-code">The MV3 constraint: data fetch ✅, remote code ❌</h2>
+
+<p>MV3 program policy: <strong>"an extension can only execute JavaScript that is included within its package"</strong> — no remotely-hosted code (JS from your server, CDN libraries, or bundled libs that dynamically fetch remote code).</p>
+
+<p>Crucially, the policy <strong>distinguishes code from data</strong>: extensions <em>may</em> fetch <strong>configuration data</strong> (e.g. a JSON file) to toggle features and change behavior at runtime; what's forbidden is fetching and <em>executing</em> code (Chrome docs, and the chromium-extensions thread clarifying remote config JSON is allowed).</p>
+
+<p><strong>Implications for license validation — both valid approaches are MV3-compliant:</strong></p>
+
+<ol>
+<li><strong>Pure local crypto</strong> — verify a pasted signed key with the embedded public key via <code>@noble/ed25519</code>: no network at all, trivially compliant. <span class="tag">MV3-SAFE</span></li>
+<li><strong>Data fetch</strong> — call ExtPay / Lemon Squeezy / Polar / Keygen license API, receive a JSON validation result or signed token: this is fetching <strong>data</strong>, not code — explicitly allowed. <span class="tag">MV3-SAFE</span> (exactly how ExtPay operates — <code>getUser()</code> is a data fetch).</li>
+</ol>
+
+<div class="callout">What you may <strong>not</strong> do: download a JS "license validator" module from a server and <code>eval</code> / import it at runtime. Keep all verification logic in the shipped bundle; only ever move <strong>data</strong> across the wire.</div>
+
+<h2 id="recommended-license-architecture-for-totem">Recommended license architecture for Totem</h2>
+
+<h3>Summary</h3>
+
+<p><span class="hl">Shipped design: provider-issued license keys, validated online once at activation and cached locally</span> (read offline from cache, re-checked in the background with fail-open), with a hosted merchant-of-record handling checkout, tax, issuance, and device counting. No Totem server. No per-launch phone-home. Honest, published "this is crackable and that's okay" stance. <em>(The offline-signed-key exploration that follows was considered and set aside — see the decision banner above.)</em></p>
+
+<h3>Where the key comes from</h3>
+
+<ul>
+<li><strong>Issuance (private side):</strong> a merchant-of-record handles checkout + tax. Two viable setups:
+<ul>
+<li><strong>(A) Keyforge/Keygen-style signing</strong> wired to <strong>Lemon Squeezy or Polar</strong> checkout: on successful order, the vendor (or a tiny serverless function / the licensing vendor itself) signs an Ed25519 license payload and emails the key to the buyer. Keyforge explicitly supports Stripe / Polar / Lemon Squeezy as payment and issues offline-verifiable signed tokens.</li>
+<li><strong>(B) DIY issuance:</strong> keep the Ed25519 <strong>private key</strong> in a single serverless endpoint (or even an offline signing script you run on orders). It signs <code>base64(json).base64(sig)</code> per Keygen's format. This is the cheapest, most "no-vendor-lock-in" option and fits Totem's ethos, at the cost of running one small signer.</li>
+</ul>
+</li>
+<li>The <strong>public key</strong> is embedded in the extension bundle (safe to ship; it can only verify, not sign).</li>
+</ul>
+
+<h3>Exact verification mechanism</h3>
+
+<p>In the extension's service worker (the API boundary), on key entry:</p>
+
+<pre><code>import * as ed from '@noble/ed25519';
+const PUBKEY = /* 32-byte ed25519 public key, hardcoded in bundle */;
+
+async function verifyLicense(key) {
+  const [b64data, b64sig] = key.trim().split('.');
+  if (!b64data || !b64sig) return null;
+  const data = JSON.parse(atobUtf8(b64data));            // {email, plan, exp, feat, ...}
+  const msg  = new TextEncoder().encode(b64data);        // sign/verify over the encoded data
+  const sig  = base64ToBytes(b64sig);
+  const ok   = await ed.verify(sig, msg, PUBKEY);        // pure local crypto, no network
+  if (!ok) return null;
+  if (data.exp &amp;&amp; new Date(data.exp) &lt; new Date()) return null; // null exp = lifetime
+  return data;                                            // valid entitlement
+}</code></pre>
+
+<p>Mirrors Keygen's offline verify pattern and <code>@noble/ed25519</code>'s <code>verify(sig, msg, pubkey)</code> API.</p>
+
+<h3>Online vs offline decision</h3>
+
+<ul>
+<li><strong>Shipped: online-validate-then-cache.</strong> Validate the key with the provider once at activation (counts the device), then read <code>isPro</code> from the local cache on every launch — no per-launch network. Preserves the local-first, zero-telemetry feel while enabling device management.</li>
+<li><strong>Background re-check, fail-open:</strong> at most weekly, Totem re-validates (or fetches a small revocation-list JSON) to catch refunds/charge-backs — a <strong>data fetch</strong>, MV3-legal. No network → <strong>stay Pro</strong>. The re-check is non-blocking and never the gate for a normal launch.</li>
+</ul>
+
+<h3>What's stored where</h3>
+
+<ul>
+<li><strong><code>chrome.storage.local</code>:</strong> the verified entitlement — <code>{ isPro: true, plan, email, order, feat, verifiedAt }</code>. Survives cache/history clears and is shared across service worker + extension pages.</li>
+<li><strong>The raw signed key:</strong> also stored in <code>chrome.storage.local</code> so it can be re-verified on demand and re-displayed.</li>
+<li><strong>Runtime:</strong> <code>isPro</code> mirrored into the Zustand store (matching Totem's existing state pattern) so React gates read it synchronously.</li>
+<li><strong>Re-verification:</strong> re-run the signature check on each startup from the stored key (cheap, offline) rather than trusting a bare boolean — so a flipped <code>isPro</code> in storage alone (without a valid key) doesn't unlock. (Caveat: a recompile still bypasses this — accepted.)</li>
+</ul>
+
+<h3>How revocation works</h3>
+
+<ul>
+<li><strong>Lifetime, no subscription</strong> → the dominant case never needs revocation.</li>
+<li><strong>Refund / chargeback</strong> → optional revocation-list fetch, fail-open. Worst case: a refunded user keeps Pro. Acceptable leakage.</li>
+<li><strong>If Totem ever adds a subscription tier</strong>, switch that tier to a <strong>short-<code>exp</code> signed token refreshed online</strong> (Keyforge model — revocation arrives at next refresh; grace period to avoid offline lockout). Not needed for the recommended $19 lifetime.</li>
+</ul>
+
+<h3>The honest stance (ship this copy)</h3>
+
+<p>Publish, in the README and the upgrade screen, the stance statement: open source, patchable, no DRM arms race, $19 funds the work, free tier stays whole. This is on-brand trust for Totem's audience and converts the "it's crackable" weakness into a feature.</p>
+
+<h2 id="end-to-end-sequence-purchase-unlock">End-to-end sequence: purchase → unlock</h2>
+
+<ol>
+<li><strong>PURCHASE</strong> — Buyer clicks "Upgrade to Pro – $19 lifetime" → opens hosted checkout (Lemon Squeezy / Polar = merchant-of-record, handles card + VAT).</li>
+<li><strong>LICENSE ISSUED</strong> — On successful order, issuer signs an Ed25519 license payload <code>{ email, plan:"pro-lifetime", order, exp:null, feat:[...] }</code> → <code>base64(payload).base64(sig)</code>. Emailed to buyer (+ shown on success page).</li>
+<li><strong>ENTERED / ACTIVATED</strong> — Buyer pastes the key into Totem's "Enter license" field (extension Options / upgrade screen). No account, no login required.</li>
+<li><strong>VERIFIED (offline, local crypto)</strong> — Service worker: <code>ed.verify(sig, encodedPayload, EMBEDDED_PUBKEY)</code> + check <code>exp</code>. Pure local computation, zero network. <span class="tag">MV3-SAFE</span></li>
+<li><strong>isPro = true</strong> — On valid signature → entitlement object derived from <code>payload.feat</code>.</li>
+<li><strong>PERSISTED</strong> — <code>{ isPro, plan, email, order, feat, verifiedAt }</code> + raw key → <code>chrome.storage.local</code> (survives restarts/cache clears), mirrored into Zustand for synchronous React reads.</li>
+<li><strong>GATES UNLOCK</strong> — Export (MD/CSV/JSONL), deleted-tweet preservation, bulk ops, advanced filters, annotations check <code>isPro</code> from the store. Re-verified from stored key on each startup (offline).</li>
+<li><strong>(optional) BEST-EFFORT REVOCATION</strong> — weekly fetch of static revocation-list JSON; fail-open. Never blocks offline users.</li>
+</ol>
+
+<h2 id="concrete-recommendation">Concrete recommendation</h2>
+
+<p><em>(Final decision — this supersedes the offline-key recommendation explored above.)</em> Ship <strong>provider-issued license keys validated online and cached</strong>: sell through a merchant-of-record (Lemon Squeezy or Polar) that handles checkout, tax, key issuance, and device counting; on activation the service worker calls the provider's <strong>validate/activate</strong> endpoint once (a public, no-secret <strong>data</strong> fetch — MV3-legal), then persists the result to <code>chrome.storage.local</code> + Zustand and <strong>reads from that cache on every launch</strong> (no per-launch network). Re-validate weekly in the background, <strong>failing open</strong> so an outage never revokes a paying user, which also catches refunds/charge-backs. Set a generous <strong>device limit (~5)</strong> with self-serve deactivation. Use <strong>lifetime keys</strong> so there is no subscription to manage — and publish the honest, on-brand stance that <span class="hl">the check is patchable by design</span>, because for a $19 one-time tool the cracker's experience is worse than just paying, and Totem's privacy-first audience will trust the absence of DRM more than they'd respect its presence.</p>
+<nav class="pager"><a class="pager-link prev" href="appendix-f-payments-compared.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">Payment Gateways Compared</span></a><a class="pager-link next" href="appendix-h-market-discourse.html"><span class="pager-eyebrow">Next</span><span class="pager-title">2026 Market Discourse</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#the-constraint-stated-honestly-up-front">The constraint, stated honestly up front</a>
+<a href="#signed-license-keys-with-offline-verification-the-crypto-layer">Signed license keys with offline verification (the crypto layer)</a>
+<a href="#the-fundamental-reality-it-s-crackable-and-that-s-fine">The fundamental reality: it's crackable, and that's fine</a>
+<a href="#online-activation-vs-fully-offline-vendor-comparison">Online activation vs fully-offline (vendor comparison)</a>
+<a href="#the-mv3-constraint-data-fetch-remote-code">The MV3 constraint: data fetch ✅, remote code ❌</a>
+<a href="#recommended-license-architecture-for-totem">Recommended license architecture for Totem</a>
+<a href="#end-to-end-sequence-purchase-unlock">End-to-end sequence: purchase → unlock</a>
+<a href="#concrete-recommendation">Concrete recommendation</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-h-market-discourse.html
+++ b/plans/research/premium-monetization/site/appendix-h-market-discourse.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>2026 Market Discourse · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html" aria-current="page">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix H</div><h1 class="page-title">2026 Market Discourse</h1><p class="lead">What builders actually said in the last six months of 2026 about charging for Chrome extensions: one-time versus subscription, the conversion numbers behind it, and the backlash waiting for anyone who bolts a paywall onto a free tool.</p>
+
+<h2 id="the-headline-signal-one-time-wins-for-tools-subscriptions-win-for-server-cost">The headline signal: one-time wins for tools, subscriptions win for server-cost</h2>
+<p>The strongest recurring theme across 2026 builder posts is that <span class="hl">subscription fatigue is real for client-side utility extensions</span>, and one-time / lifetime pricing converts materially better for them. The crucial qualifier: this is category-dependent, not universal. Subscriptions still dominate the high-revenue and professional/server-cost tiers.</p>
+
+<div class="callout">Pattern across every 2026 source: one-time wins for self-contained client-side utilities; subscription wins where there is ongoing or server-backed value.</div>
+
+<h3>First-party builder evidence (highest weight)</h3>
+<p><strong>"Real Numbers: Freemium Chrome Extension Monetization After 6 Months"</strong> — DEV Community, by ktg0215, ~May 6 2026. A solo dev running <strong>5 extensions on ExtensionPay</strong>. <span class="tag">VERIFIED</span> Real numbers:</p>
+<ul>
+<li>Overall free→paid conversion: <strong>0.8%</strong> across all 5 extensions; best (Japanese Font Finder) <strong>~1.4%</strong>, worst (PaletteGrab) <strong>0.3%</strong>.</li>
+<li><strong>MRR ~$180/mo</strong>, up from <strong>$60/mo</strong> three months prior, <strong>$0</strong> six months prior.</li>
+<li>Payment-flow completion: <strong>~60–70%</strong> of users who click "Upgrade" finish paying.</li>
+<li>Pricing spread: Procshot $4.99/mo (free: 2 guides/mo), Japanese Font Finder $2.99/mo (free: 30 inspections/day), <strong>PaletteGrab $3.99 one-time</strong> (free: 10 colors), AdLegalCheck $9.99/mo (free: 3 scans/mo).</li>
+</ul>
+<blockquote>One-time pricing for utility tools increased conversions 60% over monthly subscriptions for PaletteGrab.<span class="cite"> - DEV "Real Numbers", ktg0215, May 6 2026</span></blockquote>
+<p>On upgrade-prompt copy: prompt→upgrade conversion was <strong>2% with a basic alert, 8% when the prompt showed a value proposition with benefits listed</strong> — a 4x lift from copy alone.</p>
+<blockquote>The free limit should be just below the threshold for your power user's typical session.<span class="cite"> - DEV "Real Numbers", May 6 2026</span></blockquote>
+
+<p><strong>"Why Lifetime Pricing Converts Better Than Subscriptions for Chrome Extensions"</strong> — Medium, by Soraia, <strong>March 2 2026</strong>. Builder of the MiroMiro extension (design-asset extraction, 5,000+ installs). Was subscriptions-only at €5/mo; adding a prominent lifetime option produced <strong>"5 paying customers in a row"</strong> where conversions previously came "weeks or months" apart.</p>
+<blockquote>People don't cancel because they're unhappy. They cancel because they look at subscriptions and think, "wait, what is this again?"<span class="cite"> - Soraia, Medium, Mar 2 2026</span></blockquote>
+<blockquote>Chrome extensions aren't SaaS apps. They're tools. And people prefer to buy tools once.<span class="cite"> - Soraia, Medium, Mar 2 2026</span></blockquote>
+
+<p><strong>ExtPay user quote</strong> (chromium-extensions Google Group, ExtPay 3.1 announcement thread, posted <strong>March 24 2025</strong>; also reproduced on extensionpay.com):</p>
+<blockquote>It took less than an hour to set up and test it. It hasn't been under a year and I'm already going to pass $4,000 in annual subscriptions.<span class="cite"> - chromium-extensions Google Group, Mar 24 2025</span></blockquote>
+<p>Another commonly cited line: a builder "wouldn't have tried to monetize using Stripe directly" but found ExtPay easy.</p>
+
+<h3>The counter-signal: don't over-index on lifetime</h3>
+<p>Subscriptions clearly still dominate the high-revenue tier and professional/server-cost categories. <strong>NicheCheck, "Most Profitable Chrome Extensions: 2026 Revenue Breakdown by Category"</strong> (Feb 22 2026) reports top-10% performers:</p>
+<table class="striped">
+<thead><tr><th>Category</th><th>Top-10% revenue</th><th>Model</th></tr></thead>
+<tbody>
+<tr><td>SEO &amp; Marketing</td><td>$10k–$50k/mo</td><td>subscription $15–$30/mo</td></tr>
+<tr><td>Developer Tools</td><td>$5k–$30k/mo</td><td>subscription $6–$8/mo</td></tr>
+<tr><td>AI-Powered</td><td>$5k–$25k/mo</td><td>subscription $10–$20/mo</td></tr>
+<tr><td>Productivity</td><td>$3k–$15k/mo</td><td>freemium $3–$7/mo</td></tr>
+<tr><td>Privacy &amp; Security</td><td>$1k–$8k/mo</td><td>hybrid (freemium + donations + enterprise)</td></tr>
+</tbody>
+</table>
+<p>NicheCheck states "recurring subscriptions dominate profitable extensions" and that <strong>"Annual plans (typically at a 30–40% discount) reduce churn by 50–60%."</strong> Freemium conversion benchmark: <strong>1–3% of the active user base</strong> (not installs).</p>
+
+<p><strong>chromegoldmine, "Chrome Extension Revenue Benchmarks by User Count"</strong> (March 26 2026) — benchmark by active users:</p>
+<table class="compact">
+<thead><tr><th>Active users</th><th>Freemium</th><th>Subscription</th><th>One-time / LTD</th></tr></thead>
+<tbody>
+<tr><td>2k–10k</td><td>$50–$500/mo</td><td>$100–$1,500/mo</td><td>$1,000–$10,000 cumulative</td></tr>
+<tr><td>10k–50k</td><td>—</td><td>$500–$7,500/mo</td><td>$5,000–$30,000</td></tr>
+<tr><td>50k–200k+</td><td>—</td><td>$20k–$200k+/mo</td><td>"less practical at scale"</td></tr>
+</tbody>
+</table>
+<p>Named high-revenue extensions (all subscription/affiliate, not one-time): <strong>GMass ~$5.4M/yr (~$200k MRR)</strong>, <strong>Browse AI $1.3M/yr</strong>, <strong>Momentum ~$996k/yr</strong>, <strong>SkyVerge $4.2M/yr</strong>. Reddit case cited: <strong>50,000 users → $21K ARR (~$1,750/mo), sub-1% conversion.</strong></p>
+<blockquote>Your revenue-per-user goes up as you get better at converting, not as your user count grows.<span class="cite"> - chromegoldmine, Mar 26 2026</span></blockquote>
+<p>Conversion mechanics: users shown a paywall <strong>mid-task convert at "3–5x the rate"</strong> of install-time prompts.</p>
+
+<p><strong>ExtensionPay's "8 extensions with impressive revenue" roundup</strong> (older data, instructive by category): CSS Scan <strong>$100k+ on a $69 one-time</strong> (dev tool — one-time worked); Spider <strong>$10k in 2 months at $38 one-time</strong>; versus subscription winners GMass ($130k/mo at $8–$20/mo), Closet Tools ($42k/mo at $30/mo), BlackMagic by Tony Dinh (~$3k/mo subscription).</p>
+
+<div class="takeaway"><div class="takeaway-label">SYNTHESIS</div> A local-first, low-marginal-cost client-side tool sits squarely in the bucket where one-time/lifetime converts best — but one-time structurally caps revenue at "new buyers per month" and is explicitly "less practical at scale." The conventional escape hatch: keep the core unlock one-time, layer a small separate subscription only on a genuinely server-backed feature later.</div>
+
+<h2 id="free-tier-gating-that-converts-without-backlash">Free-tier gating that converts without backlash</h2>
+<p>Clear, repeated 2026 consensus on how to introduce paid tiers:</p>
+<ol>
+<li><strong>Launch freemium from day one — never bolt a paywall onto an already-free extension.</strong> ExtensionFast (Dec 5 2025): "Adding a paywall retroactively generates negative reviews." Launch with the free/paid split from the first public version.</li>
+<li><strong>Feature-gating beats usage caps for most tools.</strong> ExtensionFast (Feb 22 2026): "Feature gating works better than usage limits in most cases. Locking a specific high-value feature behind the paid tier is clearer and less frustrating" than punishing caps like "5 uses/day."</li>
+<li><strong>Trigger the upsell at the moment of delight or pain, mid-workflow — not at install.</strong> Contextual prompts convert <strong>3–5x</strong> better (chromegoldmine, Fungies, NicheCheck, all 2026). ExtensionFast example copy: "Liked that? Unlock unlimited conversions for just $4/month."</li>
+<li><strong>Upsell copy matters as much as placement</strong> — recall the DEV "Real Numbers" jump from <strong>2%→8%</strong> purely by listing benefits instead of a bare alert.</li>
+<li><strong>Set the free limit just below the power-user's typical session</strong> (DEV "Real Numbers") — but feature-gating is preferred over any cap.</li>
+</ol>
+
+<div class="callout">⚠️ Retroactive-paywall risk for a currently-free, open-source tool: the move from free→freemium must <strong>grandfather existing users</strong> and gate only genuinely new value, or it invites 1-star reviews. ExtensionFast, Dec 2025.</div>
+
+<h3>Realistic internal expectations</h3>
+<p>Freemium converts <strong>~1–3% of active users</strong> (0.8% observed across one real 5-extension portfolio); payment-flow completion <strong>~60–70%</strong>. Do not model off install counts.</p>
+
+<h2 id="contradictions-that-challenge-the-lifetime-always-wins-brief">Contradictions that challenge the "lifetime always wins" brief</h2>
+<ol>
+<li><strong>"Lifetime always wins" is too strong.</strong> It wins for client-side utility tools but subscriptions dominate every high-revenue professional category (SEO, dev tools, AI) and the entire $5k–$200k/mo tier; one-time is explicitly "less practical at scale." (NicheCheck, chromegoldmine, 2026.)</li>
+<li><strong>Retroactive paywalls cause review backlash</strong> — the single biggest execution risk for a currently free and open-source tool. (ExtensionFast, Dec 2025.)</li>
+<li><strong>Open-source + paid is a tension.</strong> If code is on GitHub, a license check is trivially bypassable; the moat becomes convenience, trust/updates, and data that only accrues for active paid users. Builders lean on merchant-of-record + "support the maintainer" framing over hard DRM. Polar.sh explicitly positions for OSS monetization.</li>
+<li><strong>ExtPay is convenient but is itself a hosted third party and not a merchant of record</strong> — a subtle ethos compromise for a "no server, local-first" brand, and it leaves global tax on you.</li>
+<li><strong>Polar's 2026 repricing</strong> erodes the "cheapest developer-first MoR" narrative — the flat 4% is now gated behind a $20–$400/mo plan; re-check live fees before committing. (Dodo review, 2026.)</li>
+</ol>
+
+<h2 id="source-index">Source index</h2>
+<ul>
+<li>DEV — Real Numbers: Freemium after 6 months — ~May 6 2026 — <code>dev.to/ktg0215/real-numbers-freemium-chrome-extension-monetization-after-6-months-5hga</code></li>
+<li>Medium (Soraia) — Why Lifetime Converts Better — Mar 2 2026</li>
+<li>chromium-extensions Google Group — ExtPay 3.1 / "$4,000 in annual subscriptions" — Mar 24 2025</li>
+<li>chromegoldmine — Revenue Benchmarks by User Count — Mar 26 2026</li>
+<li>NicheCheck — Most Profitable Extensions by Category — Feb 22 2026</li>
+<li>ExtensionPay — 8 Extensions with Impressive Revenue</li>
+<li>ExtensionFast — How to Price Your Chrome Extension — Feb 22 2026</li>
+<li>ExtensionFast — First $100 (gating/paywall placement) — Dec 5 2025</li>
+</ul>
+<nav class="pager"><a class="pager-link prev" href="appendix-g-license-arch.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">License Architecture &amp; DRM Stance</span></a><a class="pager-link next" href="appendix-i-cws-policy-ux.html"><span class="pager-eyebrow">Next</span><span class="pager-title">CWS Policy &amp; Paywall UX</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#the-headline-signal-one-time-wins-for-tools-subscriptions-win-for-server-cost">The headline signal: one-time wins for tools, subscriptions win for server-cost</a>
+<a href="#free-tier-gating-that-converts-without-backlash">Free-tier gating that converts without backlash</a>
+<a href="#contradictions-that-challenge-the-lifetime-always-wins-brief">Contradictions that challenge the "lifetime always wins" brief</a>
+<a href="#source-index">Source index</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-i-cws-policy-ux.html
+++ b/plans/research/premium-monetization/site/appendix-i-cws-policy-ux.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>CWS Policy & Paywall UX · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html" aria-current="page">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix I</div><h1 class="page-title">CWS Policy &amp; Paywall UX</h1><p class="lead">Totem is MV3, local-first, free and open source today. Shipping a $19 one-time Pro unlock (founders $14) introduces the product's first outbound network call — a license check. This appendix records the Chrome Web Store policy that governs that move and the paywall UX that converts a privacy-conscious, anti-subscription, local-first audience without burning their trust.</p>
+
+<h2 id="native-web-store-payments-are-dead-an-external-processor-is-mandatory">Native Web Store payments are dead — an external processor is mandatory</h2>
+
+<p>Chrome Web Store's built-in payments (the "Chrome Web Store Payments" / Google-Wallet-for-extensions API and <code>chrome.payments</code>) were <strong>deprecated and fully shut down on 1 February 2021.</strong> There is no native, Google-provided in-extension purchase flow anymore.</p>
+
+<p>The consequence is unavoidable: <span class="hl">all billing, tax/VAT, refunds, and license management must run through an external payment processor</span> and your own (or a third party's) infrastructure. Commonly used: Stripe, Paddle / Lemon Squeezy (merchant-of-record handles VAT), Gumroad, or the extension-specific wrapper <strong>ExtensionPay</strong> (<code>extpay</code>).</p>
+
+<p>The <strong>Chrome Web Store Developer Agreement</strong> explicitly allows charging fees but makes the developer <strong>solely responsible for all transactions, tax, and chargebacks.</strong> Free trial versions with an upsell to a full version are explicitly permitted and encouraged.</p>
+
+<div class="takeaway"><div class="takeaway-label">FOR TOTEM</div> The purchase flow happens off-extension — a checkout page on <code>usetotem.xyz</code> (or processor-hosted). For a one-time lifetime unlock, a merchant-of-record (Paddle / Lemon Squeezy) removes the global-tax burden vs. raw Stripe. The extension only ever <em>reads back a license result</em>.</div>
+
+<h2 id="mv3-no-remotely-hosted-code-fetching-a-license-is-fine-executing-fetched-code-is-not">MV3 "no remotely hosted code" — fetching a license is fine; executing fetched code is not</h2>
+
+<p>This is the single most important architectural constraint, and the good news is that it does <strong>not</strong> block license validation. The exact policy wording:</p>
+
+<blockquote>The full functionality of an extension must be easily discernible from its submitted code, unless otherwise exempt.<span class="cite"> - CWS Program Policies, Additional Requirements for MV3</span></blockquote>
+
+<h3>Prohibited (counts as Remotely Hosted Code / RHC)</h3>
+<ul>
+<li>Including a <code>&lt;script&gt;</code> tag that points to a resource that is not within the extension's package.</li>
+<li>Using JavaScript's <code>eval()</code> method or other mechanisms to execute a string fetched from a remote source.</li>
+<li>Building an interpreter to run complex commands fetched from a remote source, even if those commands are fetched as data.</li>
+</ul>
+
+<h3>Explicitly allowed (same policy page)</h3>
+<ul>
+<li>Syncing user account data with a remote server.</li>
+<li>Fetching a remote configuration file for A/B testing or determining enabled features, where all logic for the functionality is contained within the extension package.</li>
+<li>Fetching remote resources that are not used to evaluate logic, such as images.</li>
+<li>Performing server-side operations with data (such as for the purposes of encryption with a private key).</li>
+</ul>
+
+<blockquote>Remotely hosted code, or RHC, is what the Chrome Web Store calls anything that is executed by the browser that is loaded from someplace other than the extension's own files. Things like JavaScript and WASM. It does not include data or things like JSON or CSS.<span class="cite"> - CWS, Deal with remote hosted code violations</span></blockquote>
+
+<p>What this means for the license check:</p>
+<ul>
+<li>A network call that returns <strong>JSON</strong> ("is this license key valid? → <code>{valid: true, tier: 'pro', features: [...]}</code>") is <span class="hl">data, not code — fully compliant.</span> The Chrome docs literally name "determining enabled features" via a fetched remote config as an allowed pattern.</li>
+<li>The <strong>gating logic must live inside the shipped extension</strong> — the extension decides "if <code>tier === pro</code>, enable export." You must NOT fetch a JS blob that <em>implements</em> export, NOR build a mini-interpreter that runs server-sent commands.</li>
+<li>Compliant license design: extension sends a license key / token to your endpoint (or to the processor's verify endpoint, or ExtensionPay's API) → endpoint returns signed JSON (ideally a signed token / JWT or Ed25519-signed payload so the result can be cached and offline-verified) → extension stores the entitlement in <code>chrome.storage.local</code> and flips local feature flags. All feature code is already in the package and merely toggled.</li>
+</ul>
+
+<div class="callout">Reviewer-facing nuance: even allowed remote communication "must still be possible to determine the full functionality of your extension and the interaction must still comply with user data policies." Keep the request/response minimal and documented.</div>
+
+<h2 id="single-purpose-policy-adding-pro-features-must-not-broaden-the-purpose">Single-purpose policy — adding Pro features must not broaden the purpose</h2>
+
+<p>Extensions must have a <strong>single, narrow purpose.</strong> "Extensions are assumed to utilize each of the permissions they request," and "excessive permissions unrelated to an extension's single purpose … will be viewed as enabling unrelated functionalities, resulting in a policy violation."</p>
+
+<p>New-tab override extensions get <strong>extra scrutiny</strong> — Google updated the <strong>Quality Guidelines FAQ on 22 Jan 2025</strong> specifically to clarify how the Single Purpose Policy applies to new tab pages (vertical vs. horizontal functionality). Totem already overrides the new tab; the Pro features (export, annotations, preservation, search filters, bulk ops) are all the <span class="hl">same single purpose — "reading / searching / exporting your X bookmarks"</span> — so they are safe <em>as long as the framing stays "bookmark management"</em> and you don't bolt on an unrelated AI chat or a second product.</p>
+
+<div class="takeaway"><div class="takeaway-label">ACTION</div> The single-purpose description in the Privacy practices tab should describe the whole feature set (free + pro) as one coherent purpose. Don't list "monetization" as a purpose.</div>
+
+<h2 id="privacy-policy-data-use-disclosures-triggered-by-the-new-license-call">Privacy policy + data-use disclosures triggered by the new license call</h2>
+
+<p>Adding any outbound call that includes user-identifiable data (email, license key, possibly account identifier) interacts with the <strong>Limited Use</strong> and <strong>User Data</strong> policies and the <strong>Privacy practices tab.</strong></p>
+
+<h3>Privacy practices tab — required fields</h3>
+<ol>
+<li><strong>Single purpose description.</strong></li>
+<li><strong>Permission justification</strong> — one justification per requested permission and per host permission.</li>
+<li><strong>Remote code declaration</strong> — must declare whether the extension uses remote code. For Totem the honest answer is <span class="tag">NO</span> (license response is data, not code) — declaring No correctly is important and defensible.</li>
+<li><strong>Data usage disclosure checkboxes</strong> — first group: which data types are collected (e.g. <em>personally identifiable information</em> like email, <em>authentication information</em>, <em>website content</em>). Second group: certifications.</li>
+<li><strong>Three Limited-Use certifications</strong> — certify you (a) do not sell user data / use it for unrelated purposes, (b) do not use/transfer data for ads or creditworthiness, (c) limit use to disclosed practices.</li>
+<li><strong>Privacy policy URL</strong> — required; must be consistent with the URL on the developer account.</li>
+</ol>
+
+<blockquote>Limit your use of user data to providing or improving your single purpose. … The privacy policy must, together with any in-Product disclosures, comprehensively disclose how your Product collects, uses and shares user data and all parties the user data will be shared with.<span class="cite"> - CWS, Limited Use policy</span></blockquote>
+
+<p>Limited Use bans: personalized ads, selling to data brokers, creditworthiness. Data sharing with third parties is only allowed where necessary for the purpose, legal compliance, or with explicit consent.</p>
+
+<p><strong>Implication for Totem (currently no server / no PII collection):</strong></p>
+<ul>
+<li>Adding a license check that transmits an <strong>email + license key to a payment processor and/or a Totem endpoint</strong> changes the data-collection answer from "none" to "personally identifiable information + authentication information." The disclosures and the privacy policy on <code>usetotem.xyz</code> must be updated to name Stripe / Paddle / ExtensionPay (or whoever) as a third party that receives the license/email data, and to state it is used solely for license validation — not for ads, not sold.</li>
+<li>Keep bookmark content <strong>out</strong> of the license call. Totem's whole pitch is local-first; the license payload should be license-key / email only, never bookmark data. This keeps "web browsing activity / website content" <em>not transmitted</em>, preserving the strongest privacy claim.</li>
+</ul>
+
+<h2 id="permissions-csp-for-the-license-endpoint">Permissions + CSP for the license endpoint</h2>
+
+<p>The license endpoint host must be reachable. Two options:</p>
+<ul>
+<li><strong><code>host_permissions</code></strong> entry for the endpoint domain (e.g. <code>https://api.usetotem.xyz/*</code>) if you call it from a content script / need broad access, <strong>or</strong></li>
+<li>Simpler / cleaner: call it from the <strong>service worker via <code>fetch()</code></strong>, which under MV3 generally does <span class="hl">not require a <code>host_permissions</code> grant</span> for a plain cross-origin <code>fetch</code> to your own HTTPS API from the background context. Prefer this to avoid adding scary host-permission warnings.</li>
+</ul>
+
+<p>Any host permission you DO add must be <strong>justified in the Privacy practices tab</strong> and tied to the single purpose; unjustified / broad host permissions are a top rejection reason. Do not request <code>&lt;all_urls&gt;</code> for a license check — scope to the exact license host. If you use a strict <code>content_security_policy</code>, the <code>extension_pages</code> policy controls <code>connect-src</code>; ensure the license host is permitted there if you tighten CSP.</p>
+
+<h2 id="paywalling-free-trial-limited-functionality-rules">Paywalling / free-trial / "limited functionality" rules</h2>
+
+<p>There is <strong>no rule against gating features behind payment.</strong> Free trials + upsell to a full version are explicitly allowed and encouraged. The binding constraints are <span class="hl">honesty / anti-deception</span>, not the existence of a paywall:</p>
+<ul>
+<li><strong>Deceptive Installation Tactics:</strong> you must not gate <em>advertised</em> features behind unrelated actions, must not use misleading CTAs, and must "clearly state" the product's features in marketing. The Web Store listing and any install-time copy must truthfully say what's free vs. what costs money.</li>
+<li><strong>"No cheating … by misleading users …"</strong> (Best Practices): misrepresenting what the extension does — including pretending a paid thing is free or vice versa — risks a ban.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">ACTION</div> The store listing must disclose that Totem is free with an optional one-time Pro unlock, and list which features are Pro. Don't advertise "export your bookmarks!" as a headline benefit and then reveal at the moment of use that it's paid without prior disclosure — that edges toward the deceptive-tactics line. You <em>can</em> gate export behind Pro; you just have to have been upfront that export is a Pro feature.</div>
+
+<h2 id="cws-compliance-checklist-shipping-totem-pro">CWS compliance checklist — shipping Totem Pro</h2>
+
+<h3>Payments / architecture</h3>
+<ul>
+<li>Use an external processor (Paddle / Lemon Squeezy as merchant-of-record recommended for one-time + global VAT; or Stripe + own tax handling; or ExtensionPay wrapper). No native CWS payments.</li>
+<li>Checkout happens off-extension (web page / processor-hosted), not inside an extension UI flow that pretends to be a native purchase.</li>
+<li>License validation returns <strong>JSON / data only</strong> (signed token preferred). No fetched JS/WASM, no <code>eval</code>, no server-command interpreter.</li>
+<li>All Pro feature <em>logic</em> ships inside the extension package; the license result only flips local feature flags.</li>
+<li>Validate the key online once, then <strong>cache the result</strong> in <code>chrome.storage.local</code> and read it locally — with a fail-open background re-check — so Pro keeps working without a per-launch network call.</li>
+</ul>
+
+<h3>Single purpose / permissions</h3>
+<ul>
+<li>Pro features stay within the existing single purpose (bookmark reading / search / export / preservation). No unrelated functionality.</li>
+<li>License call made from the service worker via <code>fetch</code> to a narrowly scoped host; avoid <code>&lt;all_urls&gt;</code>; add <code>host_permissions</code> only if strictly necessary and justify it.</li>
+<li>If CSP is tightened, allow the license host in <code>connect-src</code> of <code>extension_pages</code>.</li>
+</ul>
+
+<h3>Privacy / data</h3>
+<ul>
+<li>Update the Privacy practices tab: single-purpose description (free + pro as one purpose), per-permission justifications, remote-code = <strong>No</strong>, data-collected checkboxes now include <strong>PII (email) + authentication info (license key)</strong>, and the 3 Limited-Use certifications.</li>
+<li>Update the privacy policy on <code>usetotem.xyz</code> to disclose: license/email sent to &lt;processor&gt; for validation; not sold, not used for ads; bookmark data never transmitted.</li>
+<li>Keep the Limited-Use affirmative statement and ensure the privacy-policy URL matches the developer-account URL.</li>
+<li>Ensure no bookmark / browsing content is included in the license request (preserve "no web browsing activity transmitted").</li>
+</ul>
+
+<h3>Listing / honesty</h3>
+<ul>
+<li>Store listing clearly states: free core + optional <strong>one-time</strong> Pro unlock; lists which features are Pro.</li>
+<li>No misleading CTAs; don't gate an <em>advertised headline</em> feature without prior disclosure (Deceptive Installation Tactics).</li>
+<li>No nagging / forced-action dark patterns at install.</li>
+</ul>
+
+<h2 id="the-macro-data-one-time-vs-subscription-soft-vs-hard-gates">The macro data: one-time vs. subscription, soft vs. hard gates</h2>
+
+<p><strong>RevenueCat 2026 benchmark</strong> (115k+ apps, $16B revenue): hard paywalls convert ~<strong>10.7%</strong>, freemium ~<strong>2.1%.</strong> Hard gates win per-user economics; freemium wins on volume / word-of-mouth. <span class="hl">Trial-format screens beat visual-only paywalls in 64.5% of experiments.</span></p>
+
+<p><strong>But Totem's audience is the exception that breaks the funnel-maximizing playbook.</strong> For privacy / local-first / anti-subscription communities (r/selfhosted, r/nosurf, HN), the open-source + free-core + <em>optional one-time</em> model is itself the trust signal. A pure hard paywall would nuke the goodwill that makes these communities <em>evangelize</em> a tool. The right model here is <strong>freemium with a generous free core + a one-time unlock</strong>, optimized not for raw % conversion but for trust-preserving conversion + word-of-mouth.</p>
+
+<div class="callout">The conversion lever that matters most is the "wow moment" before the ask. Totango: users who achieve at least one meaningful outcome are <strong>5x more likely to convert.</strong> Show the upgrade prompt only after the user has felt value.</div>
+
+<h2 id="the-reference-model-obsidian-the-gold-standard-this-audience-already-trusts">The reference model: Obsidian, the gold standard this audience already trusts</h2>
+
+<p>Plain Markdown files on device, <strong>no account, no cloud dependency, no telemetry, no data sold.</strong> Paid add-ons (Sync / Publish) are optional; the <strong>Catalyst license is a one-time payment framed as a "tip jar" / support-the-developers</strong> with perks (early betas, badge). This is repeatedly cited as "one of the most honest pricing models in productivity software."</p>
+
+<div class="takeaway"><div class="takeaway-label">LESSON FOR TOTEM</div> Lean into the same posture — "your data stays local, the app stays free and open source, Pro is a one-time unlock that funds the work." Frame Pro partly as <em>support</em>, not <em>feature ransom</em>. The one-time (not subscription) structure is the single biggest trust-aligner with this crowd.</div>
+
+<h2 id="anti-patterns-that-trigger-backlash-the-don-t-list">Anti-patterns that trigger backlash — the DON'T list</h2>
+
+<ul>
+<li><strong>Nagging.</strong> Repeated upgrade pop-ups after the user declined = the #1 anger trigger; people mute, uninstall, and post screenshots. One contextual prompt, dismissible, that stays dismissed.</li>
+<li><strong>Crippleware / bait-and-switch on existing free features.</strong> Taking a feature that's <em>currently free</em> (Totem already ships export-ish, search, sync) and moving it behind Pro for existing users feels like theft. <span class="hl">Grandfather current free features;</span> only gate genuinely new Pro capabilities, or clearly new/enhanced versions.</li>
+<li><strong>Forced action / fake "free trial" that demands a card up front.</strong> This crowd reads a card-required trial as a trap. If you trial Pro, make it <strong>no-card</strong> or just use a generous free tier instead.</li>
+<li><strong>Dark-pattern checkout</strong> (hidden recurring charge, pre-checked add-ons, confusing "cancel"). For a one-time purchase this is mostly avoided — but make crystal clear it is one-time, not a sub.</li>
+<li><strong>Surprise paywall at the moment of need with no prior disclosure</strong> (also a CWS deceptive-tactics risk).</li>
+<li><strong>Telemetry / "phone home" creep.</strong> Any new network call is scrutinized. Be loud that the license check sends only email + key (+ a device id), never bookmarks, and runs only at activation plus an occasional background re-check — not on every launch.</li>
+<li><strong>Manipulative urgency / scarcity</strong> ("only 3 left!") — reads as scammy to a technical audience. The founders price is fine <em>if framed honestly</em> ("$14 founders price, going to $19" — a real, time-boxed thing, not a fake countdown).</li>
+</ul>
+
+<h2 id="patterns-that-convert-without-backlash-the-do-list">Patterns that convert without backlash — the DO list</h2>
+
+<ul>
+<li><strong>Soft gates with lock badges, not walls.</strong> Show the Pro features <em>in the UI</em>, visible but with a small lock / "Pro" badge, so users see what they'd get. Visible-but-locked teases create "something concrete to miss."</li>
+<li><strong>"Try before you buy" via a free allowance, not a time bomb.</strong> Let users <strong>export the first N bookmarks free</strong> (e.g. 25 rows of CSV / Markdown), preview the full export, then unlock unlimited. They feel the value on <em>their own data</em> before paying — the highest-trust analog of a trial for a one-time product.</li>
+<li><strong>Contextual prompt at the moment of value, exactly once.</strong> The upgrade ask appears <em>when the user reaches for the locked capability</em> (clicks Export, selects 50 bookmarks for a bulk op, opens a deleted-tweet they'd lose). The documented highest-intent moment.</li>
+<li><strong>Honest "what you're paying for" framing</strong> — solve the "no server, why does it cost money?" objection head-on: <em>"You're paying for the work, not a subscription — Totem stays free and open source. Pro is a one-time unlock that funds ongoing development. Your data never leaves your machine."</em> Tie price to <strong>outcomes</strong> (own your archive forever, never lose a deleted tweet), not to infra.</li>
+<li><strong>Reverse-trial option (optional):</strong> give new installs a short window where Pro is fully on, then drop to free. Exposure to Pro creates a concrete thing to upgrade <em>back</em> to. Only do this <strong>no-card.</strong></li>
+<li><strong>Status / support framing</strong> (Obsidian Catalyst): a small "Founding supporter" badge or changelog credit makes Pro feel like patronage, not extortion.</li>
+<li><strong>Trial-format / value-first screen beats a bare price wall</strong> (64.5% win rate) — a screen that shows what Pro does + the free allowance result, not just "$19, pay now."</li>
+</ul>
+
+<h2 id="recommended-in-product-upgrade-moments-for-totem">Recommended in-product upgrade moments for Totem</h2>
+
+<p>Ranked by intent. Each fires <strong>once, contextually, dismissible</strong>, after the user has felt value.</p>
+
+<table class="striped">
+<thead><tr><th>#</th><th>Moment</th><th>Trigger &amp; copy</th><th>Why it works</th></tr></thead>
+<tbody>
+<tr><td>1</td><td><strong>At export, after a free preview</strong> <span class="tag">PRIMARY</span></td><td>User clicks "Export → Markdown / CSV / JSONL." Export/preview the first ~25 items free, show the full count behind a soft gate: <em>"Export all 3,412 bookmarks → Unlock Pro ($14 founders / $19)."</em></td><td>Highest intent — they're actively trying to get their data out.</td></tr>
+<tr><td>2</td><td><strong>Deleted / unavailable tweet opened</strong> <span class="tag">SECONDARY</span></td><td><em>"This tweet was deleted on X. Totem kept your copy. Pro preserves every deleted bookmark automatically."</em></td><td>Emotional, unique-value moment (loss aversion) — very strong for this audience.</td></tr>
+<tr><td>3</td><td><strong>Bulk operation</strong></td><td>User multi-selects (e.g. 50 bookmarks) to tag / delete / move: <em>"Bulk actions are a Pro feature."</em></td><td>They've already invested effort selecting — high intent.</td></tr>
+<tr><td>4</td><td><strong>Advanced search filter use</strong></td><td>User opens filters (by date / author / media / folder): show the filters with a lock badge; selecting one prompts upgrade.</td><td>Shows the capability before charging for it.</td></tr>
+<tr><td>5</td><td><strong>First annotation</strong></td><td>User tries to add a note / highlight to a bookmark.</td><td>Intent to deepen use of their own archive.</td></tr>
+</tbody>
+</table>
+
+<div class="callout">Cross-cutting placement rules: one persistent, quiet "Upgrade to Pro" / "Support Totem" entry in settings or a corner (always available, never a pop-up); never auto-popup on new-tab load; never re-prompt the same context after dismissal in a session; always state <strong>one-time, not subscription</strong> and <strong>data stays local</strong> in the prompt.</div>
+
+<h2 id="presenting-the-19-one-time-unlock-without-feeling-scammy">Presenting the $19 one-time unlock without feeling scammy</h2>
+
+<ul>
+<li><strong>Headline the model, not the price:</strong> "Totem Pro — one-time unlock. No subscription. Ever." Subscription-fatigue is the documented pain point for this crowd.</li>
+<li><strong>Pre-empt the "no server, why pay?" question</strong> with the funds-the-work / stays-open-source line.</li>
+<li><strong>Founders price done honestly:</strong> "$14 founders price (rising to $19)" — real and time-boxed, no fake countdown timers or "3 left."</li>
+<li><strong>Reassure on the license check:</strong> a small line near checkout — <em>"Pro is verified by a one-time license check (email + key only). Your bookmarks never leave your device."</em></li>
+<li><strong>Receipt of ownership:</strong> make the license restorable across machines via the key / email; <span class="hl">"buy once, use on all your browsers"</span> reinforces ownership, the core anti-subscription value.</li>
+</ul>
+<nav class="pager"><a class="pager-link prev" href="appendix-h-market-discourse.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">2026 Market Discourse</span></a><a class="pager-link next" href="appendix-j-references.html"><span class="pager-eyebrow">Next</span><span class="pager-title">References &amp; Method</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#native-web-store-payments-are-dead-an-external-processor-is-mandatory">Native Web Store payments are dead — an external processor is mandatory</a>
+<a href="#mv3-no-remotely-hosted-code-fetching-a-license-is-fine-executing-fetched-code-is-not">MV3 "no remotely hosted code" — fetching a license is fine; executing fetched code is not</a>
+<a href="#single-purpose-policy-adding-pro-features-must-not-broaden-the-purpose">Single-purpose policy — adding Pro features must not broaden the purpose</a>
+<a href="#privacy-policy-data-use-disclosures-triggered-by-the-new-license-call">Privacy policy + data-use disclosures triggered by the new license call</a>
+<a href="#permissions-csp-for-the-license-endpoint">Permissions + CSP for the license endpoint</a>
+<a href="#paywalling-free-trial-limited-functionality-rules">Paywalling / free-trial / "limited functionality" rules</a>
+<a href="#cws-compliance-checklist-shipping-totem-pro">CWS compliance checklist — shipping Totem Pro</a>
+<a href="#the-macro-data-one-time-vs-subscription-soft-vs-hard-gates">The macro data: one-time vs. subscription, soft vs. hard gates</a>
+<a href="#the-reference-model-obsidian-the-gold-standard-this-audience-already-trusts">The reference model: Obsidian, the gold standard this audience already trusts</a>
+<a href="#anti-patterns-that-trigger-backlash-the-don-t-list">Anti-patterns that trigger backlash — the DON'T list</a>
+<a href="#patterns-that-convert-without-backlash-the-do-list">Patterns that convert without backlash — the DO list</a>
+<a href="#recommended-in-product-upgrade-moments-for-totem">Recommended in-product upgrade moments for Totem</a>
+<a href="#presenting-the-19-one-time-unlock-without-feeling-scammy">Presenting the $19 one-time unlock without feeling scammy</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/appendix-j-references.html
+++ b/plans/research/premium-monetization/site/appendix-j-references.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>References & Method · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html" aria-current="page">J · References</a>
+</div>
+</nav>
+<main class="content">
+<div class="chapter-eyebrow">Appendix J</div><h1 class="page-title">References &amp; Method</h1><p class="lead">
+  This document synthesizes a nine-agent deep dive of the Totem codebase and the 2026 payments/extension market, plus an adversarial verification pass. The appendices reproduce the underlying research records.
+</p>
+
+<h2 id="method">Method</h2>
+<p>Five agents read the codebase along independent seams (data &amp; sync, features &amp; export, build &amp; release, site &amp; distribution, UI state &amp; upsell). Four agents researched the market (payments, license architecture, recent discourse, Chrome Web Store policy &amp; UX). A final reviewer adversarially re-checked the load-bearing code claims against the live repository and red-teamed the strategy. The nine raw reports are condensed in Appendices A–I; the verification pass is Chapter 11.</p>
+
+<h2 id="a-source-reports">A. Source reports</h2>
+<table class="compact">
+  <thead><tr><th>Report</th><th>Focus</th><th>Appendix</th></tr></thead>
+  <tbody>
+    <tr><td><code>cb-data-sync.md</code></td><td>Entitlement storage + reactive channel</td><td>A</td></tr>
+    <tr><td><code>cb-features-export.md</code></td><td>Export gate + feature inventory</td><td>B</td></tr>
+    <tr><td><code>cb-build-release.md</code></td><td>Pipeline + manifest + CWS mechanics</td><td>C</td></tr>
+    <tr><td><code>cb-site-distribution.md</code></td><td>Astro static site + checkout pages</td><td>D</td></tr>
+    <tr><td><code>cb-ui-state-upsell.md</code></td><td>usePro / ProGate / upsell mounts</td><td>E</td></tr>
+    <tr><td><code>rs-payments.md</code></td><td>Gateway comparison</td><td>F</td></tr>
+    <tr><td><code>rs-license-arch.md</code></td><td>License-key architecture + DRM stance (explored offline keys; plan chose online-validate-then-cache)</td><td>G</td></tr>
+    <tr><td><code>rs-recent-discourse.md</code></td><td>2026 builder evidence, lifetime vs subscription</td><td>H</td></tr>
+    <tr><td><code>rs-cws-policy-ux.md</code></td><td>CWS compliance + paywall UX</td><td>I</td></tr>
+  </tbody>
+</table>
+<p>The synthesized plan lives at <code>plans/premium-conversion-plan.md</code>; raw reports at <code>plans/research/premium-monetization/raw/</code>; strategy context at <code>plans/gtm-research-report-2026-06-16.md</code>.</p>
+
+<h2 id="b-glossary">B. Glossary</h2>
+<p><strong>MoR (Merchant of Record)</strong> — a payment provider that becomes the legal seller and remits global VAT/GST on your behalf (Lemon Squeezy, Polar, Gumroad). Removes the tax-registration burden from a solo developer.</p>
+<p><strong>MV3</strong> — Chrome Manifest V3. Bans remotely-hosted <em>code</em> but allows fetching remote <em>data</em>; an online license <strong>validate</strong> call returns JSON data (not code), so it is compliant.</p>
+<p><strong>Entitlement</strong> — the device-global fact "this install is Pro." Stored authoritatively in <code>CS_ENTITLEMENT</code> (service-worker-owned <code>chrome.storage.local</code>), independent of account or reset.</p>
+<p><strong>License key</strong> — a key the merchant-of-record mints on a paid order. The extension <strong>validates</strong> it against the provider's license API once at activation (a no-secret, public data call), caches the result in <code>CS_ENTITLEMENT</code>, and reads it locally thereafter — re-checking in the background with fail-open.</p>
+<p><strong>Cache + fail-open</strong> — the resilience rule for online verification: validate once, store the result, read from the store on every launch, and if a background re-check can't reach the network, keep Pro on (never lock out a paying user over an outage).</p>
+<p><strong>Activation / device limit</strong> — the provider caps how many devices a key can activate (recommend ~5) and exposes activate/deactivate so a user can free a slot themselves. This is how multi-browser activation is managed, and it requires the online check.</p>
+<p><strong>Grandfathering</strong> — granting existing users full features free, forever, so the paywall only ever applies to new installs. The primary backlash mitigation.</p>
+<p><strong>Hydration</strong> — Totem's existing engine that fetches and caches tweet detail, already classifying deleted/protected tweets — the basis of the "deleted-tweet preservation" Pro feature.</p>
+<p><strong>CWS</strong> — Chrome Web Store. Native in-extension payments were removed Feb 1, 2021; an external processor is mandatory.</p>
+
+<h2 id="c-acknowledgements">C. Acknowledgements</h2>
+<p>Compiled from automated codebase and market research agents over the Totem repository, reconciled into a single executable plan and verified adversarially before delivery.</p>
+<nav class="pager"><a class="pager-link prev" href="appendix-i-cws-policy-ux.html"><span class="pager-eyebrow">Previous</span><span class="pager-title">CWS Policy &amp; Paywall UX</span></a><span></span></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+<aside class="toc"><div class="toc-label">On this page</div><a href="#method">Method</a>
+<a href="#a-source-reports">A. Source reports</a>
+<a href="#b-glossary">B. Glossary</a>
+<a href="#c-acknowledgements">C. Acknowledgements</a></aside>
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/index.html
+++ b/plans/research/premium-monetization/site/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Making Totem Premium · Totem Premium</title>
+<meta name="generator" content="Kami">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+<header class="topbar">
+  <a class="wordmark" href="index.html">Totem <span>Premium Conversion</span></a>
+  <div class="topbar-meta">Research &amp; execution plan · v1.0 · 2026.06</div>
+</header>
+<div class="layout">
+<nav class="sidebar" aria-label="Sections">
+<a class="side-brand" href="index.html">Totem <span>Premium</span></a>
+<div class="side-group"><div class="side-group-label">Overview</div>
+<a class="side-link" href="index.html" aria-current="page">Home</a>
+</div>
+<div class="side-group"><div class="side-group-label">The Plan</div>
+<a class="side-link" href="02-the-model.html">The Model</a>
+<a class="side-link" href="03-features.html">Features &amp; Limits</a>
+<a class="side-link" href="04-tech-stack.html">Tech Stack</a>
+<a class="side-link" href="05-payments.html">Payment Gateway</a>
+<a class="side-link" href="06-license.html">License Architecture</a>
+<a class="side-link" href="07-system-changes.html">System Changes</a>
+<a class="side-link" href="08-compliance.html">CWS Compliance</a>
+<a class="side-link" href="09-paywall-ux.html">Paywall UX</a>
+<a class="side-link" href="10-rollout.html">Rollout &amp; Decisions</a>
+</div>
+<div class="side-group"><div class="side-group-label">Review</div>
+<a class="side-link" href="11-adversarial-review.html">Adversarial Review</a>
+</div>
+<div class="side-group"><div class="side-group-label">Appendices</div>
+<a class="side-link" href="appendix-a-data-sync.html">A · Data &amp; Sync</a>
+<a class="side-link" href="appendix-b-features-export.html">B · Features &amp; Export</a>
+<a class="side-link" href="appendix-c-build-release.html">C · Build &amp; Release</a>
+<a class="side-link" href="appendix-d-site-distribution.html">D · Site &amp; Dist.</a>
+<a class="side-link" href="appendix-e-ui-state-upsell.html">E · UI &amp; Upsell</a>
+<a class="side-link" href="appendix-f-payments-compared.html">F · Gateways</a>
+<a class="side-link" href="appendix-g-license-arch.html">G · License &amp; DRM</a>
+<a class="side-link" href="appendix-h-market-discourse.html">H · Market Discourse</a>
+<a class="side-link" href="appendix-i-cws-policy-ux.html">I · CWS Policy</a>
+</div>
+<div class="side-group"><div class="side-group-label">Reference</div>
+<a class="side-link" href="appendix-j-references.html">J · References</a>
+</div>
+</nav>
+<main class="content">
+<section class="hero"><div class="hero-eyebrow">Technical Report · Premium Monetization</div><h1 class="hero-title">Making Totem Premium</h1><p class="hero-sub">From free, open-source and local-first to a one-time $19 Pro unlock — without a server. The full research record and the file-by-file execution plan.</p></section><p class="lead">
+  Totem can become a paid product without betraying the local-first, no-server, open-source ethos that <span class="hl">is the brand</span>. The move is a freemium model with a one-time $19 lifetime Pro unlock — and the surprising finding from a full codebase audit is that this is overwhelmingly a packaging job, not a building job.
+</p>
+
+<h2 id="the-four-decisions">The four decisions</h2>
+<ol>
+  <li><strong>Model — freemium, one build, runtime-gated.</strong> The free tier stays fully functional forever; Pro is a one-time lifetime unlock. It is the only model the single-artifact pipeline and the subscription-averse, anti-DRM audience actually support.</li>
+  <li><strong>The work is packaging, not building.</strong> Five of the six proposed Pro features already exist and ship for free today — export, deleted-tweet preservation (the hydration engine), advanced search, annotations, thread-aware capture. Only <span class="tag">NET-NEW</span> bulk operations must be built. The real engineering is one clean entitlement boundary.</li>
+  <li><strong>Payments — merchant-of-record for checkout, online license validation for verification.</strong> Lemon Squeezy or Polar handles global VAT so there is no Totem billing server, and the extension validates the key against the provider's license API <em>once at activation</em>, caches the result locally, and reads it from cache thereafter — re-checking quietly in the background and failing open so an outage never locks out a paying user. Only the key and email leave the device; bookmarks never do. The provider also counts devices, so multi-browser activation is capped at a generous limit (~5) with self-serve deactivation.</li>
+  <li><strong>The #1 risk is the retroactive paywall.</strong> Totem is already free; bolting a paywall onto existing users earns 1-star reviews. Grandfather every existing install — full features, free, forever — and gate only new installs.</li>
+</ol>
+
+<h2 id="key-takeaways">Key takeaways</h2>
+<ul>
+  <li>Realistic conversion to model against: <span class="hl">1–3% of active users</span> (not installs), ~60–70% checkout completion — the one-time-tool bucket where lifetime pricing beats subscriptions.</li>
+  <li>The cleanest authoritative entitlement is a service-worker-owned <code>CS_ENTITLEMENT</code> key in <code>chrome.storage.local</code>, kept off the reset lists and stamped into the existing reactive snapshot so every open tab flips to Pro on the same event-loop tick.</li>
+  <li>One hard repo blocker exists: <code>scripts/verify-cws-featured-readiness.mjs</code> hard-pins the manifest permissions, hosts, description string, and screenshot set — it must be loosened for any new host or copy change.</li>
+  <li>An adversarial review pass corrected the load-bearing claims before this document shipped (see Chapter 11): export is not single-gated, the original "fully offline, nothing can shut down" framing was an overclaim — the design now validates online once and caches with fail-open — and grandfathering by install-reason alone misfires on reinstall.</li>
+</ul>
+
+<div class="takeaway">
+  <div class="takeaway-label">Questions this document answers</div>
+  How does Totem go premium without a server or losing its open-source trust? What is the exact tech stack, payment gateway, and license architecture? And which files change, in what order, to make the paywall work flawlessly?
+</div><hr class="soft-rule"><h2 class="browse-h">The Plan</h2><div class="browse-grid"><a class="browse-card" href="02-the-model.html"><span class="browse-eyebrow">02 · The Model</span><span class="browse-title">The Premium Model &amp; Why It Fits</span></a><a class="browse-card" href="03-features.html"><span class="browse-eyebrow">03 · Features</span><span class="browse-title">Free vs Pro — Features &amp; Limits</span></a><a class="browse-card" href="04-tech-stack.html"><span class="browse-eyebrow">04 · Stack</span><span class="browse-title">Tech Stack — What Is New</span></a><a class="browse-card" href="05-payments.html"><span class="browse-eyebrow">05 · Payments</span><span class="browse-title">Payment Gateway — The Decision</span></a><a class="browse-card" href="06-license.html"><span class="browse-eyebrow">06 · License</span><span class="browse-title">License &amp; Entitlement Architecture</span></a><a class="browse-card" href="07-system-changes.html"><span class="browse-eyebrow">07 · System</span><span class="browse-title">Internal System Changes — File by File</span></a><a class="browse-card" href="08-compliance.html"><span class="browse-eyebrow">08 · Store</span><span class="browse-title">Chrome Web Store Compliance</span></a><a class="browse-card" href="09-paywall-ux.html"><span class="browse-eyebrow">09 · UX</span><span class="browse-title">Paywall UX — Moments, Copy, Anti-Patterns</span></a><a class="browse-card" href="10-rollout.html"><span class="browse-eyebrow">10 · Rollout</span><span class="browse-title">Phased Rollout &amp; Open Decisions</span></a></div><h2 class="browse-h">Review</h2><div class="browse-grid"><a class="browse-card" href="11-adversarial-review.html"><span class="browse-eyebrow">11 · Red-Team</span><span class="browse-title">Adversarial Review — What the Red-Team Caught</span></a></div><h2 class="browse-h">Appendices</h2><div class="browse-grid"><a class="browse-card" href="appendix-a-data-sync.html"><span class="browse-eyebrow">Appendix A</span><span class="browse-title">Data, Sync &amp; Entitlement Storage</span></a><a class="browse-card" href="appendix-b-features-export.html"><span class="browse-eyebrow">Appendix B</span><span class="browse-title">Features &amp; Export Surface</span></a><a class="browse-card" href="appendix-c-build-release.html"><span class="browse-eyebrow">Appendix C</span><span class="browse-title">Build &amp; Release Pipeline</span></a><a class="browse-card" href="appendix-d-site-distribution.html"><span class="browse-eyebrow">Appendix D</span><span class="browse-title">Site &amp; Distribution</span></a><a class="browse-card" href="appendix-e-ui-state-upsell.html"><span class="browse-eyebrow">Appendix E</span><span class="browse-title">UI State &amp; Upsell Surfaces</span></a><a class="browse-card" href="appendix-f-payments-compared.html"><span class="browse-eyebrow">Appendix F</span><span class="browse-title">Payment Gateways Compared</span></a><a class="browse-card" href="appendix-g-license-arch.html"><span class="browse-eyebrow">Appendix G</span><span class="browse-title">License Architecture &amp; DRM Stance</span></a><a class="browse-card" href="appendix-h-market-discourse.html"><span class="browse-eyebrow">Appendix H</span><span class="browse-title">2026 Market Discourse</span></a><a class="browse-card" href="appendix-i-cws-policy-ux.html"><span class="browse-eyebrow">Appendix I</span><span class="browse-title">CWS Policy &amp; Paywall UX</span></a></div><h2 class="browse-h">Reference</h2><div class="browse-grid"><a class="browse-card" href="appendix-j-references.html"><span class="browse-eyebrow">Appendix J</span><span class="browse-title">References &amp; Method</span></a></div>
+<nav class="pager"><span></span><a class="pager-link next" href="02-the-model.html"><span class="pager-eyebrow">Next</span><span class="pager-title">The Premium Model &amp; Why It Fits</span></a></nav>
+<footer class="page-foot">Totem · premium-monetization research · compiled with kami</footer>
+</main>
+
+</div>
+</body>
+</html>

--- a/plans/research/premium-monetization/site/styles.css
+++ b/plans/research/premium-monetization/site/styles.css
@@ -1,0 +1,153 @@
+:root{
+  --parchment:#f5f4ed; --ivory:#faf9f5; --warm-sand:#e8e6dc;
+  --brand:#1B365D; --brand-light:#2D5A8A; --brand-tint:#EEF2F7;
+  --near-black:#141413; --dark-warm:#3d3d3a; --olive:#504e49; --stone:#6b6a64;
+  --border:#e8e6dc; --border-soft:#e5e3d8; --line:#d8d5c8; --tag-bg:#E4ECF5;
+  --serif:Charter,Georgia,Palatino,"Times New Roman",serif;
+  --mono:"JetBrains Mono","SF Mono","Fira Code",Consolas,Monaco,monospace;
+  --latin-ui:system-ui,-apple-system,"Segoe UI",Helvetica,Arial,sans-serif;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth}
+body{background:var(--parchment);color:var(--near-black);font-family:var(--serif);
+  font-size:16px;line-height:1.72;-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+a{color:var(--brand);text-decoration:none}
+a:hover{color:var(--brand-light)}
+
+/* TOPBAR */
+.topbar{position:sticky;top:0;z-index:20;display:flex;align-items:center;justify-content:space-between;
+  gap:16px;height:60px;padding:0 28px;background:rgba(245,244,237,.86);backdrop-filter:saturate(140%) blur(8px);
+  border-bottom:1px solid var(--border)}
+.wordmark{font-size:16px;font-weight:600;color:var(--near-black);letter-spacing:-.2px}
+.wordmark span{color:var(--brand);font-weight:500}
+.topbar-meta{font-family:var(--latin-ui);font-size:11.5px;color:var(--stone);letter-spacing:.3px}
+
+/* LAYOUT */
+.layout{display:flex;gap:44px;max-width:1200px;margin:0 auto;padding:36px 28px 80px;align-items:flex-start}
+.sidebar{width:188px;flex:0 0 188px;position:sticky;top:84px;max-height:calc(100svh - 108px);overflow:auto;
+  padding-right:6px}
+.content{flex:1;min-width:0;max-width:720px}
+.toc{width:172px;flex:0 0 172px;position:sticky;top:84px;max-height:calc(100svh - 108px);overflow:auto;
+  padding-top:4px;border-top:1px solid var(--border)}
+
+/* SIDEBAR NAV */
+.side-brand{display:block;font-size:13px;font-weight:600;color:var(--near-black);
+  letter-spacing:.4px;text-transform:uppercase;margin-bottom:18px}
+.side-brand span{color:var(--brand)}
+.side-group{margin-bottom:18px}
+.side-group-label{font-family:var(--latin-ui);font-size:10.5px;letter-spacing:1px;text-transform:uppercase;
+  color:var(--stone);margin-bottom:7px;padding-left:11px}
+.side-link{display:block;font-size:13.5px;line-height:1.35;color:var(--olive);
+  padding:5px 0 5px 11px;border-left:2px solid transparent;margin:1px 0}
+.side-link:hover{color:var(--brand)}
+.side-link[aria-current="page"]{color:var(--brand);font-weight:600;border-left-color:var(--brand)}
+
+/* ON THIS PAGE */
+.toc-label{font-family:var(--latin-ui);font-size:11px;letter-spacing:1px;text-transform:uppercase;
+  color:var(--stone);margin:14px 0 8px}
+.toc a{display:block;font-size:12.5px;line-height:1.4;color:var(--olive);padding:3px 0}
+.toc a:hover{color:var(--brand)}
+
+/* HEADINGS */
+.chapter-eyebrow{font-family:var(--latin-ui);font-size:11.5px;letter-spacing:1.2px;text-transform:uppercase;
+  color:var(--brand);font-weight:600;margin-bottom:9px}
+.page-title{font-size:30px;font-weight:500;line-height:1.18;letter-spacing:-.3px;color:var(--near-black);
+  border-left:3px solid var(--brand);padding-left:13px;margin-bottom:18px}
+.content h2{font-size:21px;font-weight:500;line-height:1.3;color:var(--near-black);
+  margin:34px 0 10px;scroll-margin-top:80px}
+.content h3{font-size:16.5px;font-weight:600;line-height:1.34;color:var(--dark-warm);margin:22px 0 7px}
+
+/* TEXT */
+.content p{margin:0 0 13px;color:var(--near-black)}
+.content .lead{font-size:18px;line-height:1.6;color:var(--dark-warm);margin-bottom:18px}
+.hl{color:var(--brand);font-weight:600}
+strong{font-weight:600}
+em{font-style:italic}
+.content ul,.content ol{margin:8px 0 14px;padding-left:22px}
+.content li{margin:5px 0;line-height:1.62}
+.content li::marker{color:var(--brand)}
+.content ol li::marker{font-weight:600}
+
+/* QUOTE / CALLOUT / TAKEAWAY */
+.content blockquote{border-left:2.5px solid var(--brand);margin:16px 0;padding:3px 0 3px 18px;color:var(--olive)}
+.content blockquote .cite{display:block;font-family:var(--latin-ui);font-size:12px;color:var(--stone);margin-top:6px}
+.callout{background:var(--ivory);border-left:2.5px solid var(--brand);padding:13px 17px;border-radius:5px;margin:16px 0}
+.callout p:last-child{margin-bottom:0}
+.takeaway{background:var(--brand-tint);border-radius:7px;padding:14px 18px;margin:18px 0}
+.takeaway-label{font-family:var(--latin-ui);font-size:11px;letter-spacing:1px;text-transform:uppercase;
+  color:var(--brand);font-weight:600;margin-bottom:6px}
+
+/* TAG */
+.tag{display:inline-block;background:var(--tag-bg);color:var(--brand);font-family:var(--latin-ui);
+  font-size:10.5px;font-weight:600;padding:1.5px 7px;border-radius:4px;letter-spacing:.5px;text-transform:uppercase;
+  vertical-align:middle;margin:0 2px}
+
+/* CODE */
+code{font-family:var(--mono);font-size:13px;background:var(--ivory);border:1px solid var(--border-soft);
+  padding:1px 5px;border-radius:4px;color:var(--dark-warm);word-break:break-word}
+pre{font-family:var(--mono);font-size:12.5px;line-height:1.6;background:#1e2330;color:#e7e8ec;
+  border-radius:9px;padding:15px 18px;margin:16px 0;overflow-x:auto}
+pre code{background:none;border:none;padding:0;color:inherit;font-size:inherit;word-break:normal}
+
+/* TABLE */
+.content table{width:100%;border-collapse:collapse;font-size:13.5px;line-height:1.5;margin:16px 0;
+  display:block;overflow-x:auto}
+.content th{font-family:var(--latin-ui);font-weight:600;font-size:12.5px;text-align:left;color:var(--dark-warm);
+  background:var(--ivory);padding:8px 11px;border-bottom:1.5px solid var(--border);white-space:nowrap}
+.content td{padding:7px 11px;border-bottom:1px solid var(--border-soft);vertical-align:top}
+.content table.compact th,.content table.compact td{padding:5px 9px;font-size:12.5px}
+.content tbody tr:hover td{background:rgba(27,54,93,.03)}
+
+/* HERO (home) */
+.hero{padding:8px 0 22px;border-bottom:1px solid var(--border);margin-bottom:24px}
+.hero-eyebrow{font-family:var(--latin-ui);font-size:12px;letter-spacing:1.4px;text-transform:uppercase;
+  color:var(--brand);font-weight:600;margin-bottom:14px}
+.hero-title{font-size:42px;font-weight:500;line-height:1.08;letter-spacing:-.6px;margin-bottom:14px}
+.hero-sub{font-size:18.5px;line-height:1.5;color:var(--olive);max-width:38em}
+.soft-rule{border:0;border-top:1px solid var(--border);margin:30px 0 8px}
+
+/* BROWSE GRID (home) */
+.browse-h{font-size:13px!important;font-family:var(--latin-ui);letter-spacing:1px;text-transform:uppercase;
+  color:var(--stone);font-weight:600;margin:26px 0 12px!important;border:0!important}
+.browse-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:12px;margin-bottom:8px}
+.browse-card{display:flex;flex-direction:column;gap:4px;padding:13px 15px;background:var(--ivory);
+  border:1px solid var(--border);border-radius:8px;transition:border-color .12s,transform .12s}
+.browse-card:hover{border-color:var(--brand);transform:translateY(-1px)}
+.browse-eyebrow{font-family:var(--latin-ui);font-size:10.5px;letter-spacing:.8px;text-transform:uppercase;color:var(--brand);font-weight:600}
+.browse-title{font-size:14.5px;color:var(--near-black);line-height:1.3}
+
+/* PAGER */
+.pager{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:42px;padding-top:20px;border-top:1px solid var(--border)}
+.pager-link{display:flex;flex-direction:column;gap:3px;border:0;background:none}
+.pager-link.next{text-align:right;align-items:flex-end}
+.pager-link:active{opacity:.6}
+.pager-eyebrow{font-family:var(--latin-ui);font-size:11px;letter-spacing:1px;text-transform:uppercase;color:var(--stone)}
+.pager-title{font-size:15.5px;font-weight:500;color:var(--brand);line-height:1.3}
+
+.page-foot{margin-top:40px;padding-top:16px;border-top:1px solid var(--border);
+  font-family:var(--latin-ui);font-size:11.5px;color:var(--stone)}
+
+/* RESPONSIVE */
+@media(max-width:880px){
+  .topbar-meta{display:none}
+  .layout{flex-direction:column;gap:20px;padding:18px 18px 64px}
+  .sidebar{position:static;width:auto;flex:none;max-height:none;display:flex;gap:4px;overflow-x:auto;
+    scrollbar-width:none;border-bottom:1px solid var(--border);padding:0 0 8px}
+  .sidebar::-webkit-scrollbar{display:none}
+  .side-brand{display:none}
+  .side-group{margin:0;display:flex;gap:4px;flex-shrink:0}
+  .side-group-label{display:none}
+  .side-link{white-space:nowrap;border-left:0;border-bottom:2px solid transparent;padding:6px 10px;margin:0}
+  .side-link[aria-current="page"]{border-left:0;border-bottom-color:var(--brand)}
+  .toc{display:none}
+  .content{max-width:100%}
+  .hero-title{font-size:32px}
+  .browse-grid{grid-template-columns:1fr}
+}
+@media(max-width:560px){
+  body{font-size:15px}
+  .content table{font-size:12px}
+  .page-title{font-size:25px}
+  .pager{grid-template-columns:1fr;gap:14px}
+  .pager-link.next{text-align:left;align-items:flex-start}
+}

--- a/plans/research/premium-monetization/totem-premium-research.html
+++ b/plans/research/premium-monetization/totem-premium-research.html
@@ -1,0 +1,2943 @@
+<!DOCTYPE html>
+<!-- ==================================================================
+     LONG DOCUMENT · English · parchment design system
+     Multi-page A4 white paper / tech report / annual review
+     Flow: cover -> toc -> exec summary -> chapters -> appendix
+     ================================================================== -->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Totem Premium Conversion</title>
+<meta name="author" content="nnnkit">
+<meta name="description" content="How to take Totem from free and open-source to a freemium product with a one-time $19 Pro unlock without a server: tech stack, payment gateway, license architecture, file-by-file changes, rollout.">
+<meta name="keywords" content="Totem, Chrome extension, freemium, premium, Manifest V3, Lemon Squeezy, Polar, Ed25519, license, monetization">
+<meta name="generator" content="Kami">
+<style>
+  /* Palatino is a system font, no @font-face needed */
+  @font-face { font-family: "JetBrains Mono"; src: url("../fonts/JetBrainsMono.woff2") format("woff2"); font-weight: 400; font-style: normal; }
+  @font-face { font-family: "JetBrains Mono"; src: url("../fonts/JetBrainsMono.woff2") format("woff2"); font-weight: 500; font-style: normal; }
+
+  @page {
+    size: A4;
+    margin: 20mm 22mm 22mm 22mm;
+    background: #f5f4ed;
+
+    @top-right {
+      content: string(section-title);
+      font-family: Charter, Georgia, Palatino, serif;
+      font-size: 8pt;
+      color: #6b6a64;
+    }
+
+    @bottom-center {
+      content: counter(page) "  ·  Totem Premium Conversion";
+      font-family: Charter, Georgia, Palatino, serif;
+      font-size: 9pt;
+      color: #6b6a64;
+    }
+  }
+  @page:first {
+    @top-right { content: ""; }
+    @bottom-center { content: ""; }
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --parchment: #f5f4ed;
+    --ivory:     #faf9f5;
+    --near-black:#141413;
+    --dark-warm: #3d3d3a;
+    --olive:     #504e49;
+    --stone:     #6b6a64;
+    --brand:     #1B365D;
+    --border:    #e8e6dc;
+    --border-soft:#e5e3d8;
+    --tag-bg:    #E4ECF5;
+
+    --serif: Charter, Georgia,
+             Palatino, "Times New Roman", serif;
+    --sans: var(--serif);
+    --mono:  "JetBrains Mono", "SF Mono", "Fira Code",
+             Consolas, Monaco, monospace;
+
+    --rhythm-module:  14pt;
+    --rhythm-section: 18pt;
+  }
+
+  html, body { background: var(--parchment); }
+
+  @media screen {
+    body { max-width: 210mm; margin: 0 auto; padding: 20mm 22mm 22mm 22mm; }
+  }
+
+  body {
+    color: var(--near-black);
+    font-family: var(--serif);
+    font-size: 10.5pt;
+    line-height: 1.55;
+    widows: 3;
+    orphans: 3;
+  }
+
+  .sans { font-family: var(--sans); }
+
+  /* COVER */
+  .cover {
+    min-height: 240mm;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 40mm 0 0 0;
+    break-after: page;
+  }
+  .cover-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8pt;
+    font-family: var(--sans);
+    font-size: 10pt;
+    color: var(--brand);
+    letter-spacing: 2pt;
+    text-transform: uppercase;
+    font-weight: 500;
+    margin-bottom: 18pt;
+  }
+  .cover-eyebrow::before {
+    content: "";
+    width: 9pt;
+    height: 1.5pt;
+    border-radius: 0.75pt;
+    background: var(--brand);
+    flex-shrink: 0;
+  }
+  .cover-title {
+    font-size: 40pt;
+    font-weight: 500;
+    color: var(--near-black);
+    line-height: 1.12;
+    letter-spacing: -0.5pt;
+    margin-bottom: 16pt;
+  }
+  .cover-sub {
+    font-family: var(--sans);
+    font-size: 14pt;
+    color: var(--olive);
+    line-height: 1.45;
+    max-width: 85%;
+    margin-bottom: 30pt;
+  }
+  .cover-meta {
+    font-family: var(--sans);
+    font-size: 10pt;
+    color: var(--stone);
+    line-height: 1.55;
+    font-variant-numeric: tabular-nums;
+  }
+  .cover-meta strong { color: var(--dark-warm); font-weight: 500; }
+
+  /* TOC */
+  .toc { break-after: page; }
+  .toc h2 {
+    font-size: 22pt;
+    font-weight: 500;
+    margin-bottom: var(--rhythm-module);
+    border-left: 2.5pt solid var(--brand);
+    border-radius: 1.5pt;
+    padding-left: 8pt;
+  }
+  .toc-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 6pt 0;
+    border-bottom: 0.3pt dotted var(--border);
+    font-size: 11pt;
+  }
+  .toc-item:last-of-type { border-bottom: none; }
+  .toc-num {
+    color: var(--brand);
+    font-weight: 500;
+    min-width: 30pt;
+    font-variant-numeric: tabular-nums;
+  }
+  .toc-title {
+    flex: 1;
+    color: var(--near-black);
+    padding-left: 6pt;
+  }
+  .toc-page {
+    color: var(--stone);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* HEADINGS */
+  h1 {
+    font-size: 24pt;
+    font-weight: 500;
+    line-height: 1.15;
+    letter-spacing: -0.3pt;
+    margin: 0 0 10pt 0;
+    border-left: 2.5pt solid var(--brand);
+    border-radius: 1.5pt;
+    padding-left: 8pt;
+    color: var(--near-black);
+    break-after: avoid;
+  }
+  h2 {
+    font-size: 16pt;
+    font-weight: 500;
+    line-height: 1.25;
+    margin: 24pt 0 8pt 0;
+    color: var(--near-black);
+    break-after: avoid;
+    string-set: section-title content();
+  }
+  h3 {
+    font-size: 13pt;
+    font-weight: 500;
+    line-height: 1.3;
+    margin: 18pt 0 6pt 0;
+    color: var(--dark-warm);
+    break-after: avoid;
+  }
+
+  .chapter-num {
+    font-family: var(--sans);
+    font-size: 10pt;
+    color: var(--brand);
+    letter-spacing: 1pt;
+    text-transform: uppercase;
+    font-weight: 500;
+    margin-bottom: 6pt;
+  }
+
+  /* PARAGRAPHS */
+  p { margin: 0 0 10pt 0; line-height: 1.55; color: var(--near-black); widows: 2; orphans: 2; }
+
+  .lead {
+    font-size: 12pt;
+    line-height: 1.55;
+    color: var(--dark-warm);
+    margin-bottom: var(--rhythm-module);
+  }
+
+  .hl { color: var(--brand); font-weight: 500; }
+  strong { font-weight: 500; }
+
+  /* LISTS */
+  ul, ol {
+    margin: 6pt 0 10pt 0;
+    padding-left: 20pt;
+    line-height: 1.55;
+  }
+  ul li::marker { color: var(--brand); }
+  ol li::marker { color: var(--brand); font-weight: 500; }
+
+  /* QUOTE */
+  blockquote, .quote {
+    border-left: 2pt solid var(--brand);
+    margin: 12pt 0;
+    padding: 4pt 0 4pt 16pt;
+    color: var(--olive);
+    line-height: 1.55;
+    break-inside: avoid;
+  }
+  blockquote .cite, .quote .cite {
+    display: block;
+    font-family: var(--sans);
+    font-size: 9pt;
+    color: var(--stone);
+    margin-top: 4pt;
+  }
+
+  /* CODE */
+  code {
+    font-family: var(--mono);
+    font-size: 9pt;
+    background: var(--ivory);
+    padding: 1pt 4pt;
+    border-radius: 2pt;
+    color: var(--dark-warm);
+  }
+  pre {
+    font-family: var(--mono);
+    font-size: 9pt;
+    line-height: 1.5;
+    background: var(--ivory);
+    border-radius: 4pt;
+    padding: 10pt 14pt;
+    margin: 10pt 0;
+    white-space: pre-wrap;
+    color: var(--near-black);
+    break-inside: avoid;
+  }
+  pre code { background: transparent; padding: 0; font-size: inherit; }
+
+  /* TABLE (kami-table) */
+  table, .kami-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 9.5pt;
+    margin: 12pt 0;
+    break-inside: avoid;
+  }
+  table th, .kami-table th {
+    text-align: left;
+    font-family: var(--sans);
+    font-weight: 500;
+    color: var(--dark-warm);
+    padding: 6pt 8pt;
+    border-bottom: 1pt solid var(--border);
+    background: var(--ivory);
+  }
+  table td, .kami-table td {
+    padding: 5pt 8pt;
+    border-bottom: 0.3pt solid var(--border-soft);
+    vertical-align: top;
+  }
+  table.compact th, .kami-table.compact th { padding: 3pt 6pt; font-size: 8pt; }
+  table.compact td, .kami-table.compact td { padding: 2pt 6pt; font-size: 8pt; line-height: 1.4; }
+  table.financial td:not(:first-child), .kami-table.financial td:not(:first-child) {
+    text-align: right; font-variant-numeric: tabular-nums;
+  }
+  table.financial th:not(:first-child), .kami-table.financial th:not(:first-child) { text-align: right; }
+  table.striped tbody tr:nth-child(even) td, .kami-table.striped tbody tr:nth-child(even) td {
+    background: var(--ivory);
+  }
+  table .total td, .kami-table .total td {
+    font-weight: 500; border-top: 1pt solid var(--brand); border-bottom: none; color: var(--near-black);
+  }
+
+  /* CALLOUT / TAKEAWAY */
+  .callout {
+    background: var(--ivory);
+    border-left: 2pt solid var(--brand);
+    padding: 10pt 14pt;
+    border-radius: 3pt;
+    margin: 12pt 0;
+    line-height: 1.55;
+    break-inside: avoid;
+  }
+  .callout blockquote,
+  .callout .quote {
+    border-left: none;
+    padding-left: 0;
+    margin: 6pt 0;
+    color: var(--olive);
+  }
+  .callout blockquote:first-child,
+  .callout .quote:first-child { margin-top: 0; }
+  .callout blockquote:last-child,
+  .callout .quote:last-child  { margin-bottom: 0; }
+  .takeaway {
+    background: var(--ivory);
+    border-radius: 4pt;
+    padding: 10pt 14pt;
+    margin: 14pt 0;
+    break-inside: avoid;
+  }
+  .takeaway-label {
+    font-family: var(--sans);
+    font-size: 9pt;
+    color: var(--brand);
+    letter-spacing: 1pt;
+    text-transform: uppercase;
+    font-weight: 500;
+    margin-bottom: 4pt;
+  }
+
+  /* TAG */
+  .tag {
+    display: inline-block;
+    background: var(--tag-bg);
+    color: var(--brand);
+    font-family: var(--sans);
+    font-size: 9pt;
+    font-weight: 500;
+    padding: 1pt 6pt;
+    border-radius: 3pt;
+    letter-spacing: 0.4pt;
+    text-transform: uppercase;
+    margin-right: 4pt;
+  }
+
+  /* FIGURE */
+  figure { margin: 14pt 0; break-inside: avoid; }
+  figure img { max-width: 100%; border-radius: 4pt; }
+  figcaption {
+    font-family: var(--sans);
+    font-size: 9pt;
+    color: var(--stone);
+    margin-top: 6pt;
+    text-align: center;
+  }
+
+  /* CHAPTER BREAK */
+  .chapter { break-before: page; }
+</style>
+</head>
+<body>
+
+<section class="cover">
+  <div>
+    <div class="cover-eyebrow">Technical Report · Premium Monetization</div>
+    <div class="cover-title">Making Totem<br>Premium</div>
+    <div class="cover-sub">From free, open-source and local-first to a one-time $19 Pro unlock — without a server. The full research record and the file-by-file execution plan.</div>
+  </div>
+  <div class="cover-meta">
+    <strong>nnnkit</strong><br>
+    Version 1.0 · 2026.06<br>
+    Totem · plans/research/premium-monetization
+  </div>
+</section>
+
+<section class="toc">
+  <h2>Contents</h2>
+  <div class="toc-item"><span class="toc-num">01</span><span class="toc-title">Executive Summary</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">02</span><span class="toc-title">The Premium Model &amp; Why It Fits</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">03</span><span class="toc-title">Free vs Pro — Features &amp; Limits</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">04</span><span class="toc-title">Tech Stack — What Is New</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">05</span><span class="toc-title">Payment Gateway — The Decision</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">06</span><span class="toc-title">License &amp; Entitlement Architecture</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">07</span><span class="toc-title">Internal System Changes — File by File</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">08</span><span class="toc-title">Chrome Web Store Compliance</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">09</span><span class="toc-title">Paywall UX — Moments, Copy, Anti-Patterns</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">10</span><span class="toc-title">Phased Rollout &amp; Open Decisions</span><span class="toc-page">Synthesis</span></div>
+  <div class="toc-item"><span class="toc-num">11</span><span class="toc-title">Adversarial Review — What the Red-Team Caught</span><span class="toc-page">Verification</span></div>
+  <div class="toc-item"><span class="toc-num">A</span><span class="toc-title">Appendix A · Data, Sync &amp; Entitlement Storage</span><span class="toc-page">Codebase</span></div>
+  <div class="toc-item"><span class="toc-num">B</span><span class="toc-title">Appendix B · Features &amp; Export Surface</span><span class="toc-page">Codebase</span></div>
+  <div class="toc-item"><span class="toc-num">C</span><span class="toc-title">Appendix C · Build &amp; Release Pipeline</span><span class="toc-page">Codebase</span></div>
+  <div class="toc-item"><span class="toc-num">D</span><span class="toc-title">Appendix D · Site &amp; Distribution</span><span class="toc-page">Codebase</span></div>
+  <div class="toc-item"><span class="toc-num">E</span><span class="toc-title">Appendix E · UI State &amp; Upsell Surfaces</span><span class="toc-page">Codebase</span></div>
+  <div class="toc-item"><span class="toc-num">F</span><span class="toc-title">Appendix F · Payment Gateways Compared</span><span class="toc-page">Market</span></div>
+  <div class="toc-item"><span class="toc-num">G</span><span class="toc-title">Appendix G · License Architecture &amp; DRM Stance</span><span class="toc-page">Market</span></div>
+  <div class="toc-item"><span class="toc-num">H</span><span class="toc-title">Appendix H · 2026 Market Discourse</span><span class="toc-page">Market</span></div>
+  <div class="toc-item"><span class="toc-num">I</span><span class="toc-title">Appendix I · CWS Policy &amp; Paywall UX</span><span class="toc-page">Market</span></div>
+  <div class="toc-item"><span class="toc-num">J</span><span class="toc-title">References &amp; Method</span><span class="toc-page">Reference</span></div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">01 · Executive Summary</div>
+  <h1>Executive Summary</h1>
+<p class="lead">
+  Totem can become a paid product without betraying the local-first, no-server, open-source ethos that <span class="hl">is the brand</span>. The move is a freemium model with a one-time $19 lifetime Pro unlock — and the surprising finding from a full codebase audit is that this is overwhelmingly a packaging job, not a building job.
+</p>
+
+<h2>The four decisions</h2>
+<ol>
+  <li><strong>Model — freemium, one build, runtime-gated.</strong> The free tier stays fully functional forever; Pro is a one-time lifetime unlock. It is the only model the single-artifact pipeline and the subscription-averse, anti-DRM audience actually support.</li>
+  <li><strong>The work is packaging, not building.</strong> Five of the six proposed Pro features already exist and ship for free today — export, deleted-tweet preservation (the hydration engine), advanced search, annotations, thread-aware capture. Only <span class="tag">NET-NEW</span> bulk operations must be built. The real engineering is one clean entitlement boundary.</li>
+  <li><strong>Payments — merchant-of-record for checkout, online license validation for verification.</strong> Lemon Squeezy or Polar handles global VAT so there is no Totem billing server, and the extension validates the key against the provider's license API <em>once at activation</em>, caches the result locally, and reads it from cache thereafter — re-checking quietly in the background and failing open so an outage never locks out a paying user. Only the key and email leave the device; bookmarks never do. The provider also counts devices, so multi-browser activation is capped at a generous limit (~5) with self-serve deactivation.</li>
+  <li><strong>The #1 risk is the retroactive paywall.</strong> Totem is already free; bolting a paywall onto existing users earns 1-star reviews. Grandfather every existing install — full features, free, forever — and gate only new installs.</li>
+</ol>
+
+<h2>Key takeaways</h2>
+<ul>
+  <li>Realistic conversion to model against: <span class="hl">1–3% of active users</span> (not installs), ~60–70% checkout completion — the one-time-tool bucket where lifetime pricing beats subscriptions.</li>
+  <li>The cleanest authoritative entitlement is a service-worker-owned <code>CS_ENTITLEMENT</code> key in <code>chrome.storage.local</code>, kept off the reset lists and stamped into the existing reactive snapshot so every open tab flips to Pro on the same event-loop tick.</li>
+  <li>One hard repo blocker exists: <code>scripts/verify-cws-featured-readiness.mjs</code> hard-pins the manifest permissions, hosts, description string, and screenshot set — it must be loosened for any new host or copy change.</li>
+  <li>An adversarial review pass corrected the load-bearing claims before this document shipped (see Chapter 11): export is not single-gated, the original "fully offline, nothing can shut down" framing was an overclaim — the design now validates online once and caches with fail-open — and grandfathering by install-reason alone misfires on reinstall.</li>
+</ul>
+
+<div class="takeaway">
+  <div class="takeaway-label">Questions this document answers</div>
+  How does Totem go premium without a server or losing its open-source trust? What is the exact tech stack, payment gateway, and license architecture? And which files change, in what order, to make the paywall work flawlessly?
+</div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">02 · The Model</div>
+  <h1>The Premium Model &amp; Why It Fits</h1>
+<p class="lead">Take Totem from free + open-source to a freemium product with a <span class="hl">$19 one-time "Pro" unlock</span> — without breaking the local-first, no-server, open-source ethos that <em>is</em> the brand. Grounded in a 9-agent deep dive of the actual codebase plus the 2026 payments/extension market. Date: 2026-06-19.</p>
+
+<h2>The four decisions</h2>
+
+<ol>
+<li><strong>Model: Freemium, one build, runtime-gated.</strong> The free tier stays fully functional forever; Pro is a one-time lifetime unlock. This is the only model the pipeline (single artifact, single CWS listing) and the audience (subscription-averse, anti-DRM) actually support.</li>
+<li><strong>The work is packaging, not building.</strong> <strong>5 of the 6</strong> proposed Pro features already exist and ship for free today — export, deleted-tweet preservation (the hydration engine), advanced search filters, annotations, thread-aware capture. Only <strong>bulk ops</strong> is net-new. The real engineering is a <em>single clean entitlement boundary</em>, not new features.</li>
+<li><strong>Payments: a merchant-of-record</strong> (Lemon Squeezy or Polar) for checkout, so global VAT/tax is handled and there's no Totem billing server. Verify with the <strong>provider's license API</strong>: validate the key <strong>online once at activation</strong>, cache the result locally, and read from that cache thereafter — re-checking quietly in the background and <strong>failing open</strong> so a network blip never locks out a paying user. Only the key + email leave the device; bookmark content never does. The provider also counts devices, so multi-browser activation is capped at a generous limit (~5) with self-serve deactivation.</li>
+<li><strong>The #1 risk is the retroactive paywall.</strong> Totem is already free; bolting a paywall onto existing users generates 1-star reviews. <strong>Grandfather every existing install</strong> (full features, free, forever) and only ever gate <em>new</em> installs. This single move neutralizes the biggest execution risk.</li>
+</ol>
+
+<div class="takeaway"><div class="takeaway-label">CORE BET</div> One artifact, gated at runtime; one-time lifetime price; verify online once and cache (fail-open); never claw back from existing users.</div>
+
+<h2>The premium model (and why this one)</h2>
+
+<p>The model is not a preference — it's forced by four hard constraints, two from the code and two from the audience. Each one points the same direction.</p>
+
+<table class="compact">
+<thead><tr><th>Constraint</th><th>What it forces</th></tr></thead>
+<tbody>
+<tr><td>Pipeline is single-artifact (one <code>dist/</code>, one zip, one CWS item, version-pinned)</td><td><strong>One build, entitlement-gated at runtime.</strong> Not separate Free/Pro builds.</td></tr>
+<tr><td>Audience = r/nosurf, r/selfhosted, HN, PKM (subscription-fatigued, anti-DRM, pro-ownership)</td><td><strong>One-time "lifetime" unlock</strong>, Obsidian-Catalyst-style "fund the work," not a subscription.</td></tr>
+<tr><td>Local-first, no Totem server, no telemetry is the pitch</td><td>Verification is a <strong>quick online check at activation</strong>, then <strong>cached and read locally</strong> — no per-launch phone-home; fail-open on outages; bookmarks never leave the device.</td></tr>
+<tr><td>Open-source (code is public on GitHub)</td><td>The check is <strong>patchable by design</strong> — accept it, out-serve the cracker, don't build DRM.</td></tr>
+</tbody>
+</table>
+
+<h3>The 2026 market evidence (first-party)</h3>
+
+<p>The one-time model isn't just on-brand — it converts better for this product category. The first-party signals from 2026:</p>
+
+<ul>
+<li>PaletteGrab got a <strong>60% conversion lift</strong> switching from monthly to one-time.</li>
+<li>MiroMiro got <strong>"5 paying customers in a row"</strong> after adding a lifetime option.</li>
+<li>The consensus from extension builders: <em>"Chrome extensions aren't SaaS apps. They're tools. People prefer to buy tools once."</em></li>
+</ul>
+
+<div class="callout">Subscriptions still win <strong>high-revenue, server-cost</strong> categories — SEO, dev-tools, AI at $5k–200k/mo. But Totem is squarely a low-marginal-cost client utility, the bucket where one-time wins.</div>
+
+<p>Realistic conversion to model against: <span class="hl">1–3% of <em>active</em> users</span> (not installs), at roughly 60–70% checkout completion.</p>
+
+<h3>Pricing</h3>
+
+<ul>
+<li><strong>$19 one-time lifetime</strong> — the GTM-validated number: above the $4.99 utility floor, below the $29 "enterprise-parity" expectation.</li>
+<li><strong>$14 founders price for the first 60 days</strong>, framed honestly ("$14 founders price, rising to $19") — no fake countdowns.</li>
+<li><strong>Never</strong> "2 years of updates." Use "lifetime," no expiry qualifier — the local-first architecture means it genuinely works forever.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">PRICE</div> $19 lifetime, $14 founders for 60 days. Honest framing, no countdown theater, no expiry on "lifetime."</div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">03 · Features</div>
+  <h1>Free vs Pro — Features &amp; Limits</h1>
+<p class="lead">The split is dictated by one hard rule from the research: <strong>feature-gate genuinely-new value; never claw back a feature existing users already have free.</strong> Because export, search, and annotations <em>already ship free</em>, the plan combines three levers: <span class="hl">grandfathering</span> (existing users keep everything), a free allowance (new users try Pro on their own data), and clean feature gates for genuinely new value.</p>
+
+<h2>The matrix</h2>
+
+<table class="compact">
+<thead>
+<tr>
+<th>Capability</th>
+<th>Free tier</th>
+<th>Pro ($19)</th>
+<th>Already built?</th>
+<th>Gate location</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>New-tab reading queue / Today's Read</td>
+<td>full</td>
+<td>yes</td>
+<td>yes</td>
+<td>— (never gate)</td>
+</tr>
+<tr>
+<td>Sync (GraphQL interception → IndexedDB)</td>
+<td>full, no count cap</td>
+<td>yes</td>
+<td>yes</td>
+<td>—</td>
+</tr>
+<tr>
+<td>Reader (threads/articles)</td>
+<td>full</td>
+<td>yes</td>
+<td>yes</td>
+<td>—</td>
+</tr>
+<tr>
+<td>Basic full-text search</td>
+<td>full</td>
+<td>yes</td>
+<td>yes</td>
+<td>—</td>
+</tr>
+<tr>
+<td>Import (re-import a Totem ZIP)</td>
+<td>full</td>
+<td>yes</td>
+<td>yes</td>
+<td>— (keep free: data-portability = trust)</td>
+</tr>
+<tr>
+<td><strong>Library export</strong> (CSV/MD/JSONL ZIP)</td>
+<td>first ~25 items (try-before-buy)</td>
+<td>unlimited, all formats</td>
+<td>yes (<code>quick-export.ts</code>)</td>
+<td><code>ExportModal.handleQuickExport</code></td>
+</tr>
+<tr>
+<td><strong>Per-article export</strong> (Download MD / Print PDF)</td>
+<td>Copy-to-clipboard free (teaser)</td>
+<td>Download MD / PDF</td>
+<td>yes (<code>article-download.ts</code>)</td>
+<td><code>ArticleExportMenu</code> handlers</td>
+</tr>
+<tr>
+<td><strong>Deleted-tweet preservation</strong></td>
+<td>preserves what you've already opened</td>
+<td>auto-preserves your whole library + "kept your copy" badge</td>
+<td>yes (<code>hydration-store.ts</code>)</td>
+<td><code>handleStartFullExport</code> / hydration <code>start()</code></td>
+</tr>
+<tr>
+<td><strong>Advanced search filters</strong> (<code>from: site: min_faves: has: is:</code> …)</td>
+<td>plain text only</td>
+<td>operators</td>
+<td>yes (<code>lib/search/parser.ts</code>)</td>
+<td><code>useBookmarkSearch</code> (gate parsed AST nodes)</td>
+</tr>
+<tr>
+<td><strong>Annotations</strong> (highlights + notes)</td>
+<td>create basic highlights</td>
+<td>notes + annotation <strong>export</strong></td>
+<td>yes (<code>SelectionToolbar</code>, <code>highlights</code> store)</td>
+<td><code>onHighlight</code>/<code>onAddNote</code></td>
+</tr>
+<tr>
+<td><strong>Bulk operations</strong> (multi-select tag/delete/export)</td>
+<td>—</td>
+<td>yes</td>
+<td><span class="tag">NET-NEW</span></td>
+<td>new selection UI + dispatcher</td>
+</tr>
+<tr>
+<td>Future: MCP endpoint, semantic search</td>
+<td>—</td>
+<td>yes</td>
+<td>net-new (roadmap)</td>
+<td>future modules</td>
+</tr>
+</tbody>
+</table>
+
+<h2>The grandfather rule (non-negotiable, ship in the same release)</h2>
+
+<p>On the release that introduces Pro:</p>
+
+<ul>
+<li><code>chrome.runtime.onInstalled</code> with <code>reason === "update"</code> (i.e., the user already had Totem) → stamp a <strong><code>grandfatheredAt</code></strong> entitlement: <strong>full Pro features, free, forever.</strong></li>
+<li><code>reason === "install"</code> (fresh) → free tier with the allowance/gates above.</li>
+</ul>
+
+<div class="callout"><strong><code>onInstalled.reason</code> alone is not enough (adversarial-review correction).</strong> It misfires for exactly the cohort grandfathering protects: a user who uninstalls→reinstalls, or moves to a new machine, fires <code>reason === "install"</code> and would lose grandfathered status.</div>
+
+<p>Add a <strong>secondary "existing user" heuristic</strong> that also runs on <code>install</code>: if the bookmarks IndexedDB store is non-empty (or a pre-Pro settings/growth-state key already exists locally), treat them as grandfathered. The <span class="hl">local-data check is the dependable signal</span>; don't <em>rely</em> on the <code>chrome.storage.sync</code> mirror having landed before the first gate evaluation. Net effect: the change is <em>additive</em> for everyone who already uses Totem (the people who evangelize it), and monetization is limited to genuinely new users — the low-backlash path the research demands.</p>
+
+<div class="takeaway"><div class="takeaway-label">RULE</div> The local IndexedDB bookmarks check — not <code>onInstalled.reason</code>, not the sync mirror — is the dependable "existing user" signal.</div>
+
+<h2>Why these specific gates</h2>
+
+<p><strong>Export</strong> is the <em>primary</em> gate but <span class="hl">not a single call site</span> (adversarial-review correction). The bulk-ZIP path concentrates at one place (<code>ExportModal.tsx:64</code> → <code>runQuickExport(account)</code>), but there are <strong>independent per-article egress paths</strong> in <code>src/components/BookmarkReader.tsx:313-352</code> (copy-Markdown, copy-for-agent, download <code>.md</code>, print/Save-PDF) that bypass <code>ExportModal</code> entirely. <strong>All of them must be gated</strong>, or a free user has a full-library exfiltration path one article at a time. Decide deliberately whether <em>copy-to-clipboard</em> stays free as a teaser — it is a slow leak (copy each article manually); acceptable as a teaser, but call it knowingly. The PKM/Obsidian persona is the willing-to-pay cohort and export is their #1 need.</p>
+
+<p><strong>Deleted-tweet preservation</strong> is the <em>emotional</em> gate (loss aversion): "This tweet was deleted on X. Totem kept your copy." It's already implemented as the hydration engine — it just isn't <em>sold</em> as a feature yet.</p>
+
+<p><strong>Bulk ops</strong> is the only net-new build; it doubles as a fresh, obviously-new capability that nobody can claim was "taken away."</p>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">04 · Tech Stack</div>
+  <h1>Tech Stack — What Is New</h1>
+<p class="lead">Totem stays exactly as it is — MV3, React 19, Zustand, IndexedDB/<code>idb</code>, Vite, Astro site. The premium layer adds a <span class="hl">small, deliberately boring</span> surface on top.</p>
+
+<h2>The added surface</h2>
+
+<p>Nothing here replaces the existing stack; each row is a narrow, self-contained addition chosen to preserve the local-first, no-server ethos.</p>
+
+<table>
+<thead>
+<tr><th>Concern</th><th>Choice</th><th>Why</th></tr>
+</thead>
+<tbody>
+<tr>
+<td>Checkout + tax</td>
+<td><strong>Merchant-of-record: Lemon Squeezy</strong> (primary) or <strong>Polar</strong> (cost-optimized)</td>
+<td>MoR remits global VAT/GST, so the solo dev never registers for tax anywhere. No Totem billing server.</td>
+</tr>
+<tr>
+<td>License keys</td>
+<td><strong>Provider-issued license keys</strong> (Lemon Squeezy / Polar)</td>
+<td>The MoR mints and emails the key on a paid order — <strong>no separate signer, no key-management vendor, no private signing key to host.</strong></td>
+</tr>
+<tr>
+<td>License verification</td>
+<td><strong>Online validate</strong> via the provider's license API — once at activation + a quiet periodic background re-check</td>
+<td>Validating <em>data</em> (JSON) is MV3-legal. Result is <strong>cached in <code>CS_ENTITLEMENT</code></strong> and read locally thereafter; <strong>fail-open</strong> on network errors. Only key + email leave the device.</td>
+</tr>
+<tr>
+<td>Device management</td>
+<td>Provider <strong>activation limit (~5)</strong> + self-serve <strong>deactivate</strong> page (its customer portal)</td>
+<td>Resolves multi-browser activation: a real person's few devices are fine; mass key-sharing is capped. Counting requires the online check.</td>
+</tr>
+<tr>
+<td>Entitlement storage</td>
+<td>New SW-owned <code>chrome.storage.local</code> key <code>CS_ENTITLEMENT</code></td>
+<td>Single-writer, reset-surviving, rides the existing reactive snapshot channel. Holds the cached validate result.</td>
+</tr>
+<tr>
+<td>Pricing/license pages</td>
+<td>New static Astro pages on <code>usetotem.xyz</code></td>
+<td>Site is 100% static; pages are static + client <code>&lt;script&gt;</code>, no backend.</td>
+</tr>
+</tbody>
+</table>
+
+<h2>No Totem server</h2>
+
+<p>Checkout, tax, key issuance, and device counting all live with the merchant-of-record. The extension talks to the <strong>provider's</strong> API (one host permission), never to a Totem-run backend. The MoR's <em>secret</em> API key stays server-side and never enters <code>dist/</code> — the validate call a public client makes needs no secret.</p>
+
+<div class="takeaway">
+<div class="takeaway-label">NET EFFECT</div>
+The only network the extension does for licensing is a small <strong>validate</strong> call at activation and an occasional background re-check — never a per-launch phone-home, and never anything touching bookmark data. Verify online, but read from cache and fail open, so an outage can't lock out a buyer.
+</div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">05 · Payments</div>
+  <h1>Payment Gateway — The Decision</h1>
+<p class="lead">Native Chrome Web Store payments died <strong>Feb 1, 2021</strong>, so an external processor is mandatory. The choice is not just "who takes the smallest cut" — it is which option keeps Totem <span class="hl">server-free, privacy-safe, and resilient to provider outages</span>.</p>
+
+<h2>The contenders (2026 facts)</h2>
+
+<table class="striped">
+<thead>
+<tr><th>Option</th><th>Fee on a $19 sale</th><th>Merchant of Record? (tax handled)</th><th>License API</th><th>Fits local-first + OSS?</th></tr>
+</thead>
+<tbody>
+<tr><td><strong>Lemon Squeezy</strong></td><td>5% + 50&cent; (~$1.45)</td><td>yes</td><td>most mature (validate/activate/deactivate, key-only, cacheable)</td><td>yes (Stripe-acquisition transition is the one watch-item)</td></tr>
+<tr><td><strong>Polar</strong></td><td>5%+50&cent; free / 3.8%+40&cent; on Pro plan</td><td>yes</td><td>public validate endpoint, <strong>safe for public clients</strong></td><td>yes; cheapest, OSS-positioned; younger; online-only validate</td></tr>
+<tr><td><strong>ExtensionPay</strong></td><td>5% + Stripe 2.9%+30&cent; (~8% all-in)</td><td><strong>no</strong> (you owe tax)</td><td>email magic-link, <strong>no key</strong>; <code>getUser()</code> phones home every check</td><td>no &mdash; not MoR, hard runtime dependency on extensionpay.com</td></tr>
+<tr><td>Raw Stripe</td><td>2.9%+30&cent;</td><td>no</td><td>build it yourself + server</td><td>no &mdash; defeats "minimal server / tax handled"</td></tr>
+<tr><td>Gumroad</td><td>10%+50&cent; (~$2.40)</td><td>yes</td><td>verify API</td><td>highest fee, "creator marketplace" feel</td></tr>
+</tbody>
+</table>
+
+<h2>Recommendation</h2>
+
+<div class="callout"><strong>Lemon Squeezy as merchant-of-record (primary), Polar as the cost-optimized alternative</strong> &mdash; and use the provider's license-key API for verification: validate the key online once at activation, cache the result locally, fail open, with a generous device limit.</div>
+
+<h3>Why MoR, not ExtPay</h3>
+
+<p>ExtPay is the <em>fastest</em> to wire and the most extension-native, but it (a) is <strong>not</strong> a merchant of record, so you still owe VAT in every country, and (b) makes <strong>every</strong> paid check a live <code>getUser()</code> call to <code>extensionpay.com</code> with <strong>no documented offline cache</strong> &mdash; so a network failure can throw on a routine launch. The MoR's license API is better on both axes: it removes the tax burden, and you call <strong>validate</strong> <em>once at activation</em>, then run from a local cache and only re-check occasionally in the background. <span class="hl">You verify online, but you don't depend on the network being up on every launch.</span></p>
+
+<h3>Why online validate (not a fully-offline signed key)</h3>
+
+<p>We deliberately accept one online check. It is the simplest path, it is what makes <strong>device management</strong> possible (something has to count activations), and it lets the provider revoke a refunded or charged-back key. MV3 allows it cleanly: validating a key returns <strong>JSON data</strong>, not remote code. The cost &mdash; a host permission and a reworded store description &mdash; is small. We do <strong>not</strong> ship an on-device signature verifier, a license-signing vendor, or a private signing key; the provider issues and validates the key.</p>
+
+<h3>The rule that keeps it resilient &mdash; cache + fail-open</h3>
+
+<p>Validate online at activation &rarr; write <code>isPro</code> to <code>CS_ENTITLEMENT</code> &rarr; read from that cache on every launch. Re-validate quietly in the background (e.g. weekly) to catch refunds. If a re-check can't reach the network, <strong>keep Pro on</strong> (fail-open, with a grace window) &mdash; never revoke a paying user because their Wi-Fi blipped or the provider had a hiccup. "Online verification" means <em>check when we can, trust the saved answer otherwise</em> &mdash; not <em>gate every launch on a live call</em>.</p>
+
+<h3>Multi-device activation</h3>
+
+<p>A purely offline key can't be counted (nothing knows how many browsers hold it). Because verification is <strong>online</strong>, the provider <em>is</em> that shared counter: set a generous <strong>activation limit (~5)</strong>, expose <strong>activate / deactivate</strong> so a user can free a slot from the customer portal (the fix for the reinstall-burns-a-slot complaint), and send a device id on activate. An <strong>unlimited</strong> limit ("use on all your browsers") is a defensible zero-friction alternative for a $19 honest-audience tool &mdash; you just accept that a key <em>could</em> be shared, the same way the open-source build can already be patched.</p>
+
+<div class="takeaway"><div class="takeaway-label">BRAND PROMISE, PRECISELY</div> Not "works offline, nothing can shut down," but the truthful version: <span class="hl">no Totem server to run &mdash; the provider handles checkout, tax, and licensing; your bookmarks never leave your device; Pro is verified by a quick online check, then cached and read locally.</span> Cached entitlements ride out a short provider outage &mdash; relevant given the Lemon-Squeezy&rarr;Stripe transition watch-item.</div>
+
+<h2>The honest stance (publish it &mdash; it converts for this audience)</h2>
+
+<p>Open-source + client-side means a determined user can patch out the check. <strong>Don't fight it.</strong> Ship this copy in the README and the upgrade screen:</p>
+
+<blockquote>Totem is open source. You <em>could</em> patch out the Pro check &mdash; the code is right there. We're not going to fight you with DRM that makes the app worse for everyone. Pro is $19 once; it funds the export, search, and deleted-tweet preservation work. If it's useful, buy it. If you genuinely can't, the free tier is fully functional forever.<span class="cite"> - Totem upgrade screen / README</span></blockquote>
+
+<p>For a $19 lifetime tool, the cracker's "service" (untrusted patched build, re-patch every update, no support) is worse than paying. For the privacy/HN/self-hosted audience, the <em>absence</em> of DRM is a trust signal, not a weakness. (Gabe Newell's "piracy is a service problem" &mdash; sourced in <code>rs-license-arch.md</code>.)</p>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">06 · License</div>
+  <h1>License &amp; Entitlement Architecture</h1>
+<p class="lead">A paid unlock has to survive resets, account switches, and offline launches while never violating the MV3 ban on remote code. The architecture leans on seams that already exist: a service-worker trust boundary, a reactive snapshot channel, and a cached online-validate result.</p>
+
+<h2>5.1 End-to-end flow</h2>
+
+<p>From the buyer's click to the gated feature flipping on, seven stages carry the license key through purchase, validation, caching, and propagation.</p>
+
+<pre><code>1. PURCHASE   Buyer clicks "Upgrade — $19 lifetime" in the extension
+              → opens usetotem.xyz/pricing → MoR hosted checkout
+              (Lemon Squeezy / Polar = merchant of record; card + VAT handled)
+                    │
+2. ISSUE      On paid order, the MoR mints a license key and emails it
+              to the buyer + shows it on usetotem.xyz/upgrade/success.
+              (No separate signer; the provider owns issuance.)
+                    │
+3. ACTIVATE   Buyer returns to extension. Three layered paths:
+              (a) one-click: success page → externally_connectable → onMessageExternal
+              (b) deep link: chrome-extension://&lt;id&gt;/newtab.html?license=&lt;key&gt;
+              (c) paste-a-key fallback in Settings (always shipped)
+                    │
+4. VALIDATE   Service worker calls the provider's validate/activate endpoint
+              ONCE with { key, instanceId }. Receives JSON { valid, plan, ... }.
+              Counts toward the device limit. MV3-safe (remote DATA, not code).
+                    │
+5. PERSIST    SW writes CS_ENTITLEMENT to chrome.storage.local
+              { isPro, plan, email, order, instanceId, validatedAt } + raw key.
+              Stamped into RuntimeSnapshot.
+                    │
+6. PROPAGATE  CS_RUNTIME_STATE_V2 change → chrome.storage.onChanged →
+              applyRuntimeSnapshot → Zustand → useIsPro() → every open
+              tab/reader flips to Pro on the same event-loop tick.
+                    │
+7. GATES      Export / preservation / bulk / filters / annotations read isPro
+              FROM THE CACHE on each launch (no network). A quiet background
+              re-validate (~weekly) catches refunds; it FAILS OPEN — a failed
+              re-check never revokes Pro, so an outage can't lock out a buyer.</code></pre>
+
+<h2>5.2 Where the entitlement lives — resolving the storage tension</h2>
+
+<p>The research surfaced two candidate patterns. <strong>Use the SW-owned one as authoritative</strong>; it's what makes payment "work flawlessly" across reset and account-switch and is reactive everywhere.</p>
+
+<h3>Authoritative — SW-owned write</h3>
+
+<p>The SW writes <span class="hl"><code>CS_ENTITLEMENT</code></span> (<code>"totem_entitlement"</code>) to <code>chrome.storage.local</code>, declared in <code>src/service-worker/storage-keys-sw.ts</code> → the existing <code>storage-invariants.test.ts</code> makes the SW the <em>only</em> writer for free. The SW is the right owner because it's the trust boundary and the thing that runs the validate call and caches its result.</p>
+
+<h3>Reset-surviving</h3>
+
+<p>Keep <code>CS_ENTITLEMENT</code> <strong>out of both reset lists</strong> in <code>src/lib/reset.ts</code> (mirror how auth headers are deliberately preserved). "Reset app" and account-switching must never revoke a paid unlock — it's a <strong>device-global, account-independent</strong> fact, not a per-account one. <strong>Never</strong> store it in IndexedDB (account-scoped and wiped) or the per-account sync orchestrator map.</p>
+
+<h3>Reactive — the ~6 wiring points</h3>
+
+<p>The <code>CS_RUNTIME_STATE_V2 → onChanged → applyRuntimeSnapshot</code> channel already exists and the propagation is <strong>automatic</strong>, but the snapshot is deserialized <strong>field-by-field</strong> (not spread), so <code>isPro</code> needs <strong>~6 explicit wiring points</strong> — minimal, but not "free":</p>
+
+<ol>
+<li>Add the field to <code>RuntimeSnapshotData</code> (<code>src/types/messages.ts</code>).</li>
+<li>Populate it in <code>buildRuntimeSnapshot</code> (<code>src/service-worker/auth.ts</code>).</li>
+<li>Read it in <code>normalizeAuthPayloadFromSnapshot</code>.</li>
+<li>Add it to the <code>AuthPayload</code> interface.</li>
+<li>Set it in <code>applyAuthPayload</code>.</li>
+<li>Expose <code>useIsPro()</code> in <code>src/stores/selectors.ts</code>.</li>
+</ol>
+
+<div class="callout">Keep <code>applyRuntimeSnapshot</code>'s <code>allowHydration:false</code> guard. An <code>isPro</code> flip must never trigger a sync or re-hydration.</div>
+
+<h3>Optional cross-device follow</h3>
+
+<p>Additionally mirror to a new <code>chrome.storage.sync</code> key (also SW-written, also off the reset list) so the unlock follows the user to a new machine without re-pasting. The local key stays authoritative.</p>
+
+<blockquote>The simpler "clone <code>useTheme.ts</code> into <code>usePro.ts</code> over <code>chrome.storage.sync</code>" pattern (from the UI report) is a fine MVP shortcut for the UI read, but the <em>writer</em> must be the SW after verification — a bare synced boolean is trivially forgeable and is wiped on reset. Use the snapshot/<code>useIsPro()</code> read path, SW-owned write.<span class="cite"> - UI report</span></blockquote>
+
+<h2>5.3 MV3 compliance — the load-bearing constraint</h2>
+
+<p>MV3 bans <strong>remotely-hosted code</strong>, not remote <strong>data</strong> — and license validation is squarely the allowed kind.</p>
+
+<ul>
+<li><span class="tag">VERIFIED</span> <strong>Data fetch</strong> (call the provider's validate endpoint → receive JSON <code>{ valid, plan, ... }</code>) → fetching <em>data</em>, explicitly allowed. This is the path we ship.</li>
+<li><span class="tag">VERIFIED</span> The validate result only <strong>toggles a local flag</strong>; it never returns code to run.</li>
+</ul>
+
+<p>What you must <strong>never</strong> do: fetch a JS "validator" or a script that <em>implements</em> a Pro feature and <code>eval</code>/import it. All Pro feature logic ships in the package and is merely <em>toggled</em> by <code>isPro</code>.</p>
+
+<div class="takeaway"><div class="takeaway-label">WHY ONE BUILD</div> This is why "one build, runtime-gated" is also the compliant design — every feature is in the bundle, and only the <code>isPro</code> flag decides whether it runs.</div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">07 · System Changes</div>
+  <h1>Internal System Changes — File by File</h1>
+<p class="lead">This is the heart of "how the whole system changes." Nothing here is large; the architecture already has the seams.</p>
+
+<h2>New files</h2>
+
+<p>Six net-new modules. Most clone an existing sibling so they inherit the project's handler-map and component conventions rather than inventing new ones.</p>
+
+<table class="striped">
+<thead>
+<tr><th>File</th><th>Purpose</th><th>Clone from</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><code>src/service-worker/entitlement.ts</code></td>
+<td>SW handlers: <code>ACTIVATE_LICENSE</code>, <code>VALIDATE_LICENSE</code>, <code>GET_ENTITLEMENT</code>. Calls the provider validate/activate API, caches the result to <code>CS_ENTITLEMENT</code>, re-persists snapshot; runs the background re-check with fail-open.</td>
+<td>sibling of <code>auth.ts</code>/<code>sync.ts</code> handler maps</td>
+</tr>
+<tr>
+<td><code>src/lib/license/validate.ts</code></td>
+<td>Thin <code>validateLicense(key, instanceId)</code> &rarr; entitlement | null by <code>fetch</code>-ing the provider's validate/activate endpoint and normalizing the JSON. Pure data, no embedded secret. Unit-testable (mock fetch).</td>
+<td>&mdash;</td>
+</tr>
+<tr>
+<td><code>src/hooks/usePro.ts</code> (or <code>useEntitlement.ts</code>)</td>
+<td>UI read of <code>isPro</code> (prefer reading the <code>useIsPro()</code> selector; <code>useTheme.ts</code> shape if you keep a direct storage read).</td>
+<td><code>src/hooks/useTheme.ts</code></td>
+</tr>
+<tr>
+<td><code>src/components/ProGate.tsx</code></td>
+<td><code>&lt;ProGate isPro onUpgrade&gt;</code> + <code>requirePro(isPro, action, onUpsell)</code>. Renders children when Pro; lock-badge + intercept when free.</td>
+<td>&mdash;</td>
+</tr>
+<tr>
+<td><code>src/components/UpgradeModal.tsx</code></td>
+<td>The single upsell surface (benefits list + <code>&lt;Button href={CHECKOUT_URL}&gt;</code> + paste-a-key field).</td>
+<td><code>src/components/OnboardingModal.tsx</code></td>
+</tr>
+<tr>
+<td><code>src/components/ProNudge.tsx</code></td>
+<td>One-time, dismissible, post-activation bottom banner. Suppressed when <code>isPro</code>.</td>
+<td><code>src/components/ReviewPrompt.tsx</code></td>
+</tr>
+</tbody>
+</table>
+
+<h2>Edited files (extension)</h2>
+
+<p>The seams already exist; each edit is small. Two carry traps worth flagging up front: the storage-key invariant test must be edited by hand, and the per-article egress handlers live in <code>BookmarkReader.tsx</code>, not where you'd expect.</p>
+
+<table class="striped">
+<thead>
+<tr><th>File</th><th>Change</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><code>src/service-worker/storage-keys-sw.ts</code></td>
+<td>Add <code>CS_ENTITLEMENT = "totem_entitlement"</code>. <strong>Also</strong> add the constant + its string to the hardcoded <code>SW_OWNED_KEY_NAMES</code>/<code>SW_OWNED_KEY_STRINGS</code> arrays in <code>src/lib/__tests__/storage-invariants.test.ts:71-87</code> &mdash; declaring the key does <strong>not</strong> auto-enroll it in the single-writer enforcement.</td>
+</tr>
+<tr>
+<td><code>src/types/messages.ts</code></td>
+<td>Add <code>isPro</code>/<code>entitlement</code> to <code>RuntimeSnapshotData</code>; add <code>ACTIVATE_LICENSE</code>/<code>VALIDATE_LICENSE</code>/<code>GET_ENTITLEMENT</code> to the <code>MessageRequest</code> union.</td>
+</tr>
+<tr>
+<td><code>src/service-worker/auth.ts</code></td>
+<td><code>buildRuntimeSnapshot</code> reads <code>CS_ENTITLEMENT</code> &rarr; snapshot; <code>persistRuntimeStateV2</code> includes it with safe defaults.</td>
+</tr>
+<tr>
+<td><code>src/service-worker/index.ts</code></td>
+<td>Merge <code>entitlementHandlers</code>; add <code>onInstalled</code> grandfather stamp (<code>reason==="update"</code> &rarr; grandfathered Pro); optional <code>onMessageExternal</code> for site&rarr;extension one-click.</td>
+</tr>
+<tr>
+<td><code>src/stores/runtime-store.ts</code></td>
+<td>Add <code>isPro</code> to <code>RuntimeState</code> + <code>createInitialState</code>; set it in <code>applyAuthPayload</code>; read in <code>normalizeAuthPayloadFromSnapshot</code>.</td>
+</tr>
+<tr>
+<td><code>src/stores/selectors.ts</code></td>
+<td>Add <code>useIsPro()</code>.</td>
+</tr>
+<tr>
+<td><code>src/lib/storage-keys.ts</code></td>
+<td>(If using a sync mirror) add <code>SYNC_PRO</code> to <code>CHROME_SYNC_KEYS</code>.</td>
+</tr>
+<tr>
+<td><code>src/lib/reset.ts</code></td>
+<td>Keep <code>CS_ENTITLEMENT</code> (and <code>SYNC_PRO</code>) <strong>out</strong> of the reset key lists; add a comment next to the auth-preservation note.</td>
+</tr>
+<tr>
+<td><code>src/lib/growth-state.ts</code></td>
+<td>Add a <code>pro</code> namespace (<code>nudgePromptedAt</code>/<code>nudgeDismissedAt</code>) + <code>shouldShowProNudge()</code> predicate (set-once idiom).</td>
+</tr>
+<tr>
+<td><code>src/components/ExportModal.tsx</code></td>
+<td>Wrap <code>handleQuickExport</code> (<code>:60</code>) + <code>handleStartFullExport</code> (<code>:78</code>) in <code>requirePro</code>; pass <code>isPro</code> into <code>IdleView</code> for the free-allowance cap + lock styling.</td>
+</tr>
+<tr>
+<td><code>src/components/BookmarkReader.tsx:313-352</code> (handlers live here, <strong>not</strong> in <code>TweetContent.tsx</code>)</td>
+<td>Gate the <strong>four</strong> per-article egress handlers &mdash; copy-MD (<code>:313</code>), copy-for-agent (<code>:327</code>), download-MD (<code>:338</code>), print/PDF (<code>:352</code>) &mdash; all call <code>src/lib/export/article-download.ts</code> directly. Keeping the two clipboard copies free is a <em>teaser</em> but also a slow full-library leak; gate download+print at minimum.</td>
+</tr>
+<tr>
+<td><code>src/hooks/useBookmarkSearch.ts</code></td>
+<td>When the parsed AST contains operator nodes and <code>!isPro</code> &rarr; route to upsell (keep plain text free).</td>
+</tr>
+<tr>
+<td><code>src/components/reader/SelectionToolbar.tsx</code></td>
+<td>Gate <code>onAddNote</code> (and/or advanced highlight) for free users.</td>
+</tr>
+<tr>
+<td><code>src/components/SettingsModal.tsx</code></td>
+<td>New "Totem Pro" section above Storage/Export (<code>:374</code>): free &rarr; "Upgrade" (<code>accent-soft</code> Button); Pro &rarr; <code>Badge variant="accent"&gt;PRO&lt;/Badge&gt;</code> + "Manage license" + paste-key field.</td>
+</tr>
+<tr>
+<td><code>src/components/NewTabHome.tsx</code></td>
+<td>(Optional) small always-visible "Upgrade" entry beside the gear (<code>:1086</code>).</td>
+</tr>
+<tr>
+<td><code>src/App.tsx</code></td>
+<td>Call <code>usePro()</code> at <code>:410-411</code> (both route apps); add <code>upgradeOpen</code> to <code>NewTabRouteState</code>; render <code>&lt;UpgradeModal&gt;</code>/<code>&lt;ProNudge&gt;</code> beside <code>ExportModal</code>/<code>ImportModal</code> (<code>:708-732</code>); thread <code>isPro</code> down as a prop.</td>
+</tr>
+<tr>
+<td><code>src/lib/constants/growth.ts</code></td>
+<td>Add <code>PRICING_URL = https://usetotem.xyz/pricing?utm_source=extension&amp;utm_medium=upgrade&amp;utm_campaign=pro</code>.</td>
+</tr>
+</tbody>
+</table>
+
+<div class="takeaway"><div class="takeaway-label">EGRESS CORRECTION</div> The per-article export handlers are in <code>BookmarkReader.tsx:313-352</code>, not <code>TweetContent.tsx</code>. All four call <code>src/lib/export/article-download.ts</code> directly &mdash; gate download + print at minimum.</div>
+
+<h2>Deleted-tweet preservation &mdash; the one data-layer tweak</h2>
+
+<p>The hydration engine already classifies and caches deleted/protected tweets (<code>hydration-store.ts</code>, <code>detailsStatus:"unavailable"</code>, <code>unavailableReason:"deleted"</code>). To turn it into a <em>sellable preservation</em> feature, two small policy changes in <code>src/db/</code> + <code>src/api/parsers.ts</code>:</p>
+
+<ol>
+<li><strong>Preserve-on-tombstone:</strong> today the error path <em>throws before caching</em>, so the fix is an <strong>added</strong> cache-write on the unavailable branch (not merely a no-clobber guard): when a later <code>FETCH_TWEET_DETAIL</code> returns a tombstone, keep the previously-cached <code>focalTweet</code>/thread and stamp <code>detailsStatus:"unavailable"</code> rather than dropping the row or overwriting with null.</li>
+<li><strong>Exempt preserved rows</strong> from the <code>cleanupOldTweetDetails</code> retention sweep (which currently deletes by <code>fetchedAt</code> regardless of status) for Pro users.</li>
+</ol>
+
+<p>(Media is hot-linked from <code>*.twimg.com</code>, not blobbed &mdash; text/thread/metadata preservation needs <strong>no new fetch</strong>; true media-byte preservation would be a later, separate feature.)</p>
+
+<h2>Manifest &amp; build changes</h2>
+
+<h3><code>public/manifest.json</code></h3>
+
+<ul>
+<li><strong>Add the provider API origin as a host permission.</strong> Prefer <strong><code>optional_host_permissions</code></strong> (request at upgrade time via <code>chrome.permissions.request</code>, so free users never grant it); fall back to <code>host_permissions</code> if the activation flow needs it unconditionally. If you tighten CSP, add an explicit <code>connect-src 'self' https://x.com &lt;provider-api&gt;</code>. Keep <code>script-src 'self'</code> untouched (never add a payment SDK <code>&lt;script&gt;</code>).</li>
+<li><strong>One-click activation (optional):</strong> for site&rarr;extension hand-off add <code>externally_connectable: { "matches": ["https://usetotem.xyz/*"] }</code> + an <code>onMessageExternal</code> handler &mdash; <strong>both are greenfield</strong> (neither exists today). The site only <em>hands over the key</em>; the SW still <strong>validates it with the provider</strong> before granting Pro, so entitlement is never granted on the site's say-so alone. The paste-a-key fallback is always shipped.</li>
+<li><strong>Reword <code>description</code> (required):</strong> the readiness script pins the description string <strong>exactly</strong>, including the literal "no server" phrasing. Validating online makes a network call, so reword to something true under this design &mdash; e.g. "no Totem account; your bookmarks stay on your device" &mdash; and change it in <strong>three places at once</strong>: the manifest, <code>expected.description</code> in <code>verify-cws-featured-readiness.mjs</code>, and the dashboard listing/privacy packet. Budget for this; it is not optional under online validation.</li>
+</ul>
+
+<h3>Build (<code>vite.config.ts</code>, <code>src/vite-env.d.ts</code>)</h3>
+
+<p>The provider's <strong>validate endpoint URL</strong> (and any publishable product/store id) can be injected via the existing <code>define</code> mechanism (same pattern as <code>__TOTEM_APP_VERSION__</code>) or committed as a constant &mdash; these are public, <strong>no secret ever enters <code>dist/</code></strong> (the MoR's secret API key stays server-side and is never needed for a public validate call).</p>
+
+<div class="callout"><span class="tag">NO NEW CRYPTO DEP</span> Because there is no on-device signature verification, <code>@noble/ed25519</code> is <strong>not</strong> added &mdash; and the <code>@noble/hashes</code> 2.x SHA-512 wiring trap that the earlier offline design hit simply does not apply.</div>
+
+<h3>Release pipeline</h3>
+
+<ul>
+<li><strong><code>scripts/verify-cws-featured-readiness.mjs</code></strong> hard-pins the exact permissions, host_permissions (must be exactly <code>["https://x.com/*"]</code>), name, description, and screenshot set &mdash; <strong>loosen it</strong> for any new host/permission/description or <code>cws:featured:preflight</code> (and the release flow) will fail. It does <strong>not</strong> check <code>content_security_policy</code> or <code>externally_connectable</code>, so those pass silently. This is the single most important repo-mechanical gotcha.</li>
+<li>Update <code>PUBLISH.md</code> + the dashboard packet with permission justifications + the privacy disclosure.</li>
+<li>(Optional, wise) add a grep guard in <code>scripts/package-extension.mjs</code> asserting no private-key-looking strings leaked into <code>dist/</code> before zipping.</li>
+</ul>
+
+<h2>Site changes (<code>apps/site/</code>, stays 100% static)</h2>
+
+<p>The Astro site is <code>output:"static"</code> with no adapter/functions &mdash; it <strong>can't</strong> host a license endpoint, and it <strong>shouldn't</strong> (that would be a Totem server). It only needs static pages + client <code>&lt;script&gt;</code>:</p>
+
+<table class="striped">
+<thead>
+<tr><th>New page</th><th>Path</th><th>Template</th><th>Notes</th></tr>
+</thead>
+<tbody>
+<tr>
+<td>Pricing</td>
+<td><code>src/pages/pricing.astro</code></td>
+<td><code>export-format/v1.astro</code> or a <code>SiteApp.tsx</code> island</td>
+<td>Indexable. "Buy" links out to MoR hosted checkout. Add <code>"pricing"</code> to <code>SitePageKey</code>.</td>
+</tr>
+<tr>
+<td>Success / license delivery</td>
+<td><code>src/pages/upgrade/success.astro</code></td>
+<td><code>uninstall-feedback.astro</code></td>
+<td><code>noindex</code>; MoR <code>success_url</code> lands here; client <code>&lt;script&gt;</code> reads <code>location.search</code>, shows key + copy + "activate in Totem" deep-link. Exclude from sitemap.</td>
+</tr>
+<tr>
+<td>Manage license</td>
+<td><code>src/pages/manage-license.astro</code></td>
+<td><code>uninstall-feedback.astro</code></td>
+<td>Paste-key / check-status; links to MoR customer portal. No backend.</td>
+</tr>
+</tbody>
+</table>
+
+<p>Also: centralize new URLs in <code>src/react/site-content.ts</code> <code>SITE_LINKS</code>; the build-time UTM/<code>ref</code> decoration in <code>rehype-blog-links.mjs</code> auto-tags blog&rarr;pricing and blog&rarr;checkout links (keep it). Update <code>index.astro</code>'s <code>SoftwareApplication</code> JSON-LD <code>offers</code> (currently <code>price:"0"</code>, <code>isAccessibleForFree:true</code>) to reflect free + $19 tiers.</p>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">08 · Compliance</div>
+  <h1>Chrome Web Store Compliance</h1>
+<p class="lead">Native Chrome Web Store payments died <strong>Feb 1 2021</strong> — an external processor is now mandatory, and every item below exists to keep the listing compliant once Pro ships.</p>
+
+<h2>The checklist</h2>
+
+<ul>
+<li>Checkout happens <strong>off-extension</strong> (web/MoR-hosted), not a fake-native in-extension purchase.</li>
+<li>License validation returns <strong>JSON/signed data only</strong> — no fetched JS/WASM, no <code>eval</code>. Declare <strong>remote code = No</strong> (true).</li>
+<li>All Pro feature <em>logic</em> ships in the package; the license result only flips local flags ("full functionality discernible from submitted code").</li>
+<li>Pro features stay within the <strong>single purpose</strong> (read/search/export your X bookmarks). Don't add an unrelated second product.</li>
+<li><strong>Privacy practices tab:</strong> update data-collected to include <strong>PII (email) + auth info (license key)</strong>; per-permission justifications; the 3 Limited-Use certifications.</li>
+<li><strong>Privacy policy</strong> on <code>usetotem.xyz</code> discloses: the <strong>license key + email + a device id</strong> are sent to <code>&lt;MoR&gt;</code> for validation at activation and on an occasional background re-check; not sold, not used for ads; <strong>bookmark content never transmitted</strong>. Keep the "no analytics/telemetry, no third-party tracking" claims true alongside this one scoped license call.</li>
+<li>Store listing states <strong>free core + optional one-time Pro unlock</strong> and lists Pro features (Deceptive-Installation-Tactics rule: don't advertise a headline feature then reveal at point-of-use that it's paid without prior disclosure).</li>
+<li><span class="tag">ADVERSARIAL-REVIEW FLAG</span> <strong>Featured screenshots disclose Pro.</strong> The readiness script pins the screenshot set, and <code>04-export-twitter-bookmarks-markdown-csv-notion.png</code> literally advertises export — gating export while a featured screenshot sells it is the exact "advertise-then-paywall" pattern §266 prohibits. Mitigation: the <strong>free export allowance</strong> (export your first ~25) keeps the screenshot <em>truthful</em> (export genuinely works free), and the listing copy must label unlimited export / preservation / bulk as Pro. Re-shoot or annotate the screenshot if it implies unlimited export is free.</li>
+<li>When activation arrives via <code>onMessageExternal</code> from the site, the SW still <strong>validates the key with the provider</strong> before granting Pro — never grant entitlement on the page's message alone (a reviewer reading site&rarr;extension entitlement-granting as remote control is a rejection vector).</li>
+<li>New host permission (if any) scoped narrowly (never <code>&lt;all_urls&gt;</code>), justified in the dashboard, ideally <code>optional_host_permissions</code>.</li>
+</ul>
+
+<div class="callout">Native CWS payments died <strong>Feb 1 2021</strong> — external processor is mandatory.</div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">09 · Paywall UX</div>
+  <h1>Paywall UX — Moments, Copy, Anti-Patterns</h1>
+<p class="lead">The paywall is the conversion surface, but for this audience it is also a trust surface. Frame Pro as <span class="hl">funding the work, not ransoming a feature</span> — and every moment, every line of copy, and every thing you refuse to do follows from that frame.</p>
+
+<h2>The reference model — Obsidian Catalyst</h2>
+
+<p>The model to copy is <strong>Obsidian Catalyst</strong>: "your data stays local, the app is free, Pro is a one-time unlock that funds the work." Pro is framed partly as <em>support</em>, not feature ransom. For the subscription-fatigued, anti-DRM, pro-ownership audience (r/nosurf, r/selfhosted, HN, PKM), the absence of coercion is itself the sell.</p>
+
+<div class="callout">Frame Pro partly as support, not feature ransom. The pitch is "fund the export, search, and deleted-tweet preservation work" — not "pay to unlock what we are holding hostage."</div>
+
+<h2>Upgrade moments — ranked by intent</h2>
+
+<p>Each moment fires <strong>once</strong>, <strong>contextually</strong>, is <strong>dismissible</strong>, and only after the user has felt the value. Ordered from highest to lowest intent:</p>
+
+<ol>
+<li><strong>At export, after a free preview</strong> (primary). Let free users export or preview the first ~25 of <em>their own</em> bookmarks, then: <em>"Export all 3,412 &rarr; Unlock Pro ($14 founders / $19)."</em> Highest intent.</li>
+<li><strong>When a deleted tweet is opened</strong> (secondary, emotional): <em>"This tweet was deleted on X. Totem kept your copy. Pro preserves every deleted bookmark automatically."</em></li>
+<li><strong>On a bulk op</strong> — they have already invested effort selecting.</li>
+<li><strong>On advanced filter use</strong> — show filters lock-badged.</li>
+<li><strong>On first note / annotation.</strong></li>
+</ol>
+
+<p>Plus one quiet, persistent <strong>"Upgrade / Support Totem"</strong> entry in Settings. <span class="hl">Never auto-popup on new-tab load; never re-prompt a dismissed context.</span></p>
+
+<h2>Copy that converts here</h2>
+
+<ul>
+<li><strong>Headline the model, not the price:</strong> <em>"Totem Pro — one-time unlock. No subscription. Ever."</em></li>
+<li><strong>Pre-empt "no server, why pay?":</strong> <em>"You're paying for the work, not infrastructure. Totem stays free and open source; Pro funds development. Your data never leaves your machine."</em></li>
+<li><strong>Reassure on the check:</strong> <em>"Verified by a one-time online license check (email + key only). Your bookmarks never leave your device."</em></li>
+<li><strong>Ownership:</strong> <em>"Buy once, use on up to 5 of your browsers."</em> (or "all your browsers" if you ship an unlimited device limit).</li>
+</ul>
+
+<h2>Anti-patterns that nuke goodwill</h2>
+
+<p>These are the <span class="tag">DON'T</span> list — each one specifically corrodes trust with this audience:</p>
+
+<ul>
+<li>Nagging after dismissal.</li>
+<li>Clawing back currently-free features (&rarr; grandfather instead).</li>
+<li>Card-required "free trials."</li>
+<li>Fake scarcity / countdown.</li>
+<li>Surprise paywall with no prior disclosure.</li>
+<li>Any telemetry creep.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">DATA</div> Upgrade-prompt copy that lists the value proposition converts <strong>~4x</strong> a bare alert — 2% &rarr; 8% in real first-party data.</div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">10 · Rollout</div>
+  <h1>Phased Rollout &amp; Open Decisions</h1>
+<p class="lead">The build order is deliberately sequenced so the load-bearing, low-visibility work lands before anything user-facing, and the minimum sellable release ships as early as possible. What follows is the phased rollout, then the genuine forks where your preference decides the outcome.</p>
+
+<h2>Phased rollout — do these in order</h2>
+
+<h3>Phase 0 — Decisions &amp; accounts (no code)</h3>
+<p>Pick the merchant-of-record (Lemon Squeezy vs Polar). Create the $19 product plus the $14 founders coupon, <strong>enable license keys</strong>, and set the <strong>activation/device limit</strong> (~5). Note the provider's validate endpoint URL. Write the privacy-policy update and the "honest stance" copy.</p>
+
+<h3>Phase 1 — The entitlement spine (ship dark)</h3>
+<p><code>CS_ENTITLEMENT</code> + <code>entitlement.ts</code> + <code>validateLicense</code> + the snapshot field + <code>useIsPro()</code> + the grandfather stamp on <code>onInstalled</code>. No gates yet, no UI. Test that <code>isPro</code> propagates reactively and survives reset/account-switch. This is the <span class="hl">load-bearing, low-visibility work</span>.</p>
+
+<h3>Phase 2 — The gate + the one feature</h3>
+<p><code>&lt;ProGate&gt;</code> / <code>requirePro</code> / <code>UpgradeModal</code> / <code>usePro</code>. Gate <strong>export</strong> only — the cleanest, highest-intent surface — with the free-allowance and grandfathering in place. Paste-a-key activation in Settings. Ship the site <code>pricing</code> / <code>success</code> / <code>manage-license</code> pages plus the MoR checkout.</p>
+<div class="takeaway"><div class="takeaway-label">MILESTONE</div> This is the minimum sellable release.</div>
+
+<h3>Phase 3 — The emotional gate</h3>
+<p>Wire deleted-tweet preservation (the two data-layer tweaks) and its "kept your copy" moment. Add the per-article export, advanced-filter, and annotation gates — all already-built features, behind the same wrapper.</p>
+
+<h3>Phase 4 — Net-new value</h3>
+<p>Build <strong>bulk operations</strong> — the only net-new feature — a clearly-new Pro capability nobody can claim was taken away. Then the <code>ProNudge</code>, the time-boxed founders-price banner, and analytics on the success page.</p>
+
+<h3>Phase 5 — Optional hardening</h3>
+<p>Tune the device limit and the background re-check cadence; add a "deactivate this device" affordance inside the extension (mirrors the provider portal) for the reinstall case; surface refund/chargeback revocation gracefully — the provider already revokes, so keep the re-check fail-open so a <em>network</em> failure never looks like a revocation.</p>
+
+<h2>Open decisions for you</h2>
+<p>These are genuine forks where your preference matters — everything else above is a recommendation I'd ship as-is.</p>
+
+<ol>
+<li><strong>MoR:</strong> Lemon Squeezy (most mature license API, Stripe-transition watch) vs Polar (cheaper, OSS-positioned, younger). Both are fine; pick on whether maturity or cost/ethos weighs more.</li>
+<li><strong>Device limit:</strong> the exact activation cap — <strong>~5 with self-serve deactivate</strong> (recommended: kills mass key-sharing, never bites a real user) vs <strong>unlimited</strong> ("buy once, use on all your browsers," zero friction, accepts key-sharing). And whether to expose deactivate inside the extension or only via the provider's portal.</li>
+<li><strong>Free export allowance:</strong> the exact N (25 is the research default) and whether per-article <em>Copy-to-clipboard</em> stays free as a teaser (recommended yes).</li>
+<li><strong>Annotations / advanced-search free vs Pro:</strong> the GTM doc gates them; the retroactive-paywall risk argues for keeping the <em>currently-shipping</em> versions free for everyone and gating only <em>export of</em> annotations + <em>new</em> filter operators. Worth a deliberate call.</li>
+</ol>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">11 · Red-Team</div>
+  <h1>Adversarial Review — What the Red-Team Caught</h1>
+<p class="lead">
+  Before this plan was finalized, an independent adversarial reviewer re-checked every load-bearing code claim against the live repository and red-teamed the strategy. It confirmed most of the architecture and forced <span class="hl">three concrete corrections</span> — all already folded into the chapters above. This chapter records what it found, so the reasoning is auditable.
+</p>
+
+<h2>Confirmed against the live code</h2>
+<ul>
+  <li><strong>Entitlement storage</strong> — <code>src/service-worker/storage-keys-sw.ts</code> exists and the single-writer invariant is enforced by <code>src/lib/__tests__/storage-invariants.test.ts</code>. (Caveat: the test arrays are hardcoded, so a new key must also be added there to be enforced.)</li>
+  <li><strong>Reactive channel</strong> — the <code>CS_RUNTIME_STATE_V2 → onChanged → applyRuntimeSnapshot</code> path is real; an added snapshot field propagates to every tab.</li>
+  <li><strong>Reset survival</strong> — <code>src/lib/reset.ts</code> has explicit key lists and already preserves auth keys deliberately; <code>CS_ENTITLEMENT</code> can be kept out of them.</li>
+  <li><strong>Deleted-tweet preservation</strong> — <code>TweetDetailCache</code> in <code>src/types/index.ts</code> already carries <code>detailsStatus</code>/<code>unavailableReason</code>; the hydration store already classifies deleted vs protected. The "already built" claim holds.</li>
+  <li><strong>Build pins &amp; static site</strong> — <code>scripts/verify-cws-featured-readiness.mjs</code> really hard-pins permissions, hosts, description, and screenshots; <code>apps/site/astro.config.mjs</code> is <code>output:"static"</code> with no adapter, so it cannot host a license endpoint.</li>
+</ul>
+
+<h2>Corrected before shipping</h2>
+
+<h3>1 · Export is not a single gate</h3>
+<p>The bulk-ZIP path concentrates at <code>ExportModal.tsx:64</code>, but <code>src/components/BookmarkReader.tsx:313-352</code> has four independent per-article egress handlers (copy-Markdown, copy-for-agent, download <code>.md</code>, print/PDF) that bypass <code>ExportModal</code> entirely. The "copy stays free as a teaser" idea is therefore a slow full-library leak — a knowing trade-off, not an oversight. All four handlers must be gated; the file is <code>BookmarkReader.tsx</code>, not <code>TweetContent.tsx</code>.</p>
+
+<h3>2 · "Fully offline, nothing can shut down" was an overclaim</h3>
+<p>The original plan leaned on <strong>offline Ed25519-signed keys</strong> so the extension would make zero license network calls. The review flagged two problems: the brand line "nothing can shut down" only ever held <em>post-activation</em> (checkout and issuance still need the provider online), and — more decisively — a fully-offline key <span class="hl">cannot be counted</span>, so there is no way to manage multi-device activation. The design was therefore changed to <strong>online-validate-then-cache</strong>: validate once at activation, cache the result, read locally, and re-check quietly in the background with <strong>fail-open</strong>. This is simpler (no signer, no key-management vendor, no <code>@noble/ed25519</code> dependency and its SHA-512 wiring trap), it enables the device limit, and it lets the provider revoke a refunded key — at the cost of one host permission and a reworded store description.</p>
+
+<h3>3 · Grandfathering by install-reason misfires</h3>
+<p><code>chrome.runtime.onInstalled</code> with <code>reason === "install"</code> fires for uninstall→reinstall and new-machine cases, so reason alone strips grandfathered status from exactly the engaged users it is meant to protect. Add a secondary heuristic that also runs on install: treat a non-empty bookmarks IndexedDB store (or a pre-Pro settings key) as proof of an existing user.</p>
+
+<h2>Top strategy risks the plan now weights explicitly</h2>
+<table class="compact">
+  <thead><tr><th>Risk</th><th>Mitigation in the plan</th></tr></thead>
+  <tbody>
+    <tr><td>"Nothing can shut down" / fully-offline overclaim</td><td>Design changed to online-validate-then-cache with fail-open; brand promise reworded to "no Totem server; bookmarks stay on-device; verified by a quick online check, then cached" (Ch. 4–5).</td></tr>
+    <tr><td>One-click activation puts the site in the trust chain</td><td><code>onMessageExternal</code> must still validate the key with the provider; paste-a-key is the zero-trust-chain fallback (Ch. 7–8).</td></tr>
+    <tr><td>Gating currently-free search/annotations</td><td>Flagged as an open decision; lean toward keeping today's versions free and gating only new operators + annotation export (Ch. 10).</td></tr>
+    <tr><td>Featured export screenshot vs paywall</td><td>The free export allowance keeps the pinned screenshot truthful; listing copy must label unlimited export as Pro (Ch. 8).</td></tr>
+  </tbody>
+</table>
+
+<div class="takeaway">
+  <div class="takeaway-label">Bottom line</div>
+  The architecture survived scrutiny; the three corrections are mechanical, not structural. The plan ships with them already incorporated.
+</div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix · Codebase Research</div>
+  <h1>Appendix A · Data, Sync &amp; Entitlement Storage</h1>
+<p class="lead">A codebase deep-dive into the IndexedDB schema, the end-to-end sync/interception flow, the durable-state writer-ownership model, the reactive SW&rarr;UI snapshot push, and the exact integration points where a new <code>isPro</code>/license/entitlement fact would live. All file paths are absolute; line numbers cite the code as read.</p>
+
+<h2>Orientation for the entitlement designer</h2>
+
+<p>Two distinct durable substrates exist: account-scoped <strong>IndexedDB</strong> (bookmark/detail/progress/highlight data, written by the runtime) and <strong>chrome.storage</strong> (auth + sync orchestrator + runtime snapshot), governed by a hard "single writer per fact" rule split across two key files.</p>
+
+<p>The architecture already ships a purpose-built <span class="hl">reactive SW&rarr;UI broadcast channel</span>: the service worker writes a <code>RuntimeSnapshot</code> to <code>chrome.storage.local[CS_RUNTIME_STATE_V2]</code>, and every open page picks it up via <code>chrome.storage.onChanged</code> (<code>src/runtime/RuntimeProvider.tsx:96-100</code>). An <code>isPro</code> field can ride this exact channel to be reactive everywhere (SW plus every new-tab/reader page) with zero new plumbing.</p>
+
+<div class="callout">A license/entitlement is a device-global, account-independent fact. It does <strong>not</strong> belong in IndexedDB (wiped on reset, account-scoped) and does <strong>not</strong> belong in the SW-owned sync orchestrator state (account-scoped, wiped on reset). The cleanest home is a new dedicated <code>chrome.storage</code> key with a single declared writer.</div>
+
+<h2>IndexedDB schema</h2>
+
+<h3>Databases (account-scoped)</h3>
+
+<p>File: <code>src/db/index.ts</code>; names in <code>src/lib/storage-keys.ts:1-3</code> and <code>src/lib/constants/db.ts</code>.</p>
+
+<ul>
+<li>Default DB: <code>totem</code> (<code>IDB_DATABASE_NAME</code> / <code>DB_NAME</code>).</li>
+<li>Account DB: <code>totem_acct_&lt;accountId&gt;</code> (<code>IDB_ACCOUNT_DATABASE_PREFIX</code> = <code>"totem_acct_"</code>, joined in <code>getDbNameForAccount</code>, <code>src/db/index.ts:119-122</code>).</li>
+<li>Legacy DB: <code>xbt</code> (<code>LEGACY_IDB_DATABASE_NAME</code>), migrated forward on first open (<code>migrateLegacyDatabaseIfNeeded</code>, <code>src/db/index.ts:385-425</code>).</li>
+<li><code>DB_VERSION = 9</code> (<code>src/lib/constants/db.ts:5</code>). The whole schema is created/upgraded in one <code>upgrade()</code> callback (<code>src/db/index.ts:135-277</code>).</li>
+<li>Account selection: <code>setActiveAccountId(accountId)</code> (<code>src/db/index.ts:124-133</code>) flips a module-level <code>activeDbName</code>; <strong>every</strong> read/write goes through <code>getDb()</code> which opens whatever <code>activeDbName</code> currently points at (<code>src/db/index.ts:443-463</code>). The runtime must call <code>setActiveAccountId</code> before any read (enforced convention; see <code>hydrateCurrentAccount</code>, <code>src/stores/runtime-store.ts:549-554</code>).</li>
+</ul>
+
+<h3>Object stores (9 total)</h3>
+
+<p>Schema interface <code>XBookmarksDbSchema</code>, <code>src/db/index.ts:31-101</code>:</p>
+
+<table class="compact">
+<thead><tr><th>Store</th><th>keyPath</th><th>Indexes</th><th>Value type</th></tr></thead>
+<tbody>
+<tr><td><code>bookmarks</code></td><td><code>id</code></td><td><code>tweetId</code>, <code>sortIndex</code>, <code>createdAt</code>, <code>screenName</code> (= <code>author.screenName</code>)</td><td><code>Bookmark</code></td></tr>
+<tr><td><code>tweet_details</code></td><td><code>tweetId</code></td><td><code>fetchedAt</code></td><td><code>TweetDetailCache</code></td></tr>
+<tr><td><code>reading_progress</code></td><td><code>tweetId</code></td><td><code>lastReadAt</code></td><td><code>ReadingProgress</code></td></tr>
+<tr><td><code>highlights</code></td><td><code>id</code></td><td><code>tweetId</code>, <code>createdAt</code></td><td><code>Highlight</code></td></tr>
+<tr><td><code>saved_searches</code></td><td><code>id</code></td><td><code>sortOrder</code>, <code>createdAt</code></td><td><code>SavedSearch</code></td></tr>
+<tr><td><code>search_index</code></td><td><code>id</code></td><td>&mdash;</td><td><code>{ id, json, savedAt }</code> (serialized MiniSearch index, key <code>"minisearch-v1"</code>)</td></tr>
+<tr><td><code>today_queue_snapshots</code></td><td><code>key</code></td><td><code>localDate</code>, <code>generatedAt</code></td><td><code>TodayQueueSnapshot</code></td></tr>
+<tr><td><code>bookmark_queue_metadata</code></td><td><code>tweetId</code></td><td><code>intent</code>, <code>updatedAt</code></td><td><code>BookmarkQueueMetadata</code> (intent + snooze)</td></tr>
+<tr><td><code>today_queue_exposures</code></td><td><code>id</code></td><td><code>tweetId</code>, <code>localDate</code>, <code>createdAt</code></td><td><code>TodayQueueExposure</code></td></tr>
+</tbody>
+</table>
+
+<p>Note: ARCHITECTURE.md &sect;11 lists only the first four; the actual code has 9. The extra five (<code>saved_searches</code>, <code>search_index</code>, the today-queue trio) are real and relevant to several Pro features (advanced search filters &rarr; <code>saved_searches</code>/<code>search_index</code>; queue intent &rarr; <code>bookmark_queue_metadata</code>).</p>
+
+<h3>What a saved-post ("bookmark") record contains</h3>
+
+<p><code>Bookmark</code> interface, <code>src/types/index.ts:151-174</code>. This is rich and is the single biggest asset for the <span class="hl">deleted-tweet preservation Pro feature</span> &mdash; the full text and metadata are already persisted locally:</p>
+
+<ul>
+<li>Identity/order: <code>id</code>, <code>tweetId</code>, <code>sortIndex</code> (X's opaque cursor string), <code>createdAt</code> (ms epoch), <code>bookmarked</code> (boolean &mdash; stays <code>true</code> until unbookmarked; never deleted on unbookmark, just flipped).</li>
+<li>Content: <code>text</code> (full tweet text), <code>tweetKind</code> (<code>tweet|reply|quote|repost|thread|article</code>), <code>tweetDisplayType</code>, <code>inReplyToTweetId</code>, <code>inReplyToScreenName</code>, <code>isThread</code>.</li>
+<li><strong>Author</strong> (<code>Author</code>, <code>src/types/index.ts:44-56</code>): <code>name</code>, <code>screenName</code>, <code>profileImageUrl</code>, <code>verified</code>, optional <code>bio</code>, <code>followersCount</code>, <code>followingCount</code>, <code>website</code>, <code>createdAt</code>, <code>bannerUrl</code>, <code>affiliate</code>.</li>
+<li><strong>Metrics</strong> (<code>Metrics</code>, lines 58-64): <code>likes</code>, <code>retweets</code>, <code>replies</code>, <code>views</code>, <code>bookmarks</code>.</li>
+<li><strong>Media</strong> (<code>Media[]</code>, lines 66-73): <code>type</code> (<code>photo|video|animated_gif</code>), <code>url</code> (image), <code>videoUrl</code>, <code>width</code>, <code>height</code>, <code>altText</code>. URLs point at <code>*.twimg.com</code> (CSP <code>img-src</code>/<code>media-src</code> in <code>public/manifest.json</code> allow only twimg + self &mdash; so media is hot-linked, not blobbed locally; see Sync section).</li>
+<li><strong>URLs / cards</strong> (<code>TweetUrl[]</code>, lines 84-89): <code>url</code>, <code>displayUrl</code>, <code>expandedUrl</code>, optional <code>card</code> (<code>LinkCard</code>: title/description/imageUrl/domain/cardType).</li>
+<li><strong>Quote / repost / article</strong>: <code>quotedTweet</code> (<code>QuotedTweet</code>), <code>retweetedTweet</code>, <code>article</code> (<code>ArticleContent</code>: full <code>plainText</code>, <code>title</code>, <code>coverImageUrl</code>, <code>contentBlocks</code>, <code>entityMap</code> &mdash; i.e. the entire long-form X Article body).</li>
+<li>Convenience flags: <code>hasImage</code>, <code>hasVideo</code>, <code>hasLink</code>.</li>
+</ul>
+
+<h3>Detail cache &mdash; the reader payload (most important for "deleted-tweet preservation")</h3>
+
+<p><code>TweetDetailCache</code>, <code>src/types/index.ts:176-183</code>:</p>
+
+<pre><code>interface TweetDetailCache {
+  tweetId: string;
+  fetchedAt: number;
+  focalTweet: Bookmark | null;
+  thread: ThreadTweet[];              // thread-aware capture already exists
+  detailsStatus?: "ok" | "unavailable";
+  unavailableReason?: "deleted" | "protected" | "parse_failed" | "unknown";
+}</code></pre>
+
+<ul>
+<li><code>thread: ThreadTweet[]</code> (<code>src/types/index.ts:134-149</code>) is the <strong>already-captured thread structure</strong> &mdash; each thread tweet carries its own author/media/urls/article/quoted/retweeted + <code>inReplyToTweetId</code>. So "thread-aware capture" as a Pro feature is, at the data layer, <strong>already done</strong>; it is fetched and cached whenever a tweet is opened in the reader or warmed by the prefetch controller.</li>
+<li><code>detailsStatus</code> / <code>unavailableReason</code> fields <strong>exist in the type</strong> but the parser (<code>parseTweetDetailPayload</code>, <code>src/api/parsers.ts:1231-1265</code>) does <strong>not currently set them</strong> &mdash; it returns <code>{ focalTweet, thread }</code> only. <code>unwrapTweet</code> returns <code>null</code> for <code>TweetTombstone</code>/<code>TweetUnavailable</code> (<code>src/api/parsers.ts:111-120</code>) but the surrounding code doesn't yet stamp <code>unavailableReason: "deleted"</code>.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">SMALLEST PRO HOOK</div> When a future <code>FETCH_TWEET_DETAIL</code> returns a tombstone, <strong>keep the previously-cached <code>focalTweet</code></strong> instead of overwriting, and set <code>detailsStatus: "unavailable"</code>. The retention sweep already exists (<code>cleanupOldTweetDetails</code>, <code>src/db/index.ts:1206-1226</code>, default <code>DETAIL_CACHE_RETENTION_MS</code>) and would need to <em>exempt</em> Pro-preserved rows.</div>
+
+<h3>Other store value shapes</h3>
+
+<ul>
+<li><code>ReadingProgress</code> (<code>src/types/index.ts:193-205</code>): <code>tweetId</code>, <code>openedAt</code>, <code>lastReadAt</code>, <code>scrollY</code>, <code>scrollHeight</code>, <code>completed</code>, <code>reopenCount</code>.</li>
+<li><code>Highlight</code> (<code>src/types/index.ts:207-218</code>): <code>id</code>, <code>tweetId</code>, <code>sectionId</code>, <code>startOffset</code>, <code>endOffset</code>, <code>selectedText</code>, <code>note</code> (annotations Pro feature lives here), <code>color</code>, <code>createdAt</code>, <code>type</code> (<code>highlight|note</code>).</li>
+<li><code>SavedSearch</code> (<code>src/types/index.ts:227-233</code>): <code>id</code>, <code>name</code>, <code>query</code>, <code>createdAt</code>, <code>sortOrder</code>.</li>
+<li><code>BookmarkQueueMetadata</code> (lines 259-264): <code>tweetId</code>, <code>intent</code> (<code>unset|read_soon|reference|act</code>), <code>snoozedUntil</code>, <code>updatedAt</code>.</li>
+</ul>
+
+<h3>IDB is wiped on reset and is account-scoped</h3>
+
+<p><code>clearAllLocalData</code> / <code>clearTransientStores</code> / <code>deleteBookmarksByTweetIds</code> (<code>src/db/index.ts:537-632</code>) and the full <code>resetLocalData</code> (<code>src/lib/reset.ts:135-210</code>, deletes the default DB + every <code>totem_acct_*</code> DB). <strong>Conclusion: do not store the license here.</strong> A user who hits "Reset app" or switches accounts must not lose their lifetime unlock.</p>
+
+<h2>Sync flow end-to-end</h2>
+
+<h3>Two content scripts (manifest)</h3>
+
+<p><code>public/manifest.json</code> registers two content scripts on <code>https://x.com/*</code> at <code>document_start</code>:</p>
+
+<ol>
+<li><code>content/detect-user.js</code> (ISOLATED world) &mdash; source <code>src/content/detect-user.ts</code>. Reads the <code>twid</code> cookie &rarr; writes <code>totem_user_id</code> + <code>totem_account_context_id</code> to <code>chrome.storage.local</code> (<code>src/content/detect-user.ts:21-44</code>); relays MAIN-world <code>postMessage</code> bookmark-mutation + query-id messages to the SW (lines 56-85).</li>
+<li><code>content/mutation-hook.js</code> (<strong>MAIN world</strong>) &mdash; <code>public/content/mutation-hook.js</code>. This is hand-written JS (not built from TS). It monkey-patches <code>XMLHttpRequest.prototype.open/send</code> and <code>window.fetch</code> (lines 98-133) to detect <code>CreateBookmark</code>/<code>DeleteBookmark</code> calls and <code>postMessage</code>s <code>{operation, tweetId}</code> to the ISOLATED script. It also scrapes X's JS bundles for GraphQL <code>queryId</code>s (<code>discoverQueryIds</code>, lines 135-202) and posts <code>{type:"query_ids", ids}</code>.</li>
+</ol>
+
+<div class="callout"><strong>Key nuance:</strong> the MAIN-world hook only observes <em>mutations</em> (create/delete), not the bookmark/timeline GraphQL <em>responses</em>. The actual bookmark/detail data is fetched by the <strong>service worker itself</strong>, replaying captured auth headers. So "intercepting GraphQL responses" in this codebase means: SW captures <em>auth headers</em> from real browsing (webRequest), then the SW makes its own authenticated GraphQL fetches.</div>
+
+<h3>Auth-header capture (the real interception)</h3>
+
+<p><code>src/service-worker/index.ts:320-391</code>, <code>chrome.webRequest.onSendHeaders</code> on <code>https://x.com/i/api/graphql/*</code>:</p>
+
+<ul>
+<li>Captures <code>authorization</code>, <code>cookie</code>, <code>x-csrf-token</code>, <code>x-client-uuid</code>, <code>x-client-transaction-id</code>, <code>x-twitter-*</code> (<code>CAPTURED_HEADERS</code>, lines 45-55).</li>
+<li>Requires the full "auth trio" + a valid <code>twid</code> before arming <code>totem_auth_headers</code> (lines 351-372) &mdash; this prevents stale-JWT re-login after logout.</li>
+<li>Also harvests X's <code>features</code> query param into <code>totem_features</code> (lines 378-387), reused when the SW builds its own requests.</li>
+<li>Mutation capture: <code>onBeforeRequest</code> (deletes &rarr; immediate event) and <code>onCompleted</code> (creates &rarr; confirmed event) at <code>src/service-worker/index.ts:395-438</code>.</li>
+<li>Auth state also tracked from response status (401/403 &rarr; logged out) at lines 442-456, and from <code>twid</code> cookie removal at lines 463-467.</li>
+</ul>
+
+<h3>SW &rarr; GraphQL fetch &rarr; parse &rarr; persist</h3>
+
+<p>The SW is the API boundary. <code>src/service-worker/api-proxy.ts</code>:</p>
+
+<ul>
+<li><code>FETCH_BOOKMARKS</code> (<code>handleFetchBookmarks</code>, lines 153-222): <code>withQueryId("Bookmarks", &hellip;)</code> builds the URL, <code>buildHeaders(storage)</code> replays captured headers (lines 78-105), fetches <code>https://x.com/i/api/graphql/&lt;queryId&gt;/Bookmarks</code>, returns <code>{ data: json }</code>. On 401/403 it does one silent re-auth retry then <code>markAuthLoggedOut</code>.</li>
+<li><code>FETCH_TWEET_DETAIL</code> (<code>handleFetchTweetDetail</code>, lines 281-365): same pattern for <code>TweetDetail</code>. <strong>This is the call that returns the full thread + author + media + article</strong> that becomes <code>TweetDetailCache</code>.</li>
+<li><code>DELETE_BOOKMARK</code>, <code>FETCH_VIEWER_PROFILE</code> also here.</li>
+</ul>
+
+<p>Parsing happens <strong>runtime-side</strong>, not in the SW. The runtime RPC wrappers live in <code>src/api/core/</code> (<code>bookmarks.ts</code>, <code>posts.ts</code>). <code>fetchTweetDetail</code> (<code>src/api/core/posts.ts:66-90+</code>) sends <code>FETCH_TWEET_DETAIL</code>, then <code>parseTweetDetailPayload</code> (<code>src/api/parsers.ts:1231</code>) turns raw JSON into <code>TweetDetailContent</code>, and <strong>upserts it into IDB</strong> via <code>upsertTweetDetailCache</code> (<code>src/api/core/posts.ts:1</code> imports it). Bookmark pages are parsed by the bookmark parsers and persisted via <code>upsertBookmarks</code> in the sync loop.</p>
+
+<h3>The sync loop (runtime side)</h3>
+
+<p><code>src/stores/runtime-store.ts</code> <code>sync()</code> (lines 775-1031):</p>
+
+<ol>
+<li><code>reserveSyncRun({accountId, trigger, localCount})</code> &rarr; SW decides allow + mode.</li>
+<li>On allow: <code>reconcileBookmarks</code> (<code>src/lib/reconcile.ts</code>) walks pages via <code>fetchBookmarkPage</code>, <code>onPage</code> merges each page into in-memory <code>bookmarks</code> and calls <code>upsertBookmarks(deduped)</code> (lines 887-907).</li>
+<li>On <code>full</code> completion with <code>staleIds</code>, deletes locally-removed bookmarks.</li>
+<li><code>releaseActiveLease(status, errorCode)</code> &rarr; SW <code>COMPLETE_SYNC</code> stamps <code>lastFullSyncAt</code>/cache-summary keys.</li>
+</ol>
+
+<h3>Data that already flows through and is cacheable</h3>
+
+<p>Everything needed to preserve a deleted tweet is <strong>already in the local stores before the tweet is deleted upstream</strong>:</p>
+
+<ul>
+<li>The <code>bookmarks</code> store holds full text/author/media-URLs/article/quote for every saved post.</li>
+<li>The <code>tweet_details</code> store holds the full reader payload + thread once a post has been opened or prefetched (the prefetch controller warms a top-of-list pool &mdash; <code>src/stores/prefetch-controller.ts</code>).</li>
+<li>Media is referenced by <code>*.twimg.com</code> URL, <strong>not</strong> stored as blobs. True "preservation" against X deleting the media would require downloading bytes (a new capability); but text/metadata/thread preservation needs <strong>no new fetch</strong> &mdash; only a policy change: on a later detail fetch that returns a tombstone, <em>don't overwrite</em> the existing cache row, and stamp <code>detailsStatus:"unavailable"</code>/<code>unavailableReason:"deleted"</code> (the fields already exist).</li>
+</ul>
+
+<h2>State model: durable state + writer ownership</h2>
+
+<p>ARCHITECTURE &sect;11/&sect;16 Invariant #1 ("single writer per persisted fact") is enforced at test time (<code>src/lib/__tests__/storage-invariants.test.ts</code>). Three substrates follow.</p>
+
+<h3>chrome.storage.local &mdash; split by writer across two files</h3>
+
+<p><strong>Shared keys</strong> <code>src/lib/storage-keys.ts</code> (read by anyone, written by their owner):</p>
+<ul>
+<li>SW-written: <code>CS_AUTH_HEADERS</code> (<code>totem_auth_headers</code>), <code>CS_AUTH_STATE</code>, <code>CS_AUTH_TIME</code>, <code>CS_USER_ID</code>, <code>CS_ACCOUNT_CONTEXT_ID</code>, <code>CS_VIEWER_PROFILE</code>, <code>CS_BOOKMARK_EVENTS</code>, plus undeclared SW-only strings (<code>totem_graphql_catalog</code>, <code>totem_features</code>, <code>totem_auth_state_at/_reason</code>, <code>totem_auth_diagnostics</code>).</li>
+<li>Runtime-written: <code>CS_DB_CLEANUP_AT</code>, <code>CS_RUNTIME_AUDIT</code>, <code>CS_HYDRATION_SNAPSHOT</code>, <code>CS_GROWTH_STATE</code>.</li>
+<li>Either: <code>CS_BOOKMARK_EVENTS</code> (SW enqueues, runtime acks via <code>ACK_BOOKMARK_EVENTS</code>).</li>
+<li>Broadcast: <code>CS_RESET_EPOCH</code> (<code>reset.ts</code> writes; SW + every page drop IDB handles).</li>
+</ul>
+
+<p><strong>SW-exclusive keys</strong> <code>src/service-worker/storage-keys-sw.ts</code> (non-SW imports forbidden except <code>reset.ts</code> + <code>RuntimeProvider.tsx</code>):</p>
+<ul>
+<li><code>CS_SYNC_ORCHESTRATOR_STATE</code> (<code>totem_sync_orchestrator_state</code>) &mdash; leases, cooldowns, <strong><code>lastFullSyncAt</code></strong>, per-account map.</li>
+<li><code>CS_RUNTIME_STATE_V2</code> (<code>totem_runtime_state_v2</code>) &mdash; the full <code>RuntimeSnapshot</code>.</li>
+<li><code>CS_LAST_SYNC</code>, <code>CS_LAST_SOFT_SYNC</code>, <code>CS_SOFT_SYNC_NEEDED</code> &mdash; cache-summary timestamps.</li>
+</ul>
+
+<p>Enforcement: <code>ALLOWED_WRITERS = ["service-worker/"]</code> for SW-owned keys; <code>ALLOWED_IMPORTERS = ["service-worker/", "lib/reset.ts", "runtime/RuntimeProvider.tsx"]</code> for the SW key file (<code>src/lib/__tests__/storage-invariants.test.ts:98-149</code>).</p>
+
+<h3>chrome.storage.sync &mdash; cross-device, survives reinstall on the same Google profile</h3>
+
+<p><code>src/lib/storage-keys.ts:70-76</code>: <code>SYNC_SETTINGS</code> (<code>totem_settings</code>) and <code>SYNC_THEME</code> (<code>totem_theme</code>). Read/written by <code>useSettings</code> (<code>src/hooks/useSettings.ts:104-145</code>) and <code>useTheme</code>. This is the <strong>only substrate that survives a reinstall and propagates across the user's devices</strong>. Tradeoff for licensing: convenient for "unlock follows the user," but it is also the easiest for a user to read/edit, and a full reset wipes it (<code>reset.ts:204-205</code>, only on non-<code>keepUserContent</code>).</p>
+
+<h3>Zustand runtime store &mdash; ephemeral, never persisted</h3>
+
+<p><code>src/stores/runtime-store.ts</code>. Holds <code>authPhase</code>, <code>capability</code>, <code>bookmarks</code>, <code>detailedTweetIds</code>, <code>syncStatus</code>, generations, etc. (<code>RuntimeState</code>, lines 154-174). It is a <strong>mirror</strong> of SW-owned facts + IDB contents; it writes IDB and reads everything else. It would be the place an <code>isPro</code> value is <strong>exposed to React</strong>, but never the <strong>owner</strong> of the persisted bit.</p>
+
+<h3>localStorage &mdash; app-local UI prefs only</h3>
+
+<p><code>LOCAL_STORAGE_KEYS</code> (<code>src/lib/storage-keys.ts:16-28</code>): reading tab, sorts, wallpaper, pinned tweets, reader activity, recent searches, export-ready dismissal. Per-device, not synced, wiped on reset. Wrong home for a license (trivially editable, per-device, lost on reset).</p>
+
+<h3>Who should own a new <code>isPro</code> / license fact</h3>
+
+<p>Per "single writer per persisted fact," <code>isPro</code> needs exactly one writer. The recommendation:</p>
+
+<div class="takeaway"><div class="takeaway-label">RECOMMENDED OWNER</div> The <strong>service worker</strong>, writing a new dedicated key <code>CS_ENTITLEMENT</code> (<code>totem_entitlement</code>), declared in <code>src/service-worker/storage-keys-sw.ts</code> so the existing import-boundary test makes the SW the sole writer for free. The value is a small record: <code>{ isPro: boolean, plan: "lifetime"|"founders"|null, licenseKey?: string, source: "gumroad"|"manual"|&hellip;, verifiedAt: number, signature?: string }</code>.</div>
+
+<ul>
+<li><strong>Why the SW:</strong> it is the trust boundary, it already owns the snapshot, and (critically) license <em>verification</em> (a network call to the licensing vendor / a signature check) is naturally a SW responsibility &mdash; the SW already makes authenticated network calls and is the only context that should hold any secret-ish verification logic. Putting the writer in the SW also makes the entitlement <strong>account-independent and reset-surviving by policy</strong>: keep <code>CS_ENTITLEMENT</code> out of <code>CHROME_LOCAL_RESET_KEYS</code> in <code>src/lib/reset.ts</code> (mirror how auth headers are deliberately <em>preserved</em> across reset, <code>reset.ts:30-32</code> comment) so "Reset app" never revokes a paid unlock.</li>
+<li><strong>Physical location: <code>chrome.storage.local</code></strong> (device-local). If you want the unlock to follow the user across devices, <em>additionally</em> mirror a verification token into <code>chrome.storage.sync</code> under a new key &mdash; but treat <code>chrome.storage.local[CS_ENTITLEMENT]</code>, written by the SW after verification, as the authoritative readable fact.</li>
+<li><strong>Do NOT</strong> put it in IDB (account-scoped + wiped) or in the sync orchestrator account map (account-scoped + wiped). It is not a per-account fact.</li>
+</ul>
+
+<p>Because the SW already builds and persists <code>RuntimeSnapshot</code>, the entitlement should also be <strong>stamped into the snapshot</strong> (one new field) so it propagates reactively.</p>
+
+<h2>Reactive SW &rarr; UI snapshot push (can <code>isPro</code> ride it? &mdash; yes)</h2>
+
+<h3>How the push works today</h3>
+
+<p><code>RuntimeSnapshotData</code> (<code>src/types/messages.ts:174-182</code>) is the snapshot shape: <code>sessionState</code>, <code>authPhase</code>, <code>accountContextId</code>, <code>capability</code>, <code>syncPolicy</code>, <code>blockedReason</code>, <code>cacheSummary</code>.</p>
+
+<ul>
+<li>The SW <strong>builds</strong> it in <code>buildRuntimeSnapshot</code> (<code>src/service-worker/auth.ts:364-427</code>) and <strong>persists</strong> it via <code>persistRuntimeStateV2</code> (<code>src/service-worker/auth.ts:429-471</code>) &rarr; writes <code>chrome.storage.local[CS_RUNTIME_STATE_V2]</code>. This persist is called after <strong>every</strong> reservation/completion (<code>src/service-worker/sync.ts:368-371, 509-512, 668-679</code>) and on <code>GET_RUNTIME_SNAPSHOT</code>/<code>SET_ACCOUNT_CONTEXT</code> (<code>src/service-worker/auth.ts:810-815, 843-848</code>).</li>
+<li>Every open page subscribes in <code>src/runtime/RuntimeProvider.tsx:64-105</code>. On a <code>CS_RUNTIME_STATE_V2</code> change (and no concurrent auth-key change), it calls <code>actions.applyRuntimeSnapshot(snapshot)</code> (lines 96-100).</li>
+<li><code>applyRuntimeSnapshot</code> (<code>src/stores/runtime-store.ts:1186-1192</code>) normalizes via <code>normalizeAuthPayloadFromSnapshot</code> and calls <code>applyAuthPayload(&hellip;, { allowHydration:false, allowAutoSync:false })</code> &mdash; it only updates auth/capability/session mirrors; never re-reads IDB, never starts a sync.</li>
+</ul>
+
+<h3>Riding <code>isPro</code> on this channel</h3>
+
+<p>Yes &mdash; this is the intended mechanism and the cleanest gating path:</p>
+
+<ol>
+<li>Add <code>isPro</code> (or a small <code>entitlement</code> object) to <code>RuntimeSnapshotData</code> (<code>src/types/messages.ts:174-182</code>).</li>
+<li>Populate it in <code>buildRuntimeSnapshot</code> (<code>src/service-worker/auth.ts:394-426</code>) by reading <code>CS_ENTITLEMENT</code>, and include it in the safe-defaults in <code>persistRuntimeStateV2</code> (<code>src/service-worker/auth.ts:459-470</code>).</li>
+<li>Mirror it into the Zustand store: add an <code>isPro</code> field to <code>RuntimeState</code> (<code>src/stores/runtime-store.ts:154-174</code>), set it inside <code>applyAuthPayload</code> (lines 695-724) from the normalized payload, and read it in <code>normalizeAuthPayloadFromSnapshot</code> (lines 202-222).</li>
+<li>Expose a <code>useIsPro()</code> selector in <code>src/stores/selectors.ts</code> (alongside <code>useAuthPhase</code>, etc.).</li>
+</ol>
+
+<div class="callout">Result: when the SW verifies a purchase and writes <code>CS_ENTITLEMENT</code> + re-persists the snapshot, <span class="hl">every open new-tab and reader page flips to Pro on the same event-loop tick</span>, exactly like a capability upgrade does today &mdash; no heartbeat wait, no reload. The SW, the UI, and any <code>chrome.storage.onChanged</code> listener all see the same single fact.</div>
+
+<p>One caveat to respect: <code>applyRuntimeSnapshot</code> deliberately uses <code>allowHydration:false</code>. An <code>isPro</code> flip must <strong>not</strong> trigger a re-hydration or sync &mdash; it is purely a capability mirror, so adding it as a snapshot field is safe and consistent with the existing guardrails.</p>
+
+<h2>Concrete integration points (file paths)</h2>
+
+<h3>(a) Where the entitlement value would be stored (the single writer)</h3>
+<ul>
+<li><strong>Declare the key:</strong> <code>src/service-worker/storage-keys-sw.ts</code> &mdash; add <code>export const CS_ENTITLEMENT = "totem_entitlement";</code>. This automatically makes the SW the only allowed writer and keeps runtime code from writing it (enforced by <code>src/lib/__tests__/storage-invariants.test.ts</code>).</li>
+<li><strong>Write it:</strong> a new SW handler module, e.g. <code>src/service-worker/entitlement.ts</code>, exporting a <code>HandlerMap</code> merged in <code>src/service-worker/index.ts:133-141</code> (alongside <code>authHandlers</code>, <code>syncHandlers</code>, &hellip;). Handlers like <code>ACTIVATE_LICENSE</code> / <code>VERIFY_LICENSE</code> / <code>GET_ENTITLEMENT</code> call <code>chrome.storage.local.set({ [CS_ENTITLEMENT]: &hellip; })</code> after verification. Add the new message types to <code>src/types/messages.ts</code> (<code>MessageRequest</code> union, lines 147-167).</li>
+<li><strong>Reset policy:</strong> in <code>src/lib/reset.ts</code>, keep <code>CS_ENTITLEMENT</code> <strong>out of</strong> <code>CHROME_LOCAL_RESET_KEYS</code> (lines 33-45) so a reset never revokes a paid unlock &mdash; and if you ever do want a "deactivate license" path, make it explicit, not a side effect of reset.</li>
+<li><strong>Optional cross-device mirror:</strong> add a sync key to <code>CHROME_SYNC_KEYS</code> (<code>src/lib/storage-keys.ts:73-76</code>) if the unlock should follow the user; written by the SW too.</li>
+</ul>
+
+<h3>(b) Where it is read by the service worker</h3>
+<ul>
+<li><code>src/service-worker/auth.ts</code> &mdash; <code>buildRuntimeSnapshot</code> (lines 364-427) reads <code>CS_ENTITLEMENT</code> and adds it to the returned snapshot; <code>persistRuntimeStateV2</code> (lines 429-471) includes it with safe defaults.</li>
+<li>Any Pro-gated SW capability (e.g. a future bulk-export proxy, or "don't overwrite cache on tombstone") reads <code>CS_ENTITLEMENT</code> directly in the relevant handler in <code>src/service-worker/api-proxy.ts</code>.</li>
+<li><code>src/api/core/auth.ts</code> <code>getRuntimeSnapshot()</code> (lines 21-33) already returns <code>response.data</code> verbatim, so the new field reaches the runtime with no wrapper change.</li>
+</ul>
+
+<h3>(c) Where it is exposed to React components</h3>
+<ul>
+<li><code>src/stores/runtime-store.ts</code>: add <code>isPro</code> to <code>RuntimeState</code> (lines 154-174) and to <code>createInitialState</code> (lines 355-380); set it in <code>applyAuthPayload</code> (lines 695-724) and read it from the snapshot in <code>normalizeAuthPayloadFromSnapshot</code> (lines 202-222) and from the <code>CHECK_AUTH</code> path in <code>normalizeAuthPayloadFromStatus</code> (lines 224-250) if you also surface it via <code>CHECK_AUTH</code>.</li>
+<li><code>src/runtime/RuntimeProvider.tsx</code>: <strong>no change needed</strong> &mdash; the existing <code>CS_RUNTIME_STATE_V2</code> <code>onChanged</code> branch (lines 96-100) already delivers the snapshot reactively.</li>
+<li><code>src/stores/selectors.ts</code>: add <code>export function useIsPro(): boolean { return useRuntimeStoreBase((s) =&gt; s.isPro); }</code> (mirrors <code>useAuthPhase</code>, lines 53-55). Components (<code>ExportModal.tsx</code>, <code>SettingsModal.tsx</code>, reader <code>ArticleExportMenu.tsx</code>, <code>BookmarksList.tsx</code> bulk-ops, etc.) gate on <code>useIsPro()</code>.</li>
+<li>For non-React surfaces (the reader route, the export library in <code>src/lib/export/*</code>): read the store directly via <code>runtimeStore.getState().isPro</code> (<code>src/stores/runtime-store.ts:1347-1351</code>) or pass the flag in.</li>
+</ul>
+
+<h3>(d) Supporting reference points already in place</h3>
+<ul>
+<li>Settings precedent for a sync-stored, reactively-updated boolean: <code>src/hooks/useSettings.ts</code> (<code>showOpenInTotem</code> etc. over <code>chrome.storage.sync</code> with an <code>onChanged</code> listener).</li>
+<li>Capability-mirror precedent (the exact pattern <code>isPro</code> should copy): <code>ApiCapability</code> in <code>src/types/auth.ts:11-14</code>, flowing snapshot &rarr; store &rarr; selector.</li>
+</ul>
+
+<h2>Risks / sharp edges for the entitlement design</h2>
+
+<ol>
+<li><strong>Local-first means client-trusted.</strong> Every substrate here (<code>chrome.storage.local/.sync</code>, IDB, localStorage) is user-readable/editable in DevTools. A purely local <code>isPro:true</code> is trivially forgeable. To match the "no Totem server" ethos while resisting casual piracy, the realistic option is a <span class="hl">signed license token verified by the SW</span> (vendor-issued signature over the license + a public key shipped in the extension). True server-side enforcement contradicts the no-server ethos; design for "honest-majority + raise the effort," not DRM.</li>
+<li><strong>Reset must not revoke.</strong> Default reset wipes <code>chrome.storage.sync</code> and all of IDB. Keep the entitlement key off both reset lists. Document it next to the auth-preservation comment in <code>reset.ts</code>.</li>
+<li><strong>Account switching.</strong> The entitlement is device/user-global, not per-account &mdash; keep it out of the per-account orchestrator map (<code>SyncAccountState</code>, <code>src/service-worker/sync.ts:65-86</code>) and out of account-scoped IDB.</li>
+<li><strong>Snapshot guardrail.</strong> When adding <code>isPro</code> to the snapshot, ensure the <code>applyRuntimeSnapshot</code> path keeps <code>allowHydration:false</code>/<code>allowAutoSync:false</code> (it already does) so an entitlement change never triggers IDB re-reads or syncs.</li>
+<li><strong>The MAIN-world hook is plain JS</strong> (<code>public/content/mutation-hook.js</code>) and is <strong>not</strong> a place to read entitlements &mdash; it has no access to the verified fact and shouldn't.</li>
+</ol>
+
+<h2>One-paragraph mental model for the entitlement</h2>
+
+<div class="callout">The license is a <strong>device-global, account-independent, reset-surviving fact</strong> whose single writer is the <strong>service worker</strong> (after verifying a signed token), physically stored in a new <code>chrome.storage.local</code> key (<code>CS_ENTITLEMENT</code>, declared in <code>src/service-worker/storage-keys-sw.ts</code>), stamped into the existing <code>RuntimeSnapshot</code>, and pushed reactively to every UI surface through the already-built <code>CS_RUNTIME_STATE_V2</code> &rarr; <code>chrome.storage.onChanged</code> &rarr; <code>applyRuntimeSnapshot</code> &rarr; Zustand &rarr; <code>useIsPro()</code> channel. IndexedDB stores the <em>content</em> a Pro feature acts on (full bookmark/detail/thread payloads &mdash; already enough to preserve deleted tweets' text and structure with only a cache-overwrite policy change), but never the entitlement itself.</div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix · Codebase Research</div>
+  <h1>Appendix B · Features &amp; Export Surface</h1>
+<p class="lead">A map of every user-facing feature, a deep-dive on Export (the proposed primary Pro gate), and the cost of inserting an entitlement check at each surface. The conclusion is unusual for a monetization effort: almost nothing needs to be built.</p>
+
+<div class="callout">There is <span class="hl">zero gating today</span> — every feature is fully free. Export, the proposed primary Pro gate, is one of the cleanest things in the codebase to wrap: exactly two entry points (a new-tab modal and a per-article reader menu), both routed through <code>App.tsx</code>, both already consuming <code>account</code>/<code>viewerProfile</code>, so an entitlement check slots in with almost no plumbing.</div>
+
+<h2>Export Today</h2>
+
+<h3>Formats currently supported</h3>
+
+<p>Totem has <strong>two distinct export systems</strong>.</p>
+
+<p><strong>A) Library-wide ZIP export</strong> — <code>src/lib/export/quick-export.ts</code>, <code>runQuickExport</code>, lines 561&ndash;776. One ZIP (<code>totem-export-YYYY-MM-DD.zip</code>) bundling <strong>every supported format at once</strong>:</p>
+
+<ul>
+<li><strong>CSV</strong> — <code>bookmarks.csv</code>, 11 columns (<code>quick-export.ts:95&ndash;107</code>, written by <code>bookmarkCsvLine</code>/<code>csvLines</code> <code>:314&ndash;343</code>), BOM-prefixed for Excel.</li>
+<li><strong>Markdown</strong> — <code>readme.md</code> index (<code>buildReadme :215&ndash;263</code>) <strong>plus one <code>.md</code> file per bookmark</strong> under <code>bookmarks/</code> (<code>buildBookmarkMarkdown :192&ndash;213</code>, written in the entries generator <code>:686&ndash;702</code>), rendered through the same <code>articleToMarkdown</code> path as the reader's Copy-Markdown.</li>
+<li><strong>JSONL</strong> — canonical re-importable data under <code>data/*.jsonl</code>: <code>bookmarks-&lt;year&gt;.jsonl</code> (sharded by year), <code>details.jsonl</code>, <code>highlights.jsonl</code>, <code>reading-progress.jsonl</code>, <code>today-queue-snapshots.jsonl</code>, <code>bookmark-queue-metadata.jsonl</code>, <code>today-queue-exposures.jsonl</code> (<code>:620&ndash;684</code>).</li>
+<li><strong>manifest.json</strong> — version, account id-hash, per-file SHA-256 checksums, counts, shard map (<code>:704&ndash;750</code>).</li>
+<li><strong>Zip mechanism</strong> — <strong>not</strong> <code>client-zip</code>. It uses a <strong>custom streaming zip</strong> in <code>src/lib/export/stream-zip.ts</code> (<code>makeZipEntriesStream</code>, consumed at <code>quick-export.ts:753</code>). Output streams straight to disk via the <strong>File System Access API</strong> (<code>window.showSaveFilePicker</code> &rarr; <code>createWritable</code> &rarr; <code>pipeTo</code>, <code>openWritable :284&ndash;301</code>), with a <code>Blob</code> + anchor-click fallback (<code>downloadBlob :303&ndash;312</code>) when the API is absent.</li>
+</ul>
+
+<p><strong>B) Per-article export</strong> (reader) — <code>src/lib/export/article-download.ts</code> + <code>src/components/reader/ArticleExportMenu.tsx</code>. Four actions on a single focal article/thread:</p>
+
+<ul>
+<li><strong>Copy for Agent</strong> (<code>articleToAgentMarkdown</code>), <strong>Copy Markdown</strong> (<code>articleToMarkdown</code>) &rarr; clipboard (<code>article-download.ts:62&ndash;80</code>).</li>
+<li><strong>Download Markdown</strong> &rarr; single <code>.md</code> Blob download (<code>downloadArticleMarkdown</code>/<code>downloadMarkdownFile :82&ndash;107</code>).</li>
+<li><strong>Print / Save PDF</strong> &rarr; renders print HTML into a hidden iframe and calls <code>window.print()</code> (<code>printArticleAsPdf :109&ndash;197</code>).</li>
+</ul>
+
+<h3>How export is triggered (entry points)</h3>
+
+<p>Only <strong>two</strong> UI entry points exist.</p>
+
+<ol>
+<li><strong><code>ExportModal</code></strong> (<code>src/components/ExportModal.tsx</code>). Opened from two places, both setting <code>exportOpen</code> in <code>App.tsx</code>:
+<ul>
+<li><code>NewTabHome</code> "Export" affordance &rarr; <code>onOpenExport</code> (<code>App.tsx:684</code>).</li>
+<li><code>SettingsModal</code> "Export" button &rarr; <code>onExport</code> (<code>App.tsx:706</code>; button at <code>SettingsModal.tsx:64,101</code>).</li>
+</ul>
+The modal offers <strong>Quick/Basic export</strong> (download ZIP now) and <strong>Full export</strong> (background-hydrate missing content first, then download). The click path: <code>handleStart</code> &rarr; <code>handleQuickExport</code> &rarr; <code>runQuickExport(account)</code> (<code>ExportModal.tsx:60&ndash;88</code>). Full export instead calls <code>getHydrationStore().getState().start()</code> (<code>:78&ndash;80</code>).</li>
+<li><strong><code>ArticleExportMenu</code></strong> (<code>src/components/reader/ArticleExportMenu.tsx</code>), rendered inside the reader's <code>ActionBar</code> (<code>src/components/reader/TweetContent.tsx:221&ndash;228</code>, props plumbed from <code>articleExport</code>). This is the per-article path (B above).</li>
+</ol>
+
+<h3>Code path: click &rarr; data read &rarr; file produced (ZIP)</h3>
+
+<pre><code>ExportModal.handleStart (ExportModal.tsx:82)
+  &rarr; handleQuickExport (:60)
+    &rarr; runQuickExport(account)  (quick-export.ts:561)
+        &rarr; openWritable(filename)                         // FS Access API or blob fallback (:284)
+        &rarr; Promise.all([
+            collectBookmarkMarkdownFiles(),              // iterateBookmarks() over IndexedDB (:457)
+            collectDetailSummary(),                      // iterateTweetDetails() (:413)
+            collectHighlightIds(), collectReadingProgressIds()
+          ])
+        &rarr; entries() async generator yields StreamZipEntry per file (:599)
+            // readme.md, bookmarks.csv, data/*.jsonl, bookmarks/*.md, manifest.json
+            // each text entry hashed via createSha256Hex (:372 hashingTextEntry)
+        &rarr; makeZipEntriesStream(entries())  (stream-zip.ts, :753)
+        &rarr; pipeTo(writable)  OR  new Response(stream).blob() &rarr; downloadBlob (:754&ndash;759)
+    &rarr; setQuickState({ phase: "done", result })           // counts shown in DoneView</code></pre>
+
+<p>All reads are local IndexedDB iterators (<code>src/db/index.ts</code>: <code>iterateBookmarks</code>, <code>iterateTweetDetails</code>, <code>getTweetDetailCache</code>, etc.). No network, no server — consistent with the local-first ethos.</p>
+
+<h3>Is there any gating today?</h3>
+
+<p><strong>No.</strong> The only preconditions anywhere are functional, not commercial:</p>
+
+<ul>
+<li><code>runQuickExport</code> requires a non-null <code>account</code> (<code>ExportModal.tsx:61</code>, <code>canExport = bookmarkCount &gt; 0 &amp;&amp; account !== null</code> <code>:157</code>). <code>account</code> is derived from <code>viewerProfile</code> in <code>App.tsx:713&ndash;717</code>.</li>
+<li><code>ArticleExportMenu</code> actions are always enabled.</li>
+<li>No <code>isPro</code>, <code>entitlement</code>, <code>license</code>, <code>paywall</code>, <code>upgrade</code>, or <code>checkout</code> symbol exists anywhere in <code>src/</code> or <code>apps/site/src/</code> (grep confirmed — the only "upgrade" hits are IndexedDB schema-version upgrades).</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">CLEAN SLATE</div> The codebase has no monetization machinery at all. Nothing to refactor, nothing to undo — just one boundary to add.</div>
+
+<h2>Feature Inventory &amp; Gate Difficulty</h2>
+
+<table class="striped">
+<thead><tr><th>Feature</th><th>Entry-point component / file</th><th>User trigger</th><th>Gate difficulty</th><th>GTM tier</th></tr></thead>
+<tbody>
+<tr><td>New-tab queue / Today's Read</td><td><code>NewTabHome.tsx</code>, <code>useTodayQueue</code> (<code>hooks/useTodayQueue.ts</code>)</td><td>Open new tab</td><td>n/a (don't gate)</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Reading list (Unread / Continue / Read / Today tabs)</td><td><code>BookmarksList.tsx</code></td><td>"Reading" view</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Reader (article/thread render)</td><td><code>BookmarkReader.tsx</code>, <code>reader/TweetContent.tsx</code></td><td>Click a bookmark</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Sync (intercept + IndexedDB)</td><td><code>runtime-store.ts</code> <code>actions.refresh</code>, service worker</td><td>"Sync" button</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Basic in-library search (free text)</td><td><code>useBookmarkSearch.ts</code> &rarr; <code>lib/search.ts</code></td><td>Type in search box (<code>BookmarksList.tsx:301</code>)</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td>Web search box (Google/Bing/&hellip;)</td><td><code>NewTabHome.tsx:1147</code>, <code>SearchEnginePicker.tsx</code></td><td>Type + Enter</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+<tr><td><strong>Export — library ZIP (CSV/MD/JSONL)</strong></td><td><code>ExportModal.tsx</code> &rarr; <code>quick-export.ts</code></td><td>Export button &rarr; "Download ZIP"</td><td><strong>Trivial</strong> (1 call site: <code>handleQuickExport</code>)</td><td><span class="tag">PRO</span></td></tr>
+<tr><td><strong>Export — Full export (deleted-tweet preservation)</strong></td><td><code>ExportModal.tsx</code> &rarr; <code>hydration-store.ts</code> <code>start()</code></td><td>"Start full export"</td><td><strong>Trivial</strong> (1 call site: <code>handleStartFullExport :78</code>)</td><td><span class="tag">PRO</span></td></tr>
+<tr><td><strong>Export — per-article (Download MD / Print PDF)</strong></td><td><code>ArticleExportMenu.tsx</code>, <code>article-download.ts</code></td><td>Reader menu</td><td><strong>Trivial</strong> (gate the 4 <code>on*</code> handlers in <code>TweetContent</code>)</td><td><span class="tag">PRO</span> (Copy-MD/Copy-Agent could stay free as a teaser)</td></tr>
+<tr><td>Import (re-import a Totem ZIP)</td><td><code>ImportModal.tsx</code> &rarr; <code>lib/import/run-import.ts</code></td><td>Import button</td><td>Trivial</td><td><span class="tag">FREE</span> (keeps data portability honest)</td></tr>
+<tr><td><strong>Advanced search filters</strong> (<code>from: tag: site: min_faves: has: is: since:</code> &hellip;)</td><td><code>lib/search/parser.ts</code>, <code>lib/search/executor.ts</code></td><td>Type operators in same box</td><td><strong>Medium</strong> (one box; must gate by parsed AST, not the box)</td><td><span class="tag">PRO</span></td></tr>
+<tr><td><strong>Annotations — highlights</strong></td><td><code>reader/SelectionToolbar.tsx</code>, <code>HighlightPopover.tsx</code> &rarr; <code>db.upsertHighlight</code></td><td>Select text &rarr; "Highlight"</td><td>Medium (gate <code>onHighlight</code> in <code>SelectionToolbar</code>)</td><td><span class="tag">PRO</span> (per GTM)</td></tr>
+<tr><td><strong>Annotations — notes</strong></td><td><code>reader/SelectionToolbar.tsx</code>, <code>NotePopover.tsx</code></td><td>Select text &rarr; "Add Note"</td><td>Medium (gate <code>onAddNote</code>)</td><td><span class="tag">PRO</span> (per GTM)</td></tr>
+<tr><td><strong>Bulk ops</strong></td><td><em>does not exist yet</em> (no multi-select anywhere; grep found none in <code>BookmarksList</code>)</td><td>&mdash;</td><td><strong>Hard</strong> (net-new selection UI)</td><td><span class="tag">PRO</span></td></tr>
+<tr><td><strong>Thread-aware capture</strong></td><td>partially exists: <code>hydration-store.ts</code> fetches <code>thread</code>, <code>tweet-export.ts</code> <code>buildSyntheticExportPlainText(includeThread)</code></td><td>implicit via Full export</td><td>Medium</td><td><span class="tag">PRO</span> (couple to Full export)</td></tr>
+<tr><td>Settings / theme / reset / delete-all</td><td><code>SettingsModal.tsx</code></td><td>Settings</td><td>n/a</td><td><span class="tag">FREE</span></td></tr>
+</tbody>
+</table>
+
+<p><strong>Trivial</strong> = single call-site, value already in scope. <strong>Medium</strong> = call-site exists but must gate by intent (parsed query / specific button) not the whole surface. <strong>Hard</strong> = feature doesn't exist; gate is part of new construction.</p>
+
+<h2>Proposed Pro Features — Exists vs Net-New</h2>
+
+<table class="striped">
+<thead><tr><th>Pro feature</th><th>Already in code?</th><th>File(s) that would host the gate</th></tr></thead>
+<tbody>
+<tr><td><strong>Export (MD/CSV/JSONL/ZIP)</strong></td><td><span class="tag">VERIFIED</span> <strong>EXISTS, complete.</strong> Full multi-format streaming ZIP + per-article MD/PDF.</td><td><code>ExportModal.tsx</code> (<code>handleQuickExport :60</code>); <code>reader/TweetContent.tsx</code> <code>ActionBar</code>/<code>ArticleExportMenu</code> handlers <code>:221</code>. Underlying <code>lib/export/*</code> left ungated.</td></tr>
+<tr><td><strong>Deleted-tweet caching / preservation</strong></td><td><span class="tag">VERIFIED</span> <strong>EXISTS.</strong> The "Full export" hydration engine (<code>src/stores/hydration-store.ts</code>) back-fills <code>TweetDetailCache</code> for every bookmark and explicitly classifies/persists deleted+protected tweets (<code>classifyError :116</code>, <code>cacheUnavailable</code>, <code>detailsStatus: "unavailable"</code>, <code>unavailableReason: "deleted" :132,213</code>). This <em>is</em> the preservation feature; it just isn't framed/sold as one.</td><td><code>ExportModal.tsx:78</code> (<code>handleStartFullExport</code>) and/or <code>hydration-store.ts</code> <code>start() :249</code>.</td></tr>
+<tr><td><strong>Bulk ops</strong></td><td><span class="tag">NET-NEW</span> No multi-select / batch-action UI exists in <code>BookmarksList.tsx</code> or anywhere (<code>bulk</code>/<code>selectAll</code>/<code>checkbox</code> grep is empty in components).</td><td>New code in <code>BookmarksList.tsx</code>; gate at the bulk-action dispatcher you build.</td></tr>
+<tr><td><strong>Advanced search filters</strong></td><td><span class="tag">VERIFIED</span> <strong>EXISTS, complete &amp; impressive.</strong> Full recursive-descent grammar with <code>from/to/tag/site/url/since/until/within/older_than/min_faves/min_retweets/min_replies/has/filter/is/lang</code> + AND/OR/NOT/quotes/parens (<code>lib/search/parser.ts</code>, <code>executor.ts:140&ndash;208</code>). Twitter-compatible aliases too.</td><td><code>useBookmarkSearch.ts</code> (or a wrapper) — detect operator nodes in the parsed AST and gate; keep plain free-text search free.</td></tr>
+<tr><td><strong>Annotations</strong></td><td><span class="tag">VERIFIED</span> <strong>EXISTS.</strong> Highlights (multi-color) and notes are fully built: <code>db.upsertHighlight</code>/<code>getHighlightsByTweetId</code> (<code>db/index.ts:840&ndash;880</code>), <code>SelectionToolbar.tsx</code>, <code>HighlightPopover.tsx</code>, <code>NotePopover.tsx</code>, <code>HighlightColorPicker.tsx</code>. They're even already exported in the ZIP (<code>highlights.jsonl</code>).</td><td><code>reader/SelectionToolbar.tsx</code> <code>onHighlight</code>/<code>onAddNote</code> callbacks <code>:128,131</code>, or the consuming reader component that passes them.</td></tr>
+<tr><td><strong>Thread-aware capture</strong></td><td><span class="tag">VERIFIED</span> <strong>MOSTLY EXISTS.</strong> Threads are fetched by hydration and rendered; export composes full threads (<code>tweet-export.ts:buildSyntheticExportPlainText(thread, includeThread) :152</code>, called with <code>includeThreadInExport: true</code> from <code>quick-export.ts:201</code>).</td><td>Naturally gated together with Full export / library export. No separate gate likely needed.</td></tr>
+</tbody>
+</table>
+
+<div class="takeaway"><div class="takeaway-label">5 OF 6 ALREADY BUILT</div> <span class="hl">5 of 6 proposed Pro features are already built and shipping for free.</span> Only <strong>bulk ops</strong> is net-new. Monetization here is overwhelmingly a <strong>gating/packaging exercise, not a build exercise</strong> — which makes a single clean entitlement boundary the highest-leverage piece of work.</div>
+
+<h2>Cleanest Spot for a Single Reusable Gate</h2>
+
+<h3>Recommended pattern</h3>
+
+<p><strong>(a) Entitlement source — mirror <code>useSettings</code>.</strong> Settings already persist via <code>chrome.storage.sync</code> keyed by a constant (<code>useSettings.ts:104&ndash;141</code>, <code>SYNC_SETTINGS</code> from <code>lib/storage-keys.ts</code>), with a live <code>chrome.storage.onChanged</code> subscription. <strong>Clone this exactly</strong> for entitlement: add <code>SYNC_ENTITLEMENT</code> (or <code>LOCAL_ENTITLEMENT</code>) to <code>lib/storage-keys.ts</code>, and a <code>useEntitlement()</code> hook in <code>src/hooks/useEntitlement.ts</code> that reads/normalizes the stored license and re-renders on change. This keeps the proven storage/subscription pattern and stays server-optional (the unlock token is verified once and cached locally — fits the no-server ethos).</p>
+
+<p><strong>(b) Boundary — a <code>&lt;ProGate&gt;</code> component + a <code>requirePro(action)</code> wrapper.</strong> Put both in <code>src/components/ui/ProGate.tsx</code> (alongside <code>Modal</code>, <code>Button</code>). <code>&lt;ProGate&gt;</code> renders children for Pro users and a locked/upsell affordance otherwise; <code>requirePro(isPro, action, onUpsell)</code> wraps an imperative handler so a free user gets the upsell modal instead of the action. A single shared <code>&lt;UpgradeModal&gt;</code> (sibling of <code>ExportModal</code>/<code>ImportModal</code> in <code>App.tsx:708&ndash;725</code>, opened via a new <code>upgradeOpen</code> flag in <code>newTabRouteReducer :131</code>) gives every gate one consistent surface to point at.</p>
+
+<h3>Why this is the cleanest single insertion point</h3>
+
+<ul>
+<li><strong>Export already concentrates at <code>App.tsx</code>.</strong> <code>ExportModal</code> and <code>ImportModal</code> are both rendered there with <code>viewerProfile</code>/<code>account</code> already in scope (<code>App.tsx:708&ndash;725</code>). Adding <code>upgradeOpen</code> state + an <code>&lt;UpgradeModal&gt;</code> there means <span class="hl">one place owns the upsell surface</span> for the whole new-tab app.</li>
+<li><strong>Two export gates, both trivial.</strong> For the primary gate, wrap <code>handleQuickExport</code> (<code>ExportModal.tsx:60</code>) and <code>handleStartFullExport</code> (<code>:78</code>) with <code>requirePro(...)</code>. The <code>IdleView</code> primary button (<code>:299&ndash;306</code>) can additionally show a lock state by passing <code>isPro</code> down. No change to <code>lib/export/*</code> — the data layer stays clean and testable.</li>
+<li><strong>Reader gate is one prop hop.</strong> The per-article menu handlers are passed as a single <code>articleExport</code> prop object through <code>TweetContent.tsx:221</code>. Wrap those four <code>on*</code> functions (or just <code>onDownloadMarkdown</code>/<code>onPrintPdf</code>) once at the point they're constructed.</li>
+<li><strong>Search &amp; annotations reuse the same hook.</strong> <code>useBookmarkSearch</code> and <code>SelectionToolbar</code> can both call <code>useEntitlement()</code> and route to the same <code>&lt;UpgradeModal&gt;</code> — no second mechanism.</li>
+</ul>
+
+<h3>Concrete first slice (lowest-risk MVP gate)</h3>
+
+<ol>
+<li><code>lib/storage-keys.ts</code>: add <code>SYNC_ENTITLEMENT</code>.</li>
+<li><code>src/hooks/useEntitlement.ts</code>: <code>useEntitlement(): { isPro: boolean }</code> (copy <code>useSettings</code> shape).</li>
+<li><code>src/components/ui/ProGate.tsx</code>: <code>&lt;ProGate&gt;</code> + <code>requirePro()</code>.</li>
+<li><code>App.tsx</code>: add <code>upgradeOpen</code> to <code>NewTabRouteState</code>, render <code>&lt;UpgradeModal&gt;</code> next to <code>ExportModal</code>.</li>
+<li><code>ExportModal.tsx</code>: wrap <code>handleQuickExport</code>/<code>handleStartFullExport</code>; pass <code>isPro</code> into <code>IdleView</code> for lock styling.</li>
+</ol>
+
+<p>That single boundary covers the primary Pro gate (export) and is immediately reusable for full export/preservation, advanced search, and annotations — all of which already exist and just need the same <code>requirePro</code>/<code>&lt;ProGate&gt;</code> wrapper.</p>
+
+<h2>Key File Reference</h2>
+
+<ul>
+<li><strong>Export (library ZIP):</strong> <code>src/lib/export/quick-export.ts</code>, <code>src/lib/export/stream-zip.ts</code>, <code>src/lib/export/tweet-export.ts</code>, <code>src/components/ExportModal.tsx</code></li>
+<li><strong>Export (per-article):</strong> <code>src/lib/export/article-download.ts</code>, <code>src/components/reader/ArticleExportMenu.tsx</code>, <code>src/components/reader/TweetContent.tsx:221</code></li>
+<li><strong>Deleted-tweet preservation:</strong> <code>src/stores/hydration-store.ts</code></li>
+<li><strong>Advanced search:</strong> <code>src/lib/search/parser.ts</code>, <code>src/lib/search/executor.ts</code>, <code>src/hooks/useBookmarkSearch.ts</code></li>
+<li><strong>Annotations:</strong> <code>src/components/reader/SelectionToolbar.tsx</code>, <code>HighlightPopover.tsx</code>, <code>NotePopover.tsx</code>, <code>src/db/index.ts:840&ndash;880</code></li>
+<li><strong>Wiring / proposed gate host:</strong> <code>src/App.tsx:684,706,708&ndash;725</code>; pattern to mirror: <code>src/hooks/useSettings.ts:104&ndash;141</code></li>
+</ul>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix · Codebase Research</div>
+  <h1>Appendix C · Build &amp; Release Pipeline</h1>
+<p class="lead">The exact build, package, and Chrome Web Store release pipeline as it stands today — one artifact, one manifest, one zip — and the precise repo-mechanical changes a Pro/license-check feature would force, including the single preflight script that blocks any new permission. All paths are relative to repo root <code>/Users/ankit/Documents/make/totem</code>.</p>
+
+<h2>How the extension is built and packaged today</h2>
+
+<h3>The single shippable artifact</h3>
+<p>There is exactly <strong>one</strong> shippable extension artifact: <code>release/totem-v&lt;version&gt;.zip</code>, produced from <code>dist/</code>. The <code>dist/</code> shape today:</p>
+<pre><code>dist/
+  manifest.json            # byte-identical copy of public/manifest.json (verified via diff)
+  service-worker.js        # ~48 KB IIFE bundle
+  newtab.html, reader.html # entry HTML
+  assets/
+    main.js (~1 MB), main.css (~120 KB), index.js, open-in-totem.js
+  content/
+    detect-user.js, mutation-hook.js   # copied verbatim from public/content/
+  icons/, wallpapers/, favicon*, rules.json</code></pre>
+<p>Key fact: <code>vite.config.ts</code> sets <strong>no explicit <code>publicDir</code></strong>, so Vite uses its default (<code>public/</code>) and copies everything under <code>public/</code> into <code>dist/</code> unprocessed. That is why <code>dist/manifest.json</code>, <code>dist/rules.json</code>, and <code>dist/content/*.js</code> are byte-identical copies of the <code>public/</code> source — they are static assets, <strong>not</strong> build outputs. <code>service-worker.js</code> and <code>assets/main.js</code> etc. ARE build outputs (Rollup/Vite).</p>
+
+<h3>The build graph (<code>vite.config.ts</code>)</h3>
+<p>Three things are bundled in one <code>vite build</code>:</p>
+<ul>
+<li><strong>Main app</strong> — <code>newtab.html</code> + <code>reader.html</code> as Rollup inputs &rarr; <code>assets/[name].js</code> (ES modules, <code>base: "./"</code> for relative paths inside the extension).</li>
+<li><strong>Service worker</strong> — <code>serviceWorkerPlugin()</code> runs a <em>second</em> nested <code>viteBuild()</code> in <code>closeBundle()</code> that compiles <code>src/service-worker/index.ts</code> &rarr; <code>service-worker.js</code> as a single <strong>IIFE</strong> (MV3 service workers can't be ES modules unless <code>"type":"module"</code> is set in the manifest background block, which it is not — so IIFE is required).</li>
+<li><strong>Content script</strong> — <code>contentScriptPlugin()</code> compiles <code>src/content/open-in-totem.ts</code> &rarr; <code>assets/open-in-totem.js</code> as IIFE. (The MAIN-world <code>mutation-hook.js</code> and <code>detect-user.js</code> are hand-written static files in <code>public/content/</code>, not part of the TS build.)</li>
+<li><strong>Version injection</strong> — <code>define: { __TOTEM_APP_VERSION__: JSON.stringify(appVersion) }</code> reads <code>package.json.version</code> at config-eval time and inlines it as a global. Declared in <code>src/vite-env.d.ts</code>; consumed in <code>src/lib/export/quick-export.ts:35</code>. This is the existing precedent for compile-time constant injection — <span class="hl">the same <code>define</code> mechanism is the cleanest place to inject a license public key.</span></li>
+</ul>
+
+<h3>The full pipeline, command by command</h3>
+<p>From <code>package.json</code> scripts:</p>
+<pre><code>pnpm build:extension   = pnpm typecheck &amp;&amp; vite build      # tsc --noEmit, then build
+pnpm package:extension = pnpm build:extension &amp;&amp; node scripts/package-extension.mjs</code></pre>
+<p><code>scripts/package-extension.mjs</code>:</p>
+<ol>
+<li>Asserts <code>dist/</code> and <code>dist/manifest.json</code> exist (fails if you didn't build).</li>
+<li>Reads <code>version</code> from <code>dist/manifest.json</code>.</li>
+<li><code>zip -r -q release/totem-v&lt;version&gt;.zip .</code> run with <code>cwd: dist</code> (shells out to the system <code>zip</code> binary — a host dependency, not a JS lib).</li>
+</ol>
+<p>So the literal chain is: <strong>typecheck &rarr; vite build &rarr; copy public/&rarr;dist/ &rarr; zip dist/ &rarr; release/totem-v&lt;version&gt;.zip</strong>. Upload to CWS is <strong>manual</strong> (drag-zip into the developer dashboard) per <code>PUBLISH.md</code>; there is no automated CWS upload step. The GitHub release workflow only publishes the zip as a GitHub Release <strong>asset</strong>, not to the Web Store.</p>
+
+<h3>Release orchestration &amp; versioning sync</h3>
+<p>Two-file version sync is enforced in three places:</p>
+<ul>
+<li><code>scripts/check-version-sync.mjs</code> (<code>pnpm release:version:check</code>) — hard-fails if <code>package.json.version !== public/manifest.json.version</code>.</li>
+<li><code>scripts/prepare-release.mjs</code> (<code>pnpm release:prepare</code>) — bumps <strong>both</strong> files together, regenerates <code>CHANGELOG.md</code> from filtered git subjects, then runs <code>release:version:check</code> + <code>package:extension</code>.</li>
+<li><code>scripts/release.mjs</code> (<code>pnpm release</code> / <code>ship</code>) — guards (must be on <code>main</code>, clean tree), runs prepare, commits the 3 files, pushes <code>main</code>, creates+pushes <code>v&lt;version&gt;</code> tag.</li>
+</ul>
+<p>The tag push triggers <code>.github/workflows/release-extension.yml</code>: install &rarr; <code>pnpm test:reliability</code> &rarr; <code>pnpm test</code> &rarr; <code>pnpm verify:workspace</code> &rarr; <code>pnpm release:check</code> (<code>release:version:check</code> + <code>package:extension</code>) &rarr; assert <code>tag == dist/manifest.json.version</code> &rarr; upload <code>release/*.zip</code> to the GitHub Release. CI (<code>ci.yml</code>) runs <code>pnpm ci:verify</code> = <code>test &amp;&amp; build &amp;&amp; verify:workspace &amp;&amp; audit:prod</code> on every PR/push.</p>
+
+<div class="callout"><code>scripts/verify-cws-featured-readiness.mjs</code> (<code>pnpm cws:featured:preflight</code>) is a strict gate that <strong>hard-pins the manifest</strong>: it asserts the exact <code>permissions</code> array <code>[storage, webRequest, declarativeNetRequest, scripting, cookies]</code>, the exact <code>optional_permissions</code> <code>[topSites, favicon, search]</code>, and that <code>host_permissions</code> is <strong>exactly</strong> <code>["https://x.com/*"]</code> with length 1. Any new permission or host added for licensing will fail this preflight until the script is updated — the single most important repo-mechanical blocker to know about.</div>
+
+<h2>Manifest implications of adding payments/licensing</h2>
+<p>Current relevant manifest state (<code>public/manifest.json</code>):</p>
+<ul>
+<li><code>permissions</code>: <code>storage, webRequest, declarativeNetRequest, scripting, cookies</code></li>
+<li><code>host_permissions</code>: <code>["https://x.com/*"]</code> only</li>
+<li>CSP (<code>content_security_policy.extension_pages</code>): <code>script-src 'self'; object-src 'self'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.twimg.com; media-src 'self' https://*.twimg.com</code></li>
+</ul>
+
+<h3>The MV3 "no remotely-hosted code" rule — the core constraint</h3>
+<p>Under MV3, <strong>all executable code must ship inside the package</strong>. License validation therefore must be a <span class="hl">pure data exchange</span>: the extension may <code>fetch()</code> JSON (a license token, an entitlement boolean, a signed receipt) from an endpoint, but it may <strong>not</strong> download and <code>eval</code>/inject any script, and it may <strong>not</strong> load a remote payment-provider SDK <code>&lt;script&gt;</code>. This rules out the common web pattern of dropping in <code>js.stripe.com/v3</code> or a Paddle/Lemon Squeezy overlay script. Two compliant shapes:</p>
+<ul>
+<li><span class="tag">RECOMMENDED</span> <strong>No in-extension checkout.</strong> Checkout happens on the web (a <code>usetotem.xyz/pro</code> page or the provider's hosted checkout, opened in a normal tab). The extension only ever does a <code>fetch()</code> to verify/retrieve an entitlement. The package contains zero payment SDK code. This keeps <code>script-src 'self'</code> untouched and is the cleanest MV3 posture.</li>
+<li><span class="tag">ACCEPTABLE</span> Bundle a provider's <em>client</em> library into <code>assets/main.js</code> at build time (npm dependency, compiled by Vite) and call its REST API. Still data-only at runtime; still <code>script-src 'self'</code>.</li>
+</ul>
+<p><code>script-src</code> should stay <code>'self'</code>. <strong>Do not</strong> add any host to <code>script-src</code>.</p>
+
+<h3>What must change for an outbound license fetch</h3>
+<p>A license check that calls an external endpoint needs <strong>two</strong> manifest additions:</p>
+<ol>
+<li><strong><code>host_permissions</code></strong> — add the license/verify origin, e.g. <code>"https://api.usetotem.xyz/*"</code> (a tiny first-party verify endpoint) or the provider's API origin (e.g. <code>"https://api.lemonsqueezy.com/*"</code>). Without this, <code>fetch()</code> from the extension is blocked by host-permission policy. Prefer a <strong>single, narrow, first-party</strong> origin you control — far easier to justify to reviewers than a third-party payment API, and it lets you swap providers without a manifest change/re-review.</li>
+<li><strong>CSP <code>connect-src</code></strong> — the extension's CSP currently has <strong>no <code>connect-src</code> directive</strong>, so it inherits the default and outbound <code>fetch</code>/XHR is governed by host_permissions plus the default <code>connect-src</code>. To be explicit and safe, add a <code>connect-src</code> listing exactly the verify origin (and keep <code>'self'</code>), e.g.:
+<pre><code>connect-src 'self' https://api.usetotem.xyz;</code></pre>
+Today's <code>fetch</code> to <code>x.com</code> works because <code>https://x.com/*</code> is in <code>host_permissions</code> and there is no restrictive <code>connect-src</code>. Once you add an explicit <code>connect-src</code>, you must list <strong>every</strong> origin the extension talks to (x.com, twimg via img/media already covered, and the new verify origin), or you'll break existing network calls. Safest minimal change: add the <code>host_permissions</code> entry + a <code>connect-src</code> including <code>'self'</code>, <code>https://x.com</code>, and the verify origin.</li>
+<li><strong><code>optional_host_permissions</code></strong> (strongly recommended posture) — instead of a static <code>host_permissions</code> grant, declare the verify origin under <code>optional_host_permissions</code> and request it at runtime only when the user actually upgrades. This keeps the default install footprint identical to today (helps CWS review and user trust), and means free users never grant a payment-related host. Trade-off: slightly more runtime code (<code>chrome.permissions.request</code>).</li>
+</ol>
+
+<h3>Permission additions to avoid</h3>
+<ul>
+<li><strong>Do not</strong> add <code>identity</code> / OAuth unless you truly need Google sign-in for accounts — it contradicts the "no account" ethos and adds review friction. A one-time license key (paste-a-key or deep-link redemption) avoids it entirely.</li>
+<li><strong>Do not</strong> broaden to <code>&lt;all_urls&gt;</code> or wildcard hosts. The narrower the better; <code>verify-cws-featured-readiness.mjs</code> and the local-first story both depend on a tight host list.</li>
+</ul>
+
+<h2>Build-time secrets &amp; env injection</h2>
+
+<h3>Current state</h3>
+<p>There is <strong>no <code>.env</code> anywhere</strong> (confirmed: no <code>.env*</code> files outside node_modules), and <code>.gitignore</code> already ignores <code>*.local</code> and <code>dist</code>/<code>release</code>. The only compile-time constant today is <code>__TOTEM_APP_VERSION__</code>, injected via Vite <code>define</code>. <code>import.meta.env</code> is used only for <code>import.meta.env.DEV</code> test-guards (<code>src/api/core/posts.ts</code>). So there is currently <strong>no env-injection plumbing</strong> — it must be added.</p>
+
+<h3>What a license check needs at build time, and where it lives</h3>
+<p>Critical distinction for a one-time-license model:</p>
+<ul>
+<li>The <strong>provider validate endpoint URL</strong> (and any publishable product/store id) is <strong>non-secret by design</strong> — safe to commit and safe to inline. The shipped design needs no client-side secret at all: the provider's license <strong>validate</strong> endpoint is documented as safe to call from a public client, so the extension sends only the key (the provider's <em>secret</em> API key stays server-side). <em>(An earlier exploration embedded an Ed25519 public key for offline signature verification — see Appendix G's decision note for why that was set aside.)</em></li>
+<li>A <strong>provider publishable key</strong> (e.g. a Stripe/Lemon Squeezy <em>publishable</em> key) is also non-secret and can be inlined, but is only relevant if checkout happens in-extension — which §2.1 recommends against.</li>
+<li>A <strong>provider secret key / signing private key</strong> must <strong>NEVER</strong> be in the extension build. The extension ships to users' machines; anything in <code>dist/</code> is fully readable. The private signing key lives only on the server / in CI secrets for the server, never in this repo's build.</li>
+</ul>
+
+<h3>How to inject it (matching existing patterns)</h3>
+<p>Two viable mechanisms, in order of preference:</p>
+<ol>
+<li><strong>Vite <code>define</code></strong> (matches <code>__TOTEM_APP_VERSION__</code> exactly): add <code>__TOTEM_LICENSE_PUBLIC_KEY__: JSON.stringify(process.env.TOTEM_LICENSE_PUBLIC_KEY ?? &lt;committed-default&gt;)</code> in <code>vite.config.ts</code>, declare it in <code>src/vite-env.d.ts</code>. Because the key is public, the simplest correct choice is to <span class="hl">commit the public key as a constant</span> and skip env entirely — no secret-management surface, reproducible builds, and CI needs no new secrets.</li>
+<li><strong><code>import.meta.env</code> via <code>VITE_</code> prefix</strong> — Vite auto-exposes <code>VITE_</code>-prefixed env vars to client code. Would require adding a <code>.env</code>/<code>.env.production</code> (gitignored) and a CI env var. Only worth it if the injected value is environment-specific (e.g. a staging vs prod verify URL).</li>
+</ol>
+<div class="takeaway"><div class="takeaway-label">MUST NOT ENTER dist/</div> Any private signing key, provider secret API key, webhook signing secret, or admin token. None belong in the extension build — they live in the separate license-server / payment-webhook deployment. If a per-build secret is ever introduced, add it to <code>.gitignore</code> (e.g. <code>.env.production</code>) and to GitHub Actions repo secrets for the build job; <code>release-extension.yml</code> passes no secrets to the build today, so a secret would need an explicit <code>env:</code> block.</div>
+
+<h2>CWS review / policy friction a payment integration adds</h2>
+<p>The repo already has a heavy compliance apparatus (<code>PUBLISH.md</code>, <code>plans/chrome-web-store-listing.md</code>, <code>plans/chrome-web-store-dashboard-update-packet.md</code>, the featured-readiness verifier). Payments add the following on top:</p>
+<ol>
+<li><strong>New permission justifications.</strong> Each added permission/host needs a written justification in the CWS dashboard (the pattern is already established in <code>PUBLISH.md</code> lines 83–94). For a new verify host: <em>"Validates a one-time Pro license by fetching an entitlement token from our own endpoint; no browsing data is sent, only an opaque license key."</em> If using <code>optional_host_permissions</code>, note it is requested only at upgrade time.</li>
+<li><strong>Single-purpose policy.</strong> CWS requires one narrow purpose. Adding <em>payment/account</em> features risks a reviewer reading it as a second purpose. Mitigation: frame Pro as the <strong>same</strong> purpose (reading/searching/exporting your bookmarks) with more capability, not a new product. License redemption is configuration, not a separate feature surface.</li>
+<li><strong>Privacy-practices disclosure update.</strong> The dashboard "Privacy practices" tab (today certifies <em>no data sold, all local</em> — <code>PUBLISH.md</code> 97–104) must be updated: a license check transmits the <strong>license key</strong> (and possibly an extension-instance id) to your endpoint. You must (a) disclose this data flow, (b) keep the "no analytics/telemetry, no third-party tracking" claims true, (c) ensure the privacy policy at <code>usetotem.xyz/privacy/</code> (referenced by <code>verify-cws-featured-readiness.mjs</code>) is updated to describe license validation. The local-first claim in the store description (<code>"no Totem account, no server"</code>) becomes <strong>literally false</strong> the moment a verify endpoint exists — the listing copy and <code>manifest.description</code> (which the preflight pins to an exact string) must be reworded (e.g. "no account required; bookmarks stay on-device" rather than "no server").</li>
+<li><strong>"Paid features must work" / no deceptive behavior.</strong> CWS disallows charging for things that don't function and requires clear disclosure of paid features. The store listing should state Pro is a paid upgrade and what it unlocks.</li>
+<li><strong>Remotely-hosted-code rejection risk.</strong> If any payment-provider <code>&lt;script&gt;</code> or remote SDK is loaded, near-automatic rejection. Keep it data-only.</li>
+</ol>
+<p><strong>Pipeline additions required:</strong></p>
+<ul>
+<li>Update <code>scripts/verify-cws-featured-readiness.mjs</code> to allow the new host/permission (otherwise <code>cws:featured:preflight</code> and the release flow that depends on a clean manifest will fail).</li>
+<li>Update <code>PUBLISH.md</code> permission-justification list and the dashboard packet doc with the new entries.</li>
+<li>Update the privacy policy page + the pinned <code>manifest.description</code> / listing copy.</li>
+<li>Add a build-time check (optional but wise) asserting no secret-looking strings (private keys) leaked into <code>dist/</code> before zipping — a grep guard in <code>package-extension.mjs</code>.</li>
+</ul>
+
+<h2>One build (runtime-gated) vs separate Free/Pro builds</h2>
+<div class="takeaway"><div class="takeaway-label">RECOMMENDATION</div> ONE build, entitlement-gated at runtime. Strongly.</div>
+<p>Reasoning grounded in the current pipeline:</p>
+<ol>
+<li><strong>The pipeline is architecturally single-artifact.</strong> Versioning (<code>check-version-sync</code>, <code>prepare-release</code>), packaging (<code>package-extension.mjs</code> reads one <code>dist/manifest.json</code>, produces one <code>totem-v&lt;version&gt;.zip</code>), the release workflow (uploads <code>release/*.zip</code>, validates one tag&harr;manifest version), and the featured-readiness verifier (pins one manifest) all assume exactly one artifact. A second "Pro" build would mean forking version sync, doubling the zip step, duplicating the manifest pin, and managing two CWS listings — a large pipeline rewrite for no user benefit.</li>
+<li><strong>CWS distributes one item.</strong> A free-on-store extension that unlocks Pro is the standard, frictionless model: one listing, one review, one ID (<code>acpkgdfhoaalmnhjifhneghcgfnjkglo</code>, pinned in the verifier). Separate builds imply either two store items (more review surface, confusing) or sideloaded Pro builds (kills the "install from the Web Store" UX and breaks auto-update).</li>
+<li><strong>The gating surface already exists locally.</strong> State lives in Zustand + <code>chrome.storage.local</code> and IndexedDB. An entitlement flag (<code>isPro</code>) fits naturally as another stored value, checked at the boundaries of the Pro features. The Pro-gated capabilities are already discrete modules — export lives entirely in <code>src/lib/export/*</code> (e.g. <code>quick-export.ts</code>, <code>tweet-export.ts</code>, <code>stream-zip.ts</code>, <code>article-to-markdown.ts</code>), so gating is a small set of guard checks, not a build-time code split. There is no per-build code difference to justify two artifacts.</li>
+<li><strong>No secret needs to differ per build.</strong> The license check is an <strong>online validate</strong> call that needs no client-side secret (the provider's secret key stays server-side), so both free and pro users run identical code; the only difference is whether a valid, validated license is cached in storage. Code is identical, entitlement is data.</li>
+<li><strong>Optional-permission hygiene reinforces one build.</strong> With <code>optional_host_permissions</code> for the verify origin, the default install is byte-identical in footprint to today's free experience; the payment host is only requested when a user upgrades. One manifest, one build, graceful free path.</li>
+</ol>
+<div class="callout"><strong>Net:</strong> ship one zip; add an <code>isPro</code> entitlement resolved from a cached online-validate result; gate <code>src/lib/export/*</code> (and the other Pro modules) behind it; do not fork the build/release pipeline.</div>
+
+<h2>Concrete change checklist (if/when implemented)</h2>
+<table>
+<thead><tr><th>File / target</th><th>Change</th></tr></thead>
+<tbody>
+<tr><td><code>vite.config.ts</code></td><td>Add <code>__TOTEM_LICENSE_VALIDATE_URL__</code> (+ publishable product/store id) to <code>define</code> (or just commit a constant — these are public; no secret).</td></tr>
+<tr><td><code>src/vite-env.d.ts</code></td><td>Declare the new global.</td></tr>
+<tr><td><code>public/manifest.json</code></td><td>Add verify origin to <code>optional_host_permissions</code> (preferred) or <code>host_permissions</code>; add explicit <code>connect-src 'self' https://x.com https://api.usetotem.xyz</code> to the CSP; reword <code>description</code> away from "no server".</td></tr>
+<tr><td><code>scripts/verify-cws-featured-readiness.mjs</code></td><td>Loosen the manifest pins to permit the new host/permission and the new description string.</td></tr>
+<tr><td><code>PUBLISH.md</code> + <code>plans/chrome-web-store-dashboard-update-packet.md</code></td><td>Add permission justification + privacy disclosure for license validation.</td></tr>
+<tr><td><code>usetotem.xyz/privacy/</code></td><td>Document the license-key data flow.</td></tr>
+<tr><td><code>scripts/package-extension.mjs</code></td><td>(optional) Add a guard grepping <code>dist/</code> for private-key patterns before zipping.</td></tr>
+<tr><td>Dependency</td><td><strong>None.</strong> Online validate is a plain <code>fetch</code> — no on-device crypto, so <code>@noble/ed25519</code> is not added.</td></tr>
+</tbody>
+</table>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix · Codebase Research</div>
+  <h1>Appendix D · Site &amp; Distribution</h1>
+<p class="lead">The marketing site at <code>apps/site/</code> is a 100% static Astro build deployed to Vercel with no adapter and no server runtime. As shipped it cannot host a license-issuing or verification endpoint — the funnel must lean on a merchant-of-record while the site stays pure static.</p>
+
+<h2>Site architecture, build, and deploy</h2>
+
+<p>The Astro config at <code>apps/site/astro.config.mjs</code> sets <code>site: "https://usetotem.xyz"</code>, <span class="hl"><code>output: "static"</code> (line 10)</span>, <code>outDir: "../../dist-website"</code> (line 11), <code>trailingSlash: "ignore"</code>, <code>build.format: "directory"</code>, and <code>build.assets: "assets"</code>. Integrations are <code>@astrojs/react</code> (React 19 islands), <code>@astrojs/sitemap</code> (with a <code>filter</code>/<code>serialize</code> that excludes <code>/uninstall-feedback/</code> and sets per-page <code>changefreq</code>/<code>priority</code>), and <code>@tailwindcss/vite</code>. The Markdown pipeline is <code>remark-gfm</code> plus a custom rehype plugin <code>rehypeBlogLinks</code> (see the SEO section), footnotes labeled "Sources", and <code>smartypants: true</code>.</p>
+
+<div class="callout"><strong>No Astro adapter is configured and none is installed.</strong> <code>find src/pages -name "*.ts" -o -name "*.js"</code> returns nothing (no Astro endpoints / API routes); <code>node_modules/@astrojs/vercel</code> is absent; there is no <code>middleware.*</code> file. This is a pure static-site-generator setup.</p></div>
+
+<p>The package <code>apps/site/package.json</code> is named <code>@totem/site</code>, with deps <code>astro ^5.18.2</code>, <code>@astrojs/react ^4.4.2</code>, <code>@astrojs/sitemap</code>, <code>tailwindcss v4</code>, <code>remark-gfm</code>, and <code>unist-util-visit</code>. Scripts: <code>dev</code> / <code>build</code> / <code>preview</code> / <code>check</code> (<code>astro check</code>). It is a workspace package; the root <code>package.json</code> drives it via <code>pnpm build:website</code> (<code>pnpm --filter @totem/site build</code>) and <code>pnpm package:website</code>.</p>
+
+<h3>How pages are authored</h3>
+
+<p>Two patterns live under <code>apps/site/src/pages/</code>. The first is <strong>Astro pages wrapping a shared layout</strong>, each importing <code>BaseLayout.astro</code> and passing SEO props:</p>
+
+<ul>
+<li><code>index.astro</code> — landing; reads root <code>package.json</code> version, pulls 3 recent blog posts via <code>getCollection("blog")</code>, injects <code>SoftwareApplication</code> JSON-LD (currently <code>offers.price: "0"</code>, <code>isAccessibleForFree: true</code> — this JSON-LD will need updating when a paid tier ships), and renders the <code>&lt;LandingPage&gt;</code> React island.</li>
+<li><code>privacy.astro</code> → <code>&lt;PrivacyPage&gt;</code> island; <code>how-it-works.astro</code>; <code>demo.astro</code> → <code>&lt;DemoNewTabApp client:only="react"&gt;</code> with <code>showChrome={false}</code>.</li>
+<li><code>export-format/v1.astro</code> — a fully hand-authored long-form HTML doc page (no React island). <strong>This is the best template to copy for a new <code>/pricing</code> or <code>/manage-license</code> static content page</strong> — it shows the prose/article pattern, the in-page TOC, and <code>BaseLayout</code> SEO wiring.</li>
+<li><code>uninstall-feedback.astro</code> — <strong>the closest existing precedent for a "form" page.</strong> It is a static page with a <code>&lt;form&gt;</code>, a client <code>&lt;script&gt;</code> that assembles a <code>mailto:</code>/Gmail compose URL, and <code>robots="noindex, follow"</code>. It demonstrates an interactive page with no backend (everything client-side or handed off to an external service). A "paste your license key" page would follow exactly this shape.</li>
+</ul>
+
+<p>The second pattern is <strong>content collections</strong> for the blog: <code>src/content.config.ts</code> defines a <code>blog</code> collection via <code>glob({ pattern: "**/*.md", base: "./src/content/blog" })</code> with a Zod schema (<code>title</code>, <code>slug?</code>, <code>description</code>, <code>publishedAt?</code>, <code>draft?</code>, <code>canonicalKeyword?</code>). Markdown files live in <code>src/content/blog/*.md</code> and render through <code>src/pages/blog/[slug].astro</code> (<code>getStaticPaths</code> + <code>render(post)</code>), plus <code>src/pages/blog/index.astro</code> for the list.</p>
+
+<h3>Layout &amp; shared chrome</h3>
+
+<p><code>src/layouts/BaseLayout.astro</code> is the single SEO/HTML shell. Props: <code>title</code>, <code>description</code>, <code>canonical</code>, <code>og</code>, <code>twitter</code>, <code>spaceGrotesk</code>, <code>embedGuardGa</code>, <code>showChrome</code>, <code>page</code>, <code>bodyClass</code>, <code>robots</code>. It renders <code>&lt;head&gt;</code> (fonts via Google Fonts, canonical, OG/Twitter, Organization+WebSite JSON-LD), then conditionally wraps content with <code>SiteHeader</code> + <code>SiteFooter</code> when <code>showChrome</code> is true. It also inlines the Google Analytics (gtag <code>G-VBKV6TVM6W</code>) loader — an <code>embedGuardGa</code> variant suppresses GA inside iframes/<code>?embed</code>.</p>
+
+<p>Under <code>src/components/</code> sit <code>SiteHeader.astro</code>, <code>SiteFooter.astro</code>, <code>Favicon.astro</code>, and <code>BlogPostCta.astro</code>. The header/footer pull all copy and links from <code>src/react/site-content.ts</code>. React islands live in <code>src/react/SiteApp.tsx</code> (exports <code>LandingPage</code>, <code>PrivacyPage</code>, <code>HowItWorksPage</code>) and <code>src/react/demo/</code>. Site copy/config is centralized in <span class="hl"><code>src/react/site-content.ts</code></span> — the single source of truth for <code>SITE_LINKS</code>, <code>SITE_COPY</code>, install URLs, and feature blurbs.</p>
+
+<h3>Build &amp; deploy on Vercel</h3>
+
+<p><code>vercel.json</code> at the repo root sets <code>framework: "astro"</code>, <code>installCommand: "pnpm install --frozen-lockfile"</code>, <strong><code>buildCommand: "pnpm build:website"</code></strong>, <strong><code>outputDirectory: "dist-website"</code></strong>, <code>cleanUrls: true</code>, and <code>trailingSlash: false</code>. There is one redirect: <code>/website/:path*</code> → <code>/:path*</code> (temporary).</p>
+
+<p>Because <code>output: "static"</code> plus no adapter, Vercel serves <code>dist-website/</code> as <strong>static files on the CDN only</strong>. There is no Vercel Functions deployment from this project today. The <code>cleanUrls</code>/redirects/headers in <code>vercel.json</code> are the only "server-ish" config, and they are edge/CDN config, not compute.</p>
+
+<div class="takeaway"><div class="takeaway-label">STATIC-SITE CONSTRAINT</div> The site can serve static HTML/CSS/JS and CDN-level redirects, but it cannot run server endpoints or Vercel Functions as configured. To host a license endpoint <em>here</em> you would need to <code>npm i @astrojs/vercel</code>, set <code>output: "server"</code> or <code>"hybrid"</code>, add <code>adapter: vercel()</code>, and write Astro endpoints under <code>src/pages/api/*.ts</code> — introducing a server runtime, secrets management (signing key), and a DB/KV for license records, which breaks "no Totem server" purity.</div>
+
+<p>The recommended alternative is a <span class="hl">merchant-of-record SaaS</span> (Gumroad / Lemon Squeezy / Polar) that issues and verifies license keys via <em>their</em> API/webhooks, leaving this site static. License <em>verification</em> in the extension can then be a stateless signed-token check or a call to the MoR's verify API from the extension itself.</p>
+
+<h2>Where the purchase-funnel pages live</h2>
+
+<p>All new pages slot into <code>apps/site/src/pages/</code> and reuse <code>BaseLayout.astro</code> + <code>SiteHeader</code>/<code>SiteFooter</code>. Concrete placement:</p>
+
+<table>
+<thead><tr><th>Page</th><th>File &amp; path</th><th>Reuse / template</th></tr></thead>
+<tbody>
+<tr><td><strong>Pricing</strong></td><td><code>src/pages/pricing.astro</code> → <code>/pricing</code></td><td>New React island in <code>SiteApp.tsx</code> <em>or</em> hand-authored like <code>export-format/v1.astro</code>. Add <code>"pricing"</code> to the <code>SitePageKey</code> union in <code>BaseLayout.astro</code> and the <code>page</code> prop type in <code>SiteHeader.astro</code>/<code>SiteFooter.astro</code>. Add a nav link in <code>SiteFooter.astro</code> (and header CTA copy in <code>site-content.ts</code>).</td></tr>
+<tr><td><strong>Checkout entry</strong></td><td>Usually not a page</td><td>The "Buy" button links out to the MoR hosted checkout (Gumroad/Lemon Squeezy/Polar overlay or hosted page). The button lives on <code>pricing.astro</code> (and optionally a CTA in <code>BlogPostCta.astro</code>). If an overlay widget is used, it is a <code>&lt;script&gt;</code> island on <code>pricing.astro</code>.</td></tr>
+<tr><td><strong>Post-purchase / license delivery</strong></td><td><code>src/pages/upgrade/success.astro</code> → <code>/upgrade/success</code></td><td>Set <code>robots="noindex, follow"</code> like <code>uninstall-feedback.astro</code>. The MoR's <code>success_url</code> redirects here with the license key/token in the query string; a client <code>&lt;script&gt;</code> reads <code>location.search</code>, displays the key, offers "copy" and a deep-link button back into the extension. Pure client-side — no backend.</td></tr>
+<tr><td><strong>Manage license</strong></td><td><code>src/pages/manage-license.astro</code> → <code>/manage-license</code> (or <code>/license</code>)</td><td>Static page with a "paste your key" form + "verify"/"check status" that calls the MoR verify API client-side (or links to the MoR's customer portal). Pattern mirrors <code>uninstall-feedback.astro</code> (static page + client <code>&lt;script&gt;</code>, no server).</td></tr>
+</tbody>
+</table>
+
+<p>Components and layouts to reuse directly:</p>
+
+<ul>
+<li><code>BaseLayout.astro</code> for every page (SEO, OG, GA, header/footer).</li>
+<li><code>BlogPostCta.astro</code> is the model for a reusable "Upgrade to Pro" CTA card — it already does UTM-decorated CTA URLs derived from <code>SITE_LINKS.installUrl</code>.</li>
+<li><code>uninstall-feedback.astro</code> for any <strong>form + client-script, no-backend</strong> page (success page, paste-a-key page).</li>
+<li><code>export-format/v1.astro</code> for <strong>long-form static content</strong> (a detailed pricing/FAQ/feature-comparison page).</li>
+<li>Centralize all new URLs (checkout URL, success URL, manage URL, MoR product IDs) in <code>src/react/site-content.ts</code> under <code>SITE_LINKS</code>, matching the existing <code>chromeWebStoreInstallUrl</code>/<code>installUrl</code> pattern.</li>
+</ul>
+
+<h2>Extension ↔ site handoff</h2>
+
+<h3>What exists today (one-directional, marketing-only)</h3>
+
+<p><strong>Site → extension (install):</strong> Everything funnels to the Chrome Web Store. <code>site-content.ts</code> defines <code>chromeWebStoreListingUrl = https://chromewebstore.google.com/detail/acpkgdfhoaalmnhjifhneghcgfnjkglo</code> and <code>chromeWebStoreInstallUrl</code> = that listing + <code>?utm_source=usetotem.xyz&amp;utm_medium=referral&amp;utm_campaign=site_install</code>. <code>installUrl</code> resolves to the CWS install URL (falling back to <code>github.com/nnnkit/totem/releases/latest</code> only if the CWS URL were empty). The header, footer, landing CTAs, and <code>BlogPostCta.astro</code> all link to <code>installUrl</code> with <code>target="_blank"</code>.</p>
+
+<p><strong>Extension → site (only two hard-coded links):</strong></p>
+<ul>
+<li><code>src/lib/constants/growth.ts</code>: <code>PRIVACY_POLICY_URL = https://usetotem.xyz/privacy</code> (rendered in <code>OnboardingModal.tsx</code>), and <code>UNINSTALL_FEEDBACK_URL = https://usetotem.xyz/uninstall-feedback?utm_source=extension&amp;utm_medium=uninstall&amp;utm_campaign=feedback</code>. The uninstall URL is wired via <code>chrome.runtime.setUninstallURL(...)</code> in <code>src/service-worker/index.ts</code> (<code>configureUninstallFeedback</code>, called from <code>registerReleaseFoundationHooks</code>).</li>
+<li><code>src/lib/export/quick-export.ts</code> embeds <code>https://usetotem.xyz/export-format/v1</code> as a doc link inside exported ZIPs.</li>
+</ul>
+
+<p><strong>Install-time behavior:</strong> On <code>chrome.runtime.onInstalled</code> with <code>reason === "install"</code>, the service worker opens an in-extension tab (<code>newtab.html?utm_source=extension&amp;utm_medium=oninstall&amp;utm_campaign=first_launch</code>), <strong>not</strong> the marketing site (<code>openFirstLaunchTab</code> in <code>src/service-worker/index.ts</code>). So there is no existing "open the site from the extension" deep-link beyond privacy/uninstall.</p>
+
+<div class="callout">There is currently <strong>no <code>pricing</code>, <code>license</code>, <code>upgrade</code>, <code>checkout</code>, or payment-provider reference anywhere</strong> in <code>src/</code> or <code>apps/site/src/</code> (confirmed by grep). The only <code>premium_*</code> hit is <code>premium_content_api_read_enabled: false</code> in <code>api-proxy.ts</code>, an X GraphQL feature flag unrelated to Totem monetization. <span class="tag">GREENFIELD</span></div>
+
+<h3>Wiring "upgrade in extension → checkout on site → license back to extension"</h3>
+
+<p>There is no extension custom URL scheme today, so the handoff must use standard web URLs plus a paste-key fallback. Recommended flow:</p>
+
+<ol>
+<li><strong>Upgrade entry (extension):</strong> An "Upgrade to Pro" button in the new-tab UI / settings calls <code>chrome.tabs.create({ url: PRICING_URL })</code> where <code>PRICING_URL = https://usetotem.xyz/pricing?utm_source=extension&amp;utm_medium=upgrade&amp;utm_campaign=pro</code> (add to <code>growth.ts</code>, mirroring <code>UNINSTALL_FEEDBACK_URL</code>). Optionally append the extension's stable install id / a nonce as a query param so the success page can build a return deep link.</li>
+<li><strong>Checkout (site → MoR):</strong> The <code>/pricing</code> "Buy" button opens the MoR hosted checkout. MoR handles payment, tax (merchant-of-record), and license-key generation — no Totem server required.</li>
+<li><strong>License delivery (MoR → site success page):</strong> Configure the MoR <code>success_url = https://usetotem.xyz/upgrade/success</code>. The MoR appends the license key (or order token) to the redirect. The static success page (<code>src/pages/upgrade/success.astro</code>, <code>noindex</code>) reads <code>location.search</code> client-side and shows the key + copy button.</li>
+<li><strong>Return to extension — three layered mechanisms, in preference order:</strong>
+<ul>
+<li><strong>(a) <code>chrome.runtime.sendMessage(EXTENSION_ID, {type:"TOTEM_LICENSE", key})</code> from the web page</strong> — requires adding <code>externally_connectable</code> (with <code>matches: ["https://usetotem.xyz/*"]</code>) to the extension manifest and an <code>onMessageExternal</code> handler. Cleanest one-click activation; the success page JS posts the key straight into the extension.</li>
+<li><strong>(b) Deep-link button</strong> <code>chrome-extension://&lt;id&gt;/newtab.html?license=&lt;key&gt;</code> (or a custom action) that the success page renders; the new-tab boot reads <code>?license=</code> and stores/validates it. Works without <code>externally_connectable</code> but exposes the key in a URL.</li>
+<li><strong>(c) Paste-a-key fallback (always ship this):</strong> a field in extension Settings + the <code>/manage-license</code> page where the user pastes the key manually. The robust, no-coupling path, mirroring the existing <code>uninstall-feedback.astro</code> "static page + client script, no backend" pattern.</li>
+</ul></li>
+<li><strong>Verification (extension):</strong> The service worker calls the MoR's license <strong>validate</strong> API directly (a public, no-secret data call) once at activation, then stores the unlocked state in <code>chrome.storage.local</code> alongside existing runtime/auth keys and reads it locally thereafter, re-checking in the background with fail-open. No Totem backend in the loop — the MoR is the only server, and only the key + email + a device id are sent.</li>
+</ol>
+
+<div class="takeaway"><div class="takeaway-label">MANIFEST NOTE</div> Whichever of (a)/(b) is chosen, the work is on the <strong>extension side</strong> (manifest <code>externally_connectable</code> and/or an <code>onMessageExternal</code>/URL-param handler). The site side stays static — the success/manage pages are ordinary Astro static pages with client <code>&lt;script&gt;</code> glue.</div>
+
+<h2>SEO / UTM / ref decoration the funnel must preserve</h2>
+
+<p>The site already has a consistent attribution scheme; a purchase funnel must not strip it.</p>
+
+<p>The <strong>blog link rehype plugin</strong> at <code>apps/site/src/lib/rehype-blog-links.mjs</code> (registered in <code>astro.config.mjs</code>) rewrites every <code>&lt;a&gt;</code> in blog Markdown at build time:</p>
+<ul>
+<li><strong>Internal links</strong> to <code>usetotem.xyz</code> / <code>www.usetotem.xyz</code> get <code>utm_source=blog</code>, <code>utm_medium=referral</code>, <code>utm_campaign=blog_post</code>, and <code>utm_content=&lt;post-slug&gt;</code>. <strong>Important for the funnel:</strong> a "Buy/Upgrade" link in a blog post pointing at <code>/pricing</code> is auto-decorated with these blog UTMs — desirable, keep it.</li>
+<li><strong>External links</strong> (non-Totem hosts) get <code>utm_source=usetotem.xyz</code>, <code>utm_medium=referral</code>, <code>utm_campaign=blog</code>, <strong>and <code>ref=usetotem.xyz</code></strong>, plus <code>target="_blank"</code> + <code>rel="noopener noreferrer"</code>. The MoR checkout domain (e.g. <code>gumroad.com</code>) is external, so blog links to it are decorated this way automatically.</li>
+</ul>
+
+<p><strong>Hand-built CTA UTM derivation:</strong> <code>BlogPostCta.astro</code> takes the base <code>installUrl</code> and rewrites <code>utm_campaign=site_install</code> → <code>utm_campaign=blog_post_cta&amp;utm_content=&lt;slug&gt;</code>. A Pro CTA card should follow the same derive-from-base pattern so campaigns stay attributable.</p>
+
+<p><strong>Install URL canonical params:</strong> <code>chromeWebStoreInstallUrl</code> carries <code>utm_source=usetotem.xyz&amp;utm_medium=referral&amp;utm_campaign=site_install</code>. Any new "Upgrade" link from the site should use a parallel campaign (e.g. <code>utm_campaign=pricing</code> / <code>pro_upgrade</code>) so funnel analytics separate install vs upgrade.</p>
+
+<p><strong>Extension-originated UTMs:</strong> extension→site links already tag <code>utm_source=extension</code> (<code>utm_medium=uninstall|oninstall|upgrade</code>). Keep the <code>utm_source=extension&amp;utm_medium=upgrade&amp;utm_campaign=pro</code> convention for the new pricing deep-link so in-extension conversions are distinguishable from organic.</p>
+
+<p><strong>Analytics:</strong> GA4 (<code>G-VBKV6TVM6W</code>) is loaded in <code>BaseLayout.astro</code> for every page, so <code>/pricing</code> and <code>/upgrade/success</code> get pageview tracking for free; the funnel should set up GA events/conversions on the success page. (Per the project's local-first stance, GA is on the marketing site, not the extension.)</p>
+
+<p><strong>Sitemap:</strong> the <code>astro.config.mjs</code> sitemap <code>filter</code> excludes <code>/uninstall-feedback/</code>. The <span class="hl"><code>/upgrade/success</code> page should likewise be excluded</span> (and <code>noindex</code>); <code>/pricing</code> should be included (a real indexable page) and will inherit the default <code>priority: 0.8, changefreq: monthly</code>.</p>
+
+<p><strong>Structured data caveat:</strong> <code>index.astro</code>'s <code>SoftwareApplication</code> JSON-LD currently declares <code>offers.price: "0"</code> / <code>isAccessibleForFree: true</code>. When Pro ships, update this (or add an <code>offers</code> array reflecting the free + $19 lifetime tiers) to keep rich-result data truthful.</p>
+
+<h2>Key file references</h2>
+
+<table class="compact striped">
+<thead><tr><th>File</th><th>Role</th></tr></thead>
+<tbody>
+<tr><td><code>apps/site/astro.config.mjs</code></td><td>Static output, no adapter, markdown pipeline, sitemap filter.</td></tr>
+<tr><td><code>vercel.json</code> (repo root)</td><td>Vercel build/output config, <code>cleanUrls</code>, redirects (CDN-only, no functions).</td></tr>
+<tr><td><code>apps/site/src/layouts/BaseLayout.astro</code></td><td>Shared SEO/HTML shell + GA; add <code>pricing</code> to <code>SitePageKey</code>.</td></tr>
+<tr><td><code>apps/site/src/react/site-content.ts</code></td><td><code>SITE_LINKS</code> / <code>SITE_COPY</code>, install URLs (add checkout/license URLs here).</td></tr>
+<tr><td><code>apps/site/src/pages/uninstall-feedback.astro</code></td><td>Template for a no-backend form/paste-key page.</td></tr>
+<tr><td><code>apps/site/src/pages/export-format/v1.astro</code></td><td>Template for a long-form static content page.</td></tr>
+<tr><td><code>apps/site/src/components/BlogPostCta.astro</code></td><td>UTM-derived CTA card model.</td></tr>
+<tr><td><code>apps/site/src/lib/rehype-blog-links.mjs</code></td><td>Build-time UTM/<code>ref</code> link decoration (internal + external).</td></tr>
+<tr><td><code>apps/site/src/content.config.ts</code> + <code>src/pages/blog/[slug].astro</code></td><td>Content-collection authoring.</td></tr>
+<tr><td><code>src/lib/constants/growth.ts</code></td><td>Extension's hard-coded site URLs (<code>PRIVACY_POLICY_URL</code>, <code>UNINSTALL_FEEDBACK_URL</code>); add <code>PRICING_URL</code> here.</td></tr>
+<tr><td><code>src/service-worker/index.ts</code></td><td><code>setUninstallURL</code>, <code>onInstalled</code> first-launch tab (opens in-extension newtab, not site), <code>chrome.tabs.create</code> usage; site of any future <code>onMessageExternal</code>/license handoff handler.</td></tr>
+</tbody>
+</table>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix · Codebase Research</div>
+  <h1>Appendix E · UI State &amp; Upsell Surfaces</h1>
+<p class="lead">How to model an <code>isPro</code> entitlement and where to mount Pro upsell UI, grounded entirely in existing Totem patterns. All paths relative to repo root <code>/Users/ankit/Documents/make/totem</code>.</p>
+
+<p>There is currently <strong>no</strong> pro / entitlement / premium / license / paywall code in <code>src/</code>. A grep for <code>isPro|entitlement|premium|license|upgrade|paywall|lifetime|gumroad|founders</code> returns only unrelated hits: <code>capability upgrade</code> in runtime-store tests, an IDB <code>upgrade()</code> migration callback, and a Twitter feature flag <code>premium_content_api_read_enabled</code> in <code>src/service-worker/api-proxy.ts:62</code>. This is a <span class="hl">greenfield surface</span>.</p>
+
+<h2>The existing pattern for a boolean user preference / flag</h2>
+
+<p>There are <strong>two</strong> established persistence patterns. They differ on storage area and on whether the SW owns the value. For <code>isPro</code> we want the <strong>preference pattern</strong>, not the runtime-snapshot pattern.</p>
+
+<h3>Pattern A — Synced user preference (chrome.storage.sync) — the cleanest analog</h3>
+
+<p>This is the model <code>useSettings</code>/<code>useTheme</code> use, and it is the <strong>closest analog to <code>isPro</code></strong>: a user-scoped flag, set rarely, that should follow the user across devices.</p>
+
+<ul>
+<li><strong>Where defined / shape:</strong> <code>src/types/index.ts:283</code> — <code>interface UserSettings { ... }</code> (all booleans like <code>showSearchBar</code>, <code>showOpenInTotem</code> live here). Defaults at <code>src/hooks/useSettings.ts:33</code> (<code>DEFAULT_SETTINGS</code>).</li>
+<li><strong>How persisted:</strong> <code>chrome.storage.sync</code>, under a single namespaced key. Keys are centralized in <code>src/lib/storage-keys.ts</code>:
+  <ul>
+  <li><code>SYNC_SETTINGS = "totem_settings"</code> (<code>storage-keys.ts:70</code>)</li>
+  <li><code>SYNC_THEME = "totem_theme"</code> (<code>storage-keys.ts:71</code>)</li>
+  <li>both enumerated in <code>CHROME_SYNC_KEYS</code> (<code>storage-keys.ts:73</code>)</li>
+  <li>legacy key remap in <code>LEGACY_CHROME_SYNC_KEY_MAP</code> (<code>storage-keys.ts:115</code>)</li>
+  </ul>
+</li>
+<li><strong>How read reactively in components:</strong> a hook with three effects (see <code>src/hooks/useSettings.ts:93-148</code> and the near-identical <code>src/hooks/useTheme.ts:23-106</code>):
+  <ol>
+  <li><code>useState</code> seeded with a hardcoded default.</li>
+  <li>Load-once effect: guard <code>hasChromeStorageSync()</code> (<code>src/lib/chrome.ts:1</code>), then <code>chrome.storage.sync.get({ [KEY]: DEFAULT })</code>, normalize, <code>setState</code>.</li>
+  <li>Cross-context reactivity effect: guard <code>hasChromeStorageOnChanged()</code> (<code>src/lib/chrome.ts:5</code>), subscribe to <code>chrome.storage.onChanged</code>, filter <code>areaName === "sync"</code> and the specific key, re-normalize <code>change.newValue</code>. This is what makes the flag update live across the new-tab page, reader route, and any other open Totem surface without a reload.</li>
+  <li>An <code>updateX</code> setter that optimistically <code>setState</code>s and writes <code>chrome.storage.sync.set({ [KEY]: next })</code> (fire-and-forget <code>.catch(() =&gt; {})</code>).</li>
+  </ol>
+</li>
+<li><strong>Normalization discipline:</strong> every loader runs a <code>normalizeX(value: unknown)</code> pass (<code>useSettings.ts:45</code>, <code>useTheme.ts:17</code>) so a malformed/old stored value can never crash a render. Any <code>isPro</code> reader must do the same.</li>
+<li><strong>Consumed in components:</strong> <code>useSettings()</code> is called once high in the tree (<code>src/App.tsx:411</code> in <code>NewTabRouteApp</code>, <code>src/App.tsx:751</code> in <code>ReaderRouteApp</code>) and the values are threaded down as props (e.g. <code>showSearchBar={settings.showSearchBar}</code> to <code>NewTabHome</code>, <code>src/App.tsx:672</code>). <code>useTheme()</code> is called at <code>App.tsx:410</code>.</li>
+</ul>
+
+<div class="callout"><strong>Storage-area tension for <code>isPro</code>:</strong> <code>chrome.storage.sync</code> is the right <em>ergonomic</em> analog, but it is trivially user-editable and synced by Google, so it is appropriate for an <strong>optimistic UX flag</strong> only. The authoritative entitlement check (license validation) must live behind a verification step, not be trusted purely from synced storage. See the recommended split below: cached flag in storage + verify-on-load.</div>
+
+<h3>Pattern B — One-time / lifecycle growth flags (chrome.storage.local)</h3>
+
+<p><code>src/lib/growth-state.ts</code> is the analog for <strong>"show this once, then never again"</strong> gating — directly relevant to a one-time post-install Pro nudge.</p>
+
+<ul>
+<li><strong>Shape:</strong> <code>interface GrowthState</code> (<code>growth-state.ts:18</code>) with nested <code>onboarding</code>, <code>activation</code>, <code>review</code> namespaces, each holding <code>*At: number | null</code> timestamps (the "set once" idiom: <code>x ?? now</code>, e.g. <code>growth-state.ts:316</code>).</li>
+<li><strong>Persisted:</strong> <code>chrome.storage.local</code> under <code>CS_GROWTH_STATE = "totem_growth_state"</code> (<code>storage-keys.ts:45</code>). Local (not sync) because it's device-lifecycle state.</li>
+<li><strong>Access:</strong> module-level async functions, not a hook. <code>readGrowthState()</code> (<code>growth-state.ts:256</code>) and <code>mutateGrowthState(mutator)</code> (<code>growth-state.ts:244</code>), which does read → mutate → <code>chrome.storage.local.set</code>. Pure reducers (<code>applyBookmarksSynced</code>, <code>applyReaderOpen</code>) and pure predicates (<code>shouldShowReviewPrompt:205</code>, <code>shouldShowOnboarding:213</code>, <code>shouldShowReengagementNudge:227</code>) are exported and unit-tested independently (<code>src/lib/__tests__/growth-state.test.ts</code>).</li>
+<li><strong>Wired into UI imperatively from <code>App.tsx</code>:</strong> e.g. review prompt at <code>App.tsx:805-813</code> (<code>recordReaderOpen → shouldShowReviewPrompt → markReviewPrompted → setState visible</code>), reengagement at <code>App.tsx:614-639</code>. The mark/dismiss handlers sit at <code>App.tsx:928-936</code> and <code>App.tsx:641-650</code>.</li>
+</ul>
+
+<h3>Recommendation for the isPro flag</h3>
+
+<p>Model the <strong>cached</strong> entitlement exactly like <code>useTheme</code> (the simplest single-value hook): one synced key, one normalize function, three effects, one setter. Model the <strong>"have we shown the upsell" / "license verified at"</strong> bookkeeping like <code>growth-state.ts</code> (local, set-once timestamps). Concretely:</p>
+
+<ul>
+<li>Add <code>SYNC_PRO = "totem_pro"</code> to <code>src/lib/storage-keys.ts</code> and to <code>CHROME_SYNC_KEYS</code>.</li>
+<li>Add an entitlement type to <code>src/types/index.ts</code> (e.g. <code>interface ProEntitlement { status: "free" | "pro"; licenseKey: string | null; unlockedAt: number | null; verifiedAt: number | null; }</code>).</li>
+<li>New hook <code>src/hooks/usePro.ts</code> mirroring <code>useTheme.ts</code> line-for-line.</li>
+</ul>
+
+<h2>Reusable Dialog/Modal primitives + the modal template</h2>
+
+<h3>The shared Modal wrapper (use this — do not hand-roll Base UI)</h3>
+
+<p><code>src/components/ui/Modal.tsx</code> wraps <code>@base-ui/react/dialog</code> (<code>Dialog.Root</code> / <code>Dialog.Portal</code> / <code>Dialog.Backdrop</code> / <code>Dialog.Popup</code>) into one component. It already handles: portal, backdrop (<code>bg-black/50</code> passed via <code>className</code>), enter/leave animation via <code>data-[starting-style]</code>/<code>data-[ending-style]</code> (<code>Modal.tsx:47-53</code>), title header + close button (<code>Modal.tsx:59-84</code>), <code>aria-labelledby</code> wiring, backdrop-click and Escape-to-close (<code>onOpenChange</code>, <code>Modal.tsx:40</code>), and a <code>closeDisabled</code> lock for in-progress operations. Props: <code>open</code>, <code>onClose</code>, <code>title</code>, <code>titleId</code>, <code>panelClassName</code>, <code>bodyClassName</code>, <code>closeLabel</code>, <code>closeDisabled</code> (<code>Modal.tsx:7-19</code>).</p>
+
+<p>A Pro modal should pass <code>title="Upgrade to Totem Pro"</code>, <code>titleId="upgrade-title"</code>, <code>className="bg-black/50"</code>, and (optionally) <code>panelClassName="max-w-lg"</code>.</p>
+
+<h3>Best existing templates to clone</h3>
+
+<ul>
+<li><strong><code>src/components/OnboardingModal.tsx</code></strong> — the simplest, closest template for an upsell/paywall sheet: a <code>Modal</code> with prose blocks in bordered <code>rounded border border-border bg-surface</code> cards (<code>OnboardingModal.tsx:34-56</code>) and a right-aligned footer action row mixing <code>ghost</code> / <code>secondary</code> / primary <code>Button</code>s plus an <code>href</code> CTA (<code>OnboardingModal.tsx:71-81</code>). An "Upgrade to Pro" sheet is structurally this plus a feature-benefit list and a primary CTA <code>&lt;Button href={CHECKOUT_URL}&gt;</code>.</li>
+<li><strong><code>src/components/ExportModal.tsx</code></strong> — the template for a <strong>stateful</strong> modal with internal phases. It drives a <code>quickState</code> discriminated union (<code>{ phase: "idle" | "exporting" | "done" | "error" }</code>, <code>ExportModal.tsx:30-34</code>) and renders one of several sub-views (<code>IdleView</code>, <code>DoneView</code>, <code>ErrorView</code>, …) inside a single <code>&lt;Modal&gt;</code> (<code>ExportModal.tsx:105-162</code>). Reuse this if the upgrade flow needs states (e.g. <code>idle → enter-license → verifying → success/error</code>). The radio-card selection block (<code>ExportModal.tsx:200-289</code>) is a ready-made pattern if a pricing modal ever offers tiers (lifetime vs founders).</li>
+<li><strong><code>src/components/ImportModal.tsx</code></strong> — third example of the same stateful-modal idiom.</li>
+</ul>
+
+<h3>Supporting primitives available</h3>
+
+<ul>
+<li><code>src/components/ui/Button.tsx</code> — variants <code>primary | secondary | ghost | destructive | accent-soft</code> (<code>Button.tsx:4-11</code>); the <strong><code>accent-soft</code></strong> variant (<code>bg-accent-surface text-accent</code>) is the natural "Upgrade" CTA tint. Supports <code>href</code> (renders <code>&lt;a target="_blank"&gt;</code> for <code>https://</code> — ideal for an external checkout link, <code>Button.tsx:36-51</code>).</li>
+<li><code>src/components/ui/Badge.tsx</code> — variants <code>accent</code> (filled) and <code>muted</code> (<code>Badge.tsx:3-6</code>). The <code>accent</code> badge is the ready-made <strong>"PRO" lock badge</strong> for gated buttons.</li>
+<li><code>src/components/ui/Popover.tsx</code> (<code>PopoverContent</code> over <code>@base-ui/react/popover</code>) — for an inline "this is a Pro feature" tooltip/popover on a locked control.</li>
+<li><code>src/components/ui/Toast.tsx</code>, <code>Switch.tsx</code>, <code>Select.tsx</code>, <code>Separator.tsx</code> round out the kit.</li>
+</ul>
+
+<h2>Where UI upsell surfaces would mount</h2>
+
+<h3>(a) "Upgrade" entry in Settings — primary surface</h3>
+
+<p><code>src/components/SettingsModal.tsx</code> is a single <code>Modal</code> whose body is a stack of <code>&lt;section className="py-4 first:pt-0 last:pb-0"&gt;</code> blocks separated by <code>divide-y divide-border</code> (<code>SettingsModal.tsx:147</code>). Sections today: Appearance (149), Highlight/Open-in-Totem (193), New Tab (234), Storage (347).</p>
+
+<ul>
+<li><strong>Mount point:</strong> add a new <code>&lt;section&gt;</code> (e.g. "Totem Pro" as the first section, or a dedicated row at the top of Storage right above Export at <code>SettingsModal.tsx:374</code>, since Export/CSV/Markdown is the headline gated feature). Use the same label + sub-label + right-aligned <code>Button</code> row shape already used for Import/Export (<code>SettingsModal.tsx:352-394</code>).</li>
+<li>For a <strong>free</strong> user: a row "Totem Pro — Unlock export formats, deleted-tweet preservation, bulk ops" + an <code>accent-soft</code> <code>Button</code> "Upgrade" that calls a new <code>onOpenUpgrade()</code> prop. For a <strong>pro</strong> user: same row showing a <code>Badge variant="accent"</code> "PRO" and "Manage license".</li>
+<li><strong>Prop wiring:</strong> <code>SettingsModal</code> is fully prop-driven (<code>Props</code> at <code>SettingsModal.tsx:23-35</code>, callbacks like <code>onExport</code>/<code>onImport</code> threaded from <code>App.tsx:705-706</code>). Add <code>isPro: boolean</code> and <code>onOpenUpgrade: () =&gt; void</code> props, pass from <code>App.tsx:693-707</code> (right where <code>onExport</code>/<code>onImport</code> are passed).</li>
+</ul>
+
+<h3>(b) Lock badge on gated buttons + intercepted clicks</h3>
+
+<p>Gated actions and their exact mount points:</p>
+
+<ul>
+<li><strong>Export</strong> — two surfaces:
+  <ul>
+  <li>Settings row "Export your data" <code>Button</code> (<code>SettingsModal.tsx:383-394</code>). The sub-label already literally reads "Download your bookmarks as CSV, Markdown, and JSONL" (<code>SettingsModal.tsx:379</code>) — the headline Pro features. Render a <code>Badge variant="accent"&gt;PRO&lt;/Badge&gt;</code> next to the label and, when <code>!isPro</code>, have the button call <code>onOpenUpgrade()</code> instead of <code>onExport()</code>.</li>
+  <li>New-tab "full export ready" / export entry points in <code>NewTabHome.tsx</code> (the <code>onOpenExport</code> callback is threaded through <code>NewTabHome</code> props at <code>NewTabHome.tsx:93</code>, used at <code>:1331</code>, <code>:1446</code>, <code>:1493</code>). Gating belongs at the <code>onOpenExport</code> boundary in <code>App.tsx:708-719</code> (where <code>&lt;ExportModal&gt;</code> is wired): swap the handler to open the upgrade modal for free users, OR keep the ExportModal open and gate the <em>format</em> choices inside it (the radio cards at <code>ExportModal.tsx:200-289</code> are the place — e.g. "Markdown/CSV" marked PRO).</li>
+  </ul>
+</li>
+<li><strong>Settings header toolbar</strong> — the gear button lives in the new-tab header at <code>NewTabHome.tsx:1086-1095</code> (next to the Sync button <code>:1070-1085</code>). A small "Upgrade" pill or star icon-button could sit beside the gear here for an always-visible entry point. This <code>&lt;header&gt;</code>/toolbar (<code>NewTabHome.tsx:~1060-1097</code>) is the single most visible chrome on the new tab.</li>
+<li><strong>Reader gated features</strong> (annotations, advanced highlight options) — <code>BookmarkReader</code> is rendered at <code>App.tsx:945-978</code>; highlight color is already a prop (<code>defaultHighlightColor</code>, <code>App.tsx:967</code>). Lock badges for annotation/thread-capture features mount inside <code>src/components/reader/</code> controls.</li>
+</ul>
+
+<p>Implement gating with a <code>&lt;ProGate&gt;</code> wrapper so each call site stays a <span class="hl">one-line change</span> and the lock-badge + intercept logic isn't copy-pasted.</p>
+
+<h3>(c) One-time post-install nudge</h3>
+
+<p>Reuse the <code>growth-state.ts</code> set-once idiom and the existing dismissible-banner components verbatim:</p>
+
+<ul>
+<li><strong>Visual template:</strong> <code>src/components/ReviewPrompt.tsx</code> and <code>src/components/ReengagementNudge.tsx</code> — both are <code>fixed inset-x-0 bottom-5 z-40</code> bottom-center cards with a message, a primary action, and an <code>XIcon</code> dismiss button (<code>ReviewPrompt.tsx:9-37</code>, <code>ReengagementNudge.tsx:10-43</code>). A <code>ProNudge</code> would be a copy with copy like "Totem is free forever. Pro unlocks exports + deleted-tweet preservation — $19 lifetime."</li>
+<li><strong>Gating logic:</strong> add a <code>pro</code> namespace to <code>GrowthState</code> (<code>growth-state.ts:18</code>) with <code>nudgePromptedAt</code>/<code>nudgeDismissedAt</code> (mirror <code>review</code>/<code>activation</code> at <code>growth-state.ts:36-41</code>), a <code>shouldShowProNudge(state)</code> predicate next to <code>shouldShowReviewPrompt</code> (<code>growth-state.ts:205</code>), and <code>markProNudgePrompted/Dismissed</code> mirroring <code>growth-state.ts:320-357</code>. Gate on activation (<code>activatedAt !== null</code>) so it only fires for engaged users — never on day one.</li>
+<li><strong>Orchestration mount:</strong> the same <code>App.tsx</code> effect pattern used for review/reengagement (<code>App.tsx:614-639</code> for reengagement; <code>App.tsx:805-813</code> for review). Render the component conditionally next to <code>&lt;ReviewPrompt&gt;</code>/<code>&lt;ReengagementNudge&gt;</code> (<code>App.tsx:726-732</code> and <code>App.tsx:987-992</code>). Crucially, suppress when <code>isPro</code> is true.</li>
+</ul>
+
+<h3>(d) Banner</h3>
+
+<p>For a non-blocking persistent banner, <code>src/components/ui/OfflineBanner.tsx</code> is the in-repo banner pattern. Prefer (a)+(c) over a banner to avoid nagging; a banner is the weakest of the four and should be reserved for a time-boxed founders-price promo.</p>
+
+<h2>Proposed usePro() hook + &lt;ProGate&gt; component</h2>
+
+<p>Both live beside existing analogs and follow their conventions exactly.</p>
+
+<h3>src/hooks/usePro.ts — mirrors src/hooks/useTheme.ts</h3>
+
+<p>Rationale: entitlement is a single user-scoped value that should sync across devices and update live in every open surface — identical requirements to <code>useTheme</code>. Clone its three-effect structure (load-once, <code>onChanged</code> subscription, setter) and its <code>normalizeX(unknown)</code> discipline.</p>
+
+<pre><code>// src/hooks/usePro.ts  (shape only)
+import { useCallback, useEffect, useState } from "react";
+import { hasChromeStorageSync, hasChromeStorageOnChanged } from "../lib/chrome";
+import { SYNC_PRO } from "../lib/storage-keys";          // new key, added to CHROME_SYNC_KEYS
+import type { ProEntitlement } from "../types";          // new type in src/types/index.ts
+
+const DEFAULT_PRO: ProEntitlement = {
+  status: "free", licenseKey: null, unlockedAt: null, verifiedAt: null,
+};
+
+function normalizePro(value: unknown): ProEntitlement { /* same guard style as useTheme.ts:17 */ }
+
+export function usePro() {
+  const [entitlement, setEntitlement] = useState&lt;ProEntitlement&gt;(DEFAULT_PRO);
+
+  // effect 1: chrome.storage.sync.get({ [SYNC_PRO]: DEFAULT_PRO }) → normalize → setState
+  // effect 2: chrome.storage.onChanged (areaName === "sync", key SYNC_PRO) → setState
+  // (verification — license re-check — can be a 3rd effect or a service-worker call;
+  //  keep storage as the optimistic cache, verifiedAt as the trust timestamp.)
+
+  const setEntitlementValue = useCallback((next: ProEntitlement) =&gt; {
+    setEntitlement(next);
+    if (hasChromeStorageSync()) chrome.storage.sync.set({ [SYNC_PRO]: next }).catch(() =&gt; {});
+  }, []);
+
+  return { isPro: entitlement.status === "pro", entitlement, setEntitlement: setEntitlementValue };
+}</code></pre>
+
+<p>Naming note: the task allows <code>useEntitlement()</code>; given the repo's terse domain-named hooks (<code>useSettings</code>, <code>useTheme</code>, <code>useTodayQueue</code>), <strong><code>usePro()</code> returning <code>{ isPro }</code></strong> reads best at call sites. Optionally export a thin <code>useIsPro()</code> selector that returns the boolean only, matching the <code>useShallow</code>/selector ergonomics in <code>src/stores/selectors.ts</code>.</p>
+
+<p>Call it once high in the tree alongside <code>useSettings()</code>/<code>useTheme()</code> at <code>App.tsx:410-411</code> (in both <code>NewTabRouteApp</code> and <code>ReaderRouteApp</code>) and thread <code>isPro</code> down as a prop, exactly as <code>settings.*</code> is threaded today.</p>
+
+<div class="callout"><strong>Storage-area discipline:</strong> Do <strong>not</strong> put <code>isPro</code> in the Zustand <code>runtime-store</code>: that store is the SW-owned auth/sync snapshot (<code>RuntimeState</code>, <code>runtime-store.ts:154</code>) and the codebase deliberately keeps user <em>preferences</em> out of it (<code>storage-keys.ts:47-60</code> and the <code>storage-invariants.test.ts</code> guard).</div>
+
+<h3>&lt;ProGate&gt; — lives beside the gated UI, in src/components/</h3>
+
+<p>A small wrapper that renders children for Pro users, and for free users renders the locked affordance (a <code>Badge variant="accent"&gt;PRO&lt;/Badge&gt;</code> + intercepts click to open the upgrade modal). Keeps every call site a one-liner and centralizes the lock visuals.</p>
+
+<pre><code>// src/components/ProGate.tsx  (shape only; Badge from ui/Badge.tsx, accent variant)
+interface ProGateProps {
+  isPro: boolean;
+  onUpgrade: () =&gt; void;          // opens the Upgrade modal (App.tsx route state, §3a)
+  children: React.ReactNode;      // the real control when unlocked
+  lockedLabel?: string;           // e.g. "Pro feature"
+  showBadge?: boolean;            // render the PRO badge inline
+}
+// if isPro → return &lt;&gt;{children}&lt;/&gt;
+// else → render the same control visually but route onClick → onUpgrade, append &lt;Badge variant="accent"&gt;PRO&lt;/Badge&gt;</code></pre>
+
+<p>Two usage flavors, both already supported by the codebase:</p>
+
+<ol>
+<li><strong>Hard gate</strong> (replace action): wrap the Export button so a free user's click opens the upgrade modal instead of <code>onExport</code> — applied at <code>SettingsModal.tsx:383</code> and at the <code>onOpenExport</code> boundary in <code>App.tsx:708</code>.</li>
+<li><strong>Badge-only hint</strong> (<code>showBadge</code>): annotate a control that stays interactive but surfaces locked sub-options downstream (e.g. the export-format radio cards, <code>ExportModal.tsx:200-289</code>).</li>
+</ol>
+
+<p>The upgrade modal itself (<code>UpgradeModal.tsx</code>, cloned from <code>OnboardingModal.tsx</code>) is opened via the existing route-reducer pattern: add <code>upgradeOpen</code> to <code>NewTabRouteState</code> (<code>App.tsx:117-125</code>), an <code>onOpenUpgrade</code> setter, and render <code>&lt;UpgradeModal open={upgradeOpen} …/&gt;</code> next to <code>&lt;ExportModal&gt;</code>/<code>&lt;ImportModal&gt;</code> at <code>App.tsx:708-725</code>. This is the identical mechanism already used for settings/export/import modals — no new modal-management infrastructure is needed.</p>
+
+<h2>Summary of concrete files to add / touch</h2>
+
+<table class="striped">
+<thead><tr><th>Action</th><th>File</th></tr></thead>
+<tbody>
+<tr><td>Add <code>SYNC_PRO</code> key + add to <code>CHROME_SYNC_KEYS</code> + legacy map</td><td><code>src/lib/storage-keys.ts:70,73</code></td></tr>
+<tr><td>Add <code>ProEntitlement</code> type</td><td><code>src/types/index.ts</code> (beside <code>UserSettings:283</code>)</td></tr>
+<tr><td>New <code>usePro()</code> hook (clone <code>useTheme.ts</code>)</td><td><code>src/hooks/usePro.ts</code></td></tr>
+<tr><td>Extend growth state for one-time nudge (set-once idiom)</td><td><code>src/lib/growth-state.ts:18,205,320</code></td></tr>
+<tr><td>New <code>&lt;ProGate&gt;</code> wrapper</td><td><code>src/components/ProGate.tsx</code></td></tr>
+<tr><td>New <code>UpgradeModal</code> (clone <code>OnboardingModal.tsx</code>)</td><td><code>src/components/UpgradeModal.tsx</code></td></tr>
+<tr><td>New <code>ProNudge</code> banner (clone <code>ReviewPrompt.tsx</code>)</td><td><code>src/components/ProNudge.tsx</code></td></tr>
+<tr><td>Add Pro section + gate Export button</td><td><code>src/components/SettingsModal.tsx:374-394</code></td></tr>
+<tr><td>Call <code>usePro()</code>, add <code>upgradeOpen</code> route state, render modals/nudge, thread <code>isPro</code></td><td><code>src/App.tsx:117-125,410-411,693-732,805-813,987-992</code></td></tr>
+<tr><td>Optional always-visible upgrade entry in toolbar</td><td><code>src/components/NewTabHome.tsx:1086-1095</code></td></tr>
+</tbody>
+</table>
+
+<div class="takeaway"><div class="takeaway-label">NET-NEW SURFACE</div> No existing pro/entitlement code — model the cached flag on <code>useTheme</code> (synced, optimistic), the set-once nudge bookkeeping on <code>growth-state.ts</code> (local), keep entitlement out of the SW-owned <code>runtime-store</code>, and verify the license behind a trust timestamp rather than trusting synced storage.</div>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix · Market Research</div>
+  <h1>Appendix F · Payment Gateways Compared</h1>
+<p class="lead">Selling a one-time <strong>$19 lifetime</strong> Pro unlock for Totem — a Manifest V3 Chrome extension — to a privacy-conscious, indie-hacker, PKM audience. Solo dev, local-first ethos, open-source extension code, wants minimal ops and global sales tax handled.</p>
+
+<div class="takeaway"><div class="takeaway-label">BOTTOM LINE</div> For a solo dev who wants tax handled and almost no server, the realistic finalists are <strong>Merchant-of-Record (MoR)</strong> providers. <span class="hl">Polar (polar.sh) is the recommended primary pick</span> — cheapest MoR economics, modern license-key API whose <em>validate</em> endpoint is explicitly safe to call from a public client. Lemon Squeezy is the fallback (most mature, but pricier and mid-transition). ExtensionPay is easiest to wire but is <strong>not</strong> an MoR.</div>
+
+<h2>Comparison table</h2>
+
+<table class="striped">
+<thead>
+<tr>
+<th>Provider</th>
+<th>Fee (one-time sale)</th>
+<th>MoR? (handles global VAT/GST)</th>
+<th>One-time / lifetime</th>
+<th>License key API</th>
+<th>Offline / client-side validation</th>
+<th>MV3 / JS SDK ease</th>
+<th>Refunds &amp; chargebacks</th>
+<th>Payout requirements</th>
+<th>Key gotchas</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><strong>ExtensionPay (ExtPay)</strong></td>
+<td><strong>5%</strong> at time of charge, no monthly fee; lower/flat rates for high volume by request. Runs on <strong>your own Stripe</strong> underneath (Stripe's 2.9%+30¢ on top, paid to your Stripe).</td>
+<td><strong>No.</strong> Thin layer on your Stripe — <em>you</em> are the MoR and owe sales tax/VAT.</td>
+<td>Yes — monthly, quarterly, yearly, <strong>one-time</strong>.</td>
+<td>No license keys. Identity = <strong>email magic link</strong>; paid status lives on extensionpay.com keyed to extension ID + email.</td>
+<td><strong>No.</strong> <code>getUser()</code> makes a network call to extensionpay.com every time; no documented offline cache.</td>
+<td><strong>Easiest</strong> — built for extensions. <code>ExtPay(id)</code> + <code>startBackground()</code> in SW + <code>getUser()</code>. Needs <code>storage</code> permission + CSP <code>connect-src https://extensionpay.com</code>.</td>
+<td>Handled via your Stripe dashboard (you manage disputes; you eat chargebacks).</td>
+<td>Direct to <strong>your Stripe</strong> account (Stripe payout rules apply).</td>
+<td>Hard runtime dependency on a third-party server; slow JS lib cadence; no tax handling; another origin in the trust chain for an OSS/privacy product.</td>
+</tr>
+<tr>
+<td><strong>Stripe (Payment Links / Checkout)</strong></td>
+<td><strong>2.9% + 30¢</strong> (US card).</td>
+<td><strong>No</strong> (plain Stripe). <em>You</em> are MoR; tax is your problem in every country. (Stripe Tax helps <em>calculate</em> but you still register/remit.)</td>
+<td>Yes.</td>
+<td>No built-in license keys — you build issuance + a validation endpoint yourself (needs a server/edge function + secret).</td>
+<td>Possible but <strong>you must build &amp; host it</strong>; can't safely validate against Stripe from a public client.</td>
+<td>Medium. Payment Link is trivial; reconciling "did this user pay?" needs your own backend + webhooks.</td>
+<td>You manage refunds/disputes; you pay chargeback fees.</td>
+<td>Standard Stripe payouts to your bank.</td>
+<td>Defeats the "minimal server / tax handled" goal. <strong>Stripe Managed Payments</strong> (their MoR) adds <strong>~+3.5%</strong> on top but is the heavyweight path.</td>
+</tr>
+<tr>
+<td><strong>Lemon Squeezy</strong> (Stripe-owned)</td>
+<td><strong>5% + 50¢</strong>; +1.5% intl card, +1.5% PayPal, +0.5% subscription.</td>
+<td><strong>Yes</strong> — full MoR, remits global sales tax/VAT/GST.</td>
+<td>Yes — one-time products + license keys.</td>
+<td><strong>Yes, mature.</strong> Built-in key generation + License API: <code>POST https://api.lemonsqueezy.com/v1/licenses/validate</code> and <code>/activate</code>, <code>/deactivate</code>. Endpoints take the <strong>license key itself (no secret API key)</strong>.</td>
+<td><strong>Yes</strong> — validate/activate callable client-side with just key + instance_id; cache the validated result locally.</td>
+<td>Good. Hosted overlay checkout (<code>lemon.js</code>) or hosted link; webhooks for fulfillment.</td>
+<td>MoR handles it: refunds on your behalf, <strong>$15 dispute fee</strong> + refunded amount deducted from next payout.</td>
+<td><strong>$100 minimum payout</strong>, automated on the 14th &amp; 28th.</td>
+<td><strong>Transition risk:</strong> acquired by Stripe (2024). Feb 2026 = Stripe Managed Payments public preview + migration path for LS merchants; LS still accepts signups but long-term direction is toward Stripe Managed Payments.</td>
+</tr>
+<tr>
+<td><strong>Paddle</strong></td>
+<td><strong>5% + 50¢</strong> (Starter, no monthly fee); custom on Growth/Enterprise.</td>
+<td><strong>Yes</strong> — full MoR; becomes legal seller, handles tax, fraud, chargebacks, refunds.</td>
+<td>Yes.</td>
+<td>License keys <strong>not a first-class built-in</strong> like LS/Polar; typically you provision keys yourself from the webhook. Custom flows via improved 2025–26 API.</td>
+<td>You build your own key storage/validation; feasible but more work.</td>
+<td>Medium. Good hosted + embedded checkout (<code>Paddle.js</code>), strong tax/compliance.</td>
+<td>MoR handles refunds/chargebacks.</td>
+<td>Standard Paddle payout schedule to bank.</td>
+<td>More enterprise-oriented; historically stricter merchant approval/onboarding review; license-key UX weaker than LS/Polar for indie one-time sales.</td>
+</tr>
+<tr>
+<td><strong>Polar (polar.sh)</strong></td>
+<td><strong>Starter (free): 5% + 50¢</strong>; <strong>Pro $20/mo: 3.8% + 40¢</strong>; Growth/Scale lower. +1.5% intl cards; <strong>$15 chargeback</strong>. (Orgs created before May 27, 2026 keep an "Early Member" rate.)</td>
+<td><strong>Yes</strong> — full MoR; takes on global sales-tax liability.</td>
+<td>Yes — define a <strong>one-time</strong> product.</td>
+<td><strong>Yes.</strong> License keys as a product "benefit" (auto-issued on purchase). Validate: <code>POST /v1/customer-portal/license-keys/validate</code> — explicitly "doesn't require authentication and can be safely used on a public client." Server-side variant: <code>/v1/license-keys/validate</code>.</td>
+<td><strong>Yes — best fit.</strong> Public validate endpoint is <em>designed</em> for untrusted clients, so an MV3 extension (or OSS code) can validate without embedding any secret.</td>
+<td>Good. Type-safe <code>@polar-sh/sdk</code> (npm), hosted checkout, webhooks, customer portal.</td>
+<td>MoR handles refunds; <strong>$15 per dispute</strong> regardless of outcome.</td>
+<td>Stripe-backed payouts: <strong>$2/mo active-payout fee + 0.25% + $0.25 per payout</strong>; meet minimum threshold, then on-demand.</td>
+<td>Newer/smaller than LS &amp; Paddle; 2026 pricing moved the free tier to 5%+50¢ unless you pay monthly; payout fees stack on top.</td>
+</tr>
+<tr>
+<td><strong>Gumroad</strong></td>
+<td><strong>10% + 50¢</strong> flat (Discover marketplace = 30%).</td>
+<td><strong>Yes</strong> — full MoR since <strong>Jan 1, 2025</strong> (calculates, collects, remits VAT/GST/sales tax).</td>
+<td>Yes — one-time digital products.</td>
+<td><strong>Yes</strong> — built-in license keys + verify API (<code>/v2/licenses/verify</code>).</td>
+<td>Verify endpoint callable with product_permalink + key (no secret needed); cacheable.</td>
+<td>Low/medium for extensions — checkout is web/overlay, no extension-native SDK; you'd glue email→key→extension manually.</td>
+<td>MoR handles refunds/chargebacks.</td>
+<td><strong>$10 minimum</strong>, weekly payouts (PayPal/direct deposit).</td>
+<td><strong>Highest fee (10%)</strong> — on a $19 sale ~$2.40 vs ~$1.45 (5%+50¢) vs ~$1.16 (Polar Pro 3.8%+40¢). Brand/UX feels creator-marketplace, less "software license."</td>
+</tr>
+</tbody>
+</table>
+
+<h3>MoR head-to-head (Lemon Squeezy vs Paddle vs Polar)</h3>
+<ul>
+<li><strong>All three are true MoRs</strong> — they become the legal seller and remit global VAT/GST/sales tax, so the solo dev never registers for tax anywhere. This is the single biggest reason to pick one of these over raw Stripe/ExtPay.</li>
+<li><strong>Cheapest:</strong> Polar (esp. on a paid monthly plan, 3.8%+40¢) &lt; Lemon Squeezy / Paddle (5%+50¢) &lt; Gumroad (10%+50¢).</li>
+<li><strong>Best license-key DX for a public/OSS client:</strong> <strong>Polar</strong> (auth-free public validate endpoint, stated safe for untrusted clients) and <strong>Lemon Squeezy</strong> (validate/activate take only the key, no secret) tie; <strong>Paddle</strong> trails (roll your own from webhooks).</li>
+<li><strong>Most mature / lowest "will it still exist" risk:</strong> Lemon Squeezy and Paddle. But LS now carries Stripe-acquisition/transition uncertainty (migration path to Stripe Managed Payments announced Feb 2026); Polar carries "young company" risk.</li>
+</ul>
+
+<h2>ExtensionPay (ExtPay) — exact model</h2>
+<ul>
+<li><strong>Fee:</strong> <strong>5%</strong> transaction fee at time of charge, no monthly/upfront fee. Lower fees / flat monthly rates for high-volume accounts (email glen@extensionpay.com). It is a <strong>layer on top of Stripe</strong>: funds paid <strong>directly to your own Stripe account</strong>, data stored in Stripe so you can migrate away. All-in cost = <strong>5% (ExtPay) + Stripe's 2.9%+30¢</strong>.</li>
+<li><strong>Not an MoR:</strong> the sale settles into <em>your</em> Stripe, so <strong>you are the merchant of record and owe sales tax/VAT</strong> yourself. The decisive negative vs. LS/Paddle/Polar/Gumroad.</li>
+<li><strong>Payment ↔ user association:</strong> there is <strong>no license key</strong>. Identity is the user's <strong>email via a magic login link</strong>. Paid status stored on extensionpay.com, keyed to your <strong>registered extension ID + the user's email</strong>. On reinstall or new device, the user clicks "log in" → magic-link email → paid features reactivate.</li>
+<li><strong>Paid-status check:</strong> call <code>extpay.getUser()</code>, which <strong>makes a network call to extensionpay.com</strong> and returns <code>user.paid</code> (boolean), <code>user.paidAt</code> (Date|null), <code>user.email</code>, <code>user.plan</code>, plus subscription fields. <strong>No documented offline cache</strong> — <code>getUser()</code> hits the network each time and can throw on network failure. Events: <code>extpay.onPaid.addListener(...)</code> fires on pay or login.</li>
+<li><strong>Must call extensionpay.com? Yes.</strong> The library "only communicates with ExtensionPay.com servers to manage users' paid status." Allow that origin in CSP (<code>connect-src https://extensionpay.com</code>); Firefox may also need <code>https://extensionpay.com/*</code> in permissions; content-script callbacks need a content script matching <code>https://extensionpay.com/*</code>.</li>
+<li><strong>Integration:</strong> <code>ExtPay('your-extension-id')</code>, call <code>extpay.startBackground()</code> once in the service worker, then <code>extpay.getUser()</code> / <code>extpay.openPaymentPage()</code>. Minimum manifest permission is just <code>"storage"</code>.</li>
+<li><strong>Gotchas for Totem:</strong> (1) not local-first — every paid check phones a third-party server; (2) no tax handling; (3) JS lib update cadence slow (server side still maintained); (4) for a <em>one-time lifetime</em> unlock the email-magic-link model means a user with no network can't verify Pro.</li>
+</ul>
+
+<h2>Recommendation for Totem</h2>
+
+<div class="callout"><strong>Primary pick: Polar (polar.sh).</strong> &nbsp;·&nbsp; <strong>Fallback: Lemon Squeezy.</strong></div>
+
+<h3>Why Polar</h3>
+<ol>
+<li><strong>MoR = tax is fully handled.</strong> Solo dev never registers/remits VAT/GST anywhere — Polar is the legal seller. Directly satisfies "minimal ops + tax handled."</li>
+<li><strong>Cheapest of the MoRs.</strong> On a $19 sale: ~$1.16 net fee at Pro (3.8%+40¢) or ~$1.45 at the free 5%+50¢ tier — vs Gumroad's ~$2.40. More margin on a low-price one-time unlock.</li>
+<li><strong>License-key model fits local-first + OSS perfectly.</strong> Polar issues a license key as a purchase benefit, and its <span class="hl">public validate endpoint <code>POST /v1/customer-portal/license-keys/validate</code> requires no authentication and is explicitly documented as safe for public clients</span> (desktop/mobile/extension). The extension can validate the key <strong>without embedding any secret</strong> — essential because Totem's source is public. Validate once, cache "Pro = true" + key in <code>chrome.storage.local</code>/IndexedDB, run offline thereafter, re-check occasionally. No Totem server required.</li>
+<li><strong>Modern, type-safe <code>@polar-sh/sdk</code> + hosted checkout + webhooks.</strong> Minimal integration surface.</li>
+</ol>
+
+<h3>Why not the others as primary</h3>
+<ul>
+<li><strong>ExtPay:</strong> easiest to wire, but <strong>not an MoR</strong> (you owe tax) and forces a <strong>hard runtime dependency on extensionpay.com</strong> for every paid check — antithetical to local-first, and an extra third-party origin in the trust chain for a privacy-positioned OSS product.</li>
+<li><strong>Raw Stripe / Payment Links:</strong> <strong>not an MoR</strong> — tax becomes your problem in every country, and you'd have to build your own license server. Stripe Managed Payments (their MoR) adds ~+3.5%.</li>
+<li><strong>Gumroad:</strong> clean MoR + license keys, but <strong>10%</strong> is the highest fee and the UX reads "creator marketplace," not "software license."</li>
+<li><strong>Paddle:</strong> solid MoR, but weaker first-class license-key DX for indie one-time sales and heavier onboarding.</li>
+</ul>
+
+<h3>Why Lemon Squeezy as fallback (not primary)</h3>
+<p>It's the most battle-tested license API (validate/activate/deactivate, key-only, cacheable) and a true MoR — an excellent fit — but it's <strong>pricier than Polar</strong> (5%+50¢, $100 min payout) and now sits inside <strong>Stripe's MoR transition</strong> (Feb 2026 Managed Payments preview + LS migration path). If Polar's youth/feature-gaps become a problem, LS is the safe, mature swap.</p>
+
+<div class="takeaway"><div class="takeaway-label">PRICING NOTE</div> For the $14 founders / $19 list: all MoR fees scale fine at this price; the per-transaction fixed component (40–50¢) is the bigger relative bite on a sub-$20 product, which again favors Polar's lower fixed fee.</div>
+
+<h2>Integration sketch — Polar in an MV3 extension</h2>
+<p><strong>Goal:</strong> sell a one-time $19 "Totem Pro" product in Polar, issue a license key, validate it from the extension with no secret, cache the result locally (local-first).</p>
+
+<h3>A. Polar dashboard (one-time setup, no code)</h3>
+<ul>
+<li>Create org → create a <strong>one-time product</strong> "Totem Pro — $19" ($14 founders coupon).</li>
+<li>Add the <strong>License Key</strong> benefit to the product (auto-issues a key on purchase).</li>
+<li>Grab the <strong>organization ID</strong> (public, used only to scope validation) and a hosted <strong>Checkout Link</strong>.</li>
+</ul>
+
+<h3>B. Selling</h3>
+<p>From the extension's upgrade UI, open the Polar <strong>hosted checkout</strong> in a new tab (<code>chrome.tabs.create({ url: checkoutLink })</code>). Polar collects payment, remits tax as MoR, and emails the buyer their license key + a customer-portal link. No checkout code or PCI surface in the extension.</p>
+
+<h3>C. Entering the key</h3>
+<p>The Pro settings panel has an "Enter license key" input. User pastes the key from the email.</p>
+
+<h3>D. Validation (no secret, public endpoint)</h3>
+<pre><code>// runs in the service worker; no API key embedded — safe for public/OSS code
+async function validateProKey(licenseKey) {
+  const res = await fetch('https://api.polar.sh/v1/customer-portal/license-keys/validate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      key: licenseKey,
+      organization_id: TOTEM_ORG_ID, // public scoping value, not a secret
+    }),
+  });
+  if (!res.ok) return { valid: false };
+  const data = await res.json();           // { status, key, ... }
+  return { valid: data.status === 'granted', data };
+}</code></pre>
+
+<h3>E. Local-first caching (the important part)</h3>
+<ul>
+<li>On a successful validate, store <code>{ pro: true, key, validatedAt }</code> in <code>chrome.storage.local</code> (and mirror the flag into Zustand state). Gate Pro features (MD/CSV/JSONL export, deleted-tweet preservation, bulk ops, advanced filters, annotations, thread capture) on this flag.</li>
+<li>The extension reads the <strong>local flag</strong> on every launch — <strong>fully offline</strong>. It only re-hits Polar's validate endpoint <strong>occasionally</strong> (e.g., once every N days, or on user "Re-check license") to confirm the key wasn't refunded/revoked. A failed network re-check should <strong>not</strong> instantly revoke Pro (grace period) — keeps it local-first and resilient.</li>
+</ul>
+
+<h3>F. manifest.json (MV3) needs</h3>
+<pre><code>{
+  "permissions": ["storage"],
+  "host_permissions": ["https://api.polar.sh/*"]
+}</code></pre>
+<ul>
+<li><code>host_permissions</code> (or a <code>connect-src https://api.polar.sh</code> if you ship an explicit CSP) so the service worker can <code>fetch</code> the validate endpoint.</li>
+<li><code>tabs</code> only if you use <code>chrome.tabs.create</code> for checkout (or just use a normal link / <code>window.open</code>).</li>
+<li>No client secret anywhere — the public validate endpoint + public org ID are the only Polar values in the (public) source.</li>
+</ul>
+
+<h3>G. Where the key lives</h3>
+<p>The <strong>license key string</strong> in <code>chrome.storage.local</code>; the derived <strong><code>pro</code> boolean + validatedAt</strong> alongside it (and in Zustand for runtime). Nothing sensitive, nothing server-side, no Totem backend.</p>
+
+<p><strong>Optional hardening:</strong> add a Polar <strong>webhook</strong> (<code>order.created</code> / <code>benefit_grant.created</code>) to a tiny serverless function only if you later want server-side analytics or to pre-bind keys — <strong>not required</strong> for the core unlock, keeping the no-server ethos intact.</p>
+
+<h2>Sources</h2>
+<ul>
+<li>ExtensionPay home (5% fee, Stripe payout, one-time support): <code>https://extensionpay.com/</code></li>
+<li>ExtensionPay — CWS payments replacement / 5% context: <code>https://extensionpay.com/articles/extensionpay-is-the-chrome-web-store-payments-replacement</code></li>
+<li>ExtPay GitHub (library, no-server, methods): <code>https://github.com/Glench/ExtPay</code></li>
+<li>ExtPay README (manifest, getUser network call, magic-link model): <code>https://raw.githubusercontent.com/Glench/ExtPay/master/README.md</code></li>
+<li>Stripe fees + MoR clarification (Managed Payments ~+3.5%): <code>https://dodopayments.com/blogs/stripe-fees-calculator</code> and <code>https://freemius.com/blog/stripe-transaction-fees-real-cost/</code></li>
+<li>Stripe local payment methods pricing: <code>https://stripe.com/pricing/local-payment-methods</code></li>
+<li>Stripe acquires Lemon Squeezy (2024): <code>https://www.lemonsqueezy.com/blog/stripe-acquires-lemon-squeezy</code> and <code>https://techcrunch.com/2024/07/26/stripe-acquires-payment-processing-startup-lemon-squeezy/</code></li>
+<li>Lemon Squeezy 2026 update / Stripe Managed Payments migration path: <code>https://www.lemonsqueezy.com/blog/2026-update</code></li>
+<li>Lemon Squeezy pricing (5%+50¢, surcharges): <code>https://www.lemonsqueezy.com/pricing</code></li>
+<li>Lemon Squeezy License API (validate endpoint, no Authorization header, instance_id): <code>https://docs.lemonsqueezy.com/api/license-api/validate-license-key</code> and <code>https://docs.lemonsqueezy.com/api/license-api/activate-license-key</code></li>
+<li>Lemon Squeezy refunds/chargebacks ($15 dispute fee): <code>https://docs.lemonsqueezy.com/help/payments/refunds-chargebacks</code></li>
+<li>Lemon Squeezy payouts ($100 min, 14th/28th): <code>https://docs.lemonsqueezy.com/help/affiliates-for-merchants/payouts</code></li>
+<li>Paddle fees (5%+50¢ MoR) review: <code>https://dodopayments.com/blogs/paddle-review</code> and <code>https://dev.to/onsen/paddle-review-2026-pros-cons-pricing-explained-4cgk</code></li>
+<li>Polar pricing (tiered 2026, 5%+50¢ free / 3.8%+40¢ Pro): <code>https://polar.sh/resources/pricing</code> and <code>https://dodopayments.com/blogs/polar-sh-review</code></li>
+<li>Polar fees doc (intl +1.5%, $15 chargeback, payout fees): <code>https://polar.sh/docs/merchant-of-record/fees</code></li>
+<li>Polar is an MoR (statement): <code>https://x.com/polar_sh/status/1917551367247241542</code></li>
+<li>Polar license keys benefit + SDK: <code>https://polar.apidocumentation.com/documentation/features/benefits/license-keys</code> and <code>https://www.npmjs.com/package/@polar-sh/sdk</code></li>
+<li>Polar validate endpoint — no auth, safe for public clients: <code>https://polar.sh/docs/api-reference/customer-portal/license-keys/validate</code></li>
+<li>Gumroad fees (10%+50¢) + MoR since Jan 1 2025: <code>https://checkoutpage.com/blog/gumroad-fees</code> and <code>https://www.swell.is/content/gumroad-pricing</code></li>
+<li>Gumroad license keys: <code>https://gumroad.com/help/article/76-license-keys</code></li>
+<li>MoR comparison (Polar vs LS vs Paddle, payouts, chargebacks): <code>https://www.buildmvpfast.com/blog/lemon-squeezy-vs-polar-paddle-merchant-of-record-2026</code> and <code>https://veloxthemes.com/blog/polar-vs-lemonsqueezy-vs-gumroad</code></li>
+</ul>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix · Market Research</div>
+  <h1>Appendix G · License Architecture &amp; DRM Stance</h1>
+<div class="callout"><span class="tag">DECISION UPDATE</span> This appendix is the <strong>raw research</strong> that explored <em>offline</em> Ed25519-signed keys. The project ultimately <strong>did not adopt</strong> that approach: verification is <strong>online-validate-then-cache</strong> via the provider's license API (validate once at activation, cache locally, read offline from cache, re-check in the background with fail-open) — chosen because it is simpler and because it enables multi-device management, which a fully-offline key cannot. See Chapters 4–5 for the shipped design; read the crypto exploration below as the option that was considered and set aside. The "crackable is fine" / anti-DRM stance below still holds.</div>
+
+<p class="lead">How to gate a paid "Pro" tier when the source is public on GitHub, there is no Totem server, and Chrome's MV3 policy forbids remotely-hosted code. The honest answer: the crypto is sound, the gate is patchable, and that is the correct strategy rather than a failure.</p>
+
+<h2>The constraint, stated honestly up front</h2>
+
+<p>Totem is three things at once, and they collide into one hard truth:</p>
+
+<ul>
+<li><strong>Open-source</strong> — source public on GitHub.</li>
+<li><strong>Local-first</strong> — no Totem server, no account, <code>IndexedDB</code> + <code>chrome.storage.local</code>.</li>
+<li><strong>MV3</strong> — Chrome Web Store policy forbids remotely-hosted <em>code</em>.</li>
+</ul>
+
+<div class="callout">Any client-side-only entitlement check in open-source software can be patched out by a determined user who recompiles the extension. There is no cryptography that fixes this — the public key, the verifier, and the <code>isPro</code> flag all live on the user's machine, in code they can read and edit.</div>
+
+<p>So the goal is <strong>not</strong> "make Pro uncrackable." That is impossible, and chasing it wastes engineering on DRM that the target communities (r/selfhosted, HN, r/privacy) actively distrust. The goal is to <span class="hl">make legitimately paying easier, more pleasant, and more trustworthy than cracking</span> — and keep the honest-buyer experience clean. Lose the rounding-error of users who would never have paid anyway.</p>
+
+<p>This is the canonical "service problem, not a pricing problem" framing from Gabe Newell:</p>
+
+<blockquote>Piracy is almost always a service problem and not a pricing problem... the way to stop piracy is not by selling at a lower price, but by offering a service that's better than what the pirates can provide.<span class="cite"> - Gabe Newell, Valve (Escapist / Slashdot / HN)</span></blockquote>
+
+<p>For a $19 one-time lifetime tool, the cracker's "service" — find a patched build, trust a stranger's binary, re-patch on every update, get no support — is <em>worse</em> than just paying once. <strong>That is the moat, not the crypto.</strong></p>
+
+<h2>Signed license keys with offline verification (the crypto layer)</h2>
+
+<h3>The pattern</h3>
+
+<p>A signed license key is <code>base64(payload) . base64(signature)</code> — a small data object the vendor signs with a <strong>private key</strong> (server / issuance side only) and the client verifies with an <strong>embedded public key</strong>. No secret lives client-side; the public key is safe to ship in the extension bundle. This is exactly how Keygen, Keyforge, Polar, Cryptolens, and the "license key as JWT" pattern all work.</p>
+
+<p>Keygen's canonical description: a signed key is <code>${ENCODED_DATA}.${ENCODED_SIGNATURE}</code>, e.g.</p>
+
+<pre><code>dXNlckBjdXN0b21lci5leGFtcGxl.kANuXAhc8b7rDNgbFBpoSUsmfkM7msQC0tNkeUed4b5W15xF6zxmoV3AYF54zaWFMHznSNY7M9bLloInknvlDw==</code></pre>
+
+<p>The data is base64-encoded plaintext; the signature is produced with the vendor's private Ed25519 key. The client verifies with only the public key, embedded in the application.</p>
+
+<blockquote>Unless a bad actor can break Ed25519 or RSA-2048, writing a keygen is effectively impossible.<span class="cite"> - Keygen, How to Generate Secure License Keys</span></blockquote>
+
+<p>Client verification is a handful of lines (Keygen's own example, Node <code>crypto</code>):</p>
+
+<pre><code>const [encodedData, encodedSignature] = licenseKey.split('.')
+const signature = Buffer.from(encodedSignature, 'base64')
+const data      = Buffer.from(encodedData, 'base64').toString()
+const valid     = crypto.verify(null, Buffer.from(data), publicKey, signature)</code></pre>
+
+<h3>Algorithm choice: Ed25519 (EdDSA), not RSA</h3>
+
+<ul>
+<li>Ed25519 keys/signatures are <strong>tiny</strong> vs RSA (keeps the license string short enough to paste). EdDSA is recommended for new implementations where the JWT/crypto library supports it (Curity — JWT signatures with EdDSA).</li>
+<li>Keygen defaults to Ed25519 when no scheme is set; supports Ed25519 or 2048-bit RSA, optionally AES-256-GCM encryption (Keygen cryptography docs).</li>
+<li>Industry trend: Ed25519 has displaced RSA as the modern default for signatures (DEV — SSH Keys in 2024: Why Ed25519 Replaced RSA).</li>
+</ul>
+
+<h3>Libraries — fits for Totem's existing stack</h3>
+
+<p>The repo already ships <code>@noble/hashes 2.2.0</code> (confirmed in <code>package.json</code>). The natural companions:</p>
+
+<ul>
+<li><strong><code>@noble/ed25519</code></strong> — "Fastest 5KB JS implementation of ed25519 signatures" (paulmillr). API is exactly the detached-signature shape we need:
+<pre><code>import * as ed from '@noble/ed25519';
+const isValid = await ed.verify(signature, message, publicKey); // → boolean</code></pre>
+Inputs accept <code>Uint8Array</code> or hex; verify supports detached signatures natively.</li>
+<li><strong><code>@noble/curves</code></strong> — broader suite (also from paulmillr) if more than ed25519 is ever needed.</li>
+<li><strong>Zero-dep alternative:</strong> the browser-native <code>SubtleCrypto.verify()</code> Web Crypto API supports Ed25519 in modern Chrome (MDN). This avoids adding any dependency at all, but <code>@noble/ed25519</code> is more ergonomic, battle-tested across environments, and pairs with the <code>@noble/hashes</code> already present.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">RECOMMENDATION</div> <code>@noble/ed25519</code> (+ the already-present <code>@noble/hashes</code> for the SHA-512 it needs). ~5 KB, audited, matches the existing dependency philosophy.</div>
+
+<h3>License-as-signed-JWT variant (equivalent, more standard)</h3>
+
+<p>Instead of a bespoke <code>payload.sig</code> format, the same thing can be a <strong>JWT signed with EdDSA (<code>Ed25519</code>) or RS256</strong>: header + payload + signature, verifiable offline with the public key, no server call.</p>
+
+<blockquote>A JWT is a small, signed data object that can be verified without calling a server... your app can verify it offline.<span class="cite"> - Keyforge, How to use JWTs for offline licensing</span></blockquote>
+
+<p>Keyforge issues signed license <strong>tokens (JWTs)</strong> the app verifies locally with no network call, so the app keeps working offline. The payload carries license key id, product id, device identifier, device name, and an <code>exp</code> expiration claim; the signature covers the payload so the user can't modify contents without breaking verification. For Totem the bespoke <code>base64(json).base64(ed25519sig)</code> format is simpler than dragging in a JWT lib, but a JWT is fine if a license vendor emits one natively. <strong>Either is equivalent crypto.</strong> The decision is driven by what the chosen payment vendor produces.</p>
+
+<h3>What to embed in Totem's license payload</h3>
+
+<p>Minimal, copy-paste-friendly JSON, then ed25519-signed:</p>
+
+<pre><code>{
+  "v": 1,
+  "email": "buyer@example.com",
+  "plan": "pro-lifetime",
+  "order": "ls_ord_abc123",
+  "issued": "2026-06-19",
+  "exp": null,            // null = lifetime; or an ISO date for refresh-token style
+  "feat": ["export","preserve","bulk","filters","annotate"]
+}</code></pre>
+
+<p>The "more data you embed, the larger the key" — not a problem since users paste, not type. Embedding the <strong>email</strong> is a deliberate soft anti-piracy nudge: a leaked key is traceable to the buyer, and the extension can display <em>"Licensed to buyer@example.com"</em> — social friction, not technical DRM.</p>
+
+<h2>The fundamental reality: it's crackable, and that's fine</h2>
+
+<h3>Why it's unavoidable here</h3>
+
+<p>Open-source + client-only means the verifier, the embedded public key, and the <code>isPro</code> boolean are all in readable code. A determined user can:</p>
+
+<ul>
+<li>delete the verification call and hard-code <code>isPro = true</code>, or</li>
+<li>generate their own keypair, swap the embedded public key, and self-sign keys.</li>
+</ul>
+
+<p>No client-side scheme prevents this. The community even names the trade-off: the way source-available freemium apps "protect" paid features is to keep <strong>premium pieces closed / source-available</strong> while the open core stays public. Standard Notes keeps the app + server open source but ships <strong>some subscription extensions as source-available (closed)</strong> (AlternativeTo); Obsidian sidesteps it entirely by being <strong>proprietary</strong> with paid Sync/Publish (XDA). Totem's whole pitch is auditability, so going closed-source is off the table — which means <span class="hl">accepting leakage is the correct strategy, not a failure.</span></p>
+
+<h3>The pragmatic indie consensus</h3>
+
+<ul>
+<li><strong>Gabe Newell / Valve</strong> — the foundational "piracy is a service problem; out-serve the pirates" thesis, repeatedly cited by indie devs as the reason heavy DRM backfires (Escapist, GamesRadar, TechRadar).</li>
+<li><strong>Indie devs measuring real piracy rates</strong> find a large share of "pirates" would never have paid — fighting them is negative ROI, and even AAA DRM is cracked within a week, so the winning move is a superior experience for buyers (<em>"So 52.45% of People Playing my Indie Game Have Pirated it"</em> — Game Developer; developers who <em>encourage</em> piracy as marketing because non-payers wouldn't convert anyway — PCWorld / Darkwood, TheGamer).</li>
+<li><strong>OSS monetization in practice (2024–2026)</strong> has converged on models that <em>don't</em> depend on un-crackable clients: open-core (paid features companies will pay for), sponsorship (GitHub Sponsors / Open Collective / Patreon), and managed/hosted convenience (awesome-oss-monetization, reo.dev — 7 strategies, Polar). The throughline: <strong>the moat is convenience, trust, support, and ongoing value — not a license check.</strong></li>
+</ul>
+
+<h3>What this means for Totem specifically</h3>
+
+<p>The honest stance to publish, in docs and the buy flow:</p>
+
+<blockquote>Totem is open source. You <em>could</em> patch out the Pro check — the code is right there. We're not going to fight you with DRM that would make the app worse for everyone. Pro is $19 once; it funds the deleted-tweet preservation, export, and search work. If you find it useful, buy it. If you genuinely can't, the free tier is fully functional forever.<span class="cite"> - Proposed Totem stance copy</span></blockquote>
+
+<p>This converts the crackability from a liability into a <strong>brand-aligned trust signal</strong> for exactly the privacy / self-hosted / HN audience Totem is courting — the same audience that distrusts cloud DRM and values auditability above all.</p>
+
+<h2>Online activation vs fully-offline (vendor comparison)</h2>
+
+<h3>The spectrum</h3>
+
+<table class="compact">
+<thead><tr><th>Dimension</th><th>Fully offline (signed key)</th><th>Online activation (API)</th></tr></thead>
+<tbody>
+<tr><td>Network after first entry</td><td>none — pure local crypto</td><td>required each validate (or periodic)</td></tr>
+<tr><td>Revocation speed</td><td>only at token <code>exp</code> / next refresh</td><td>immediate</td></tr>
+<tr><td>Device binding / activation limit</td><td>only what's baked into the signed payload</td><td>enforced server-side, real-time</td></tr>
+<tr><td>Works on plane / offline</td><td>yes</td><td>no (unless cached + grace period)</td></tr>
+<tr><td>Privacy (no phone-home)</td><td>best — nothing leaves device</td><td>each check is a network event</td></tr>
+<tr><td>Fits Totem's "no server" ethos</td><td>perfectly</td><td>mild tension (3rd-party server)</td></tr>
+</tbody>
+</table>
+
+<p>Keyforge's own table captures the trade: offline = no network dependency after activation, <strong>delayed</strong> revocation (until token expiry), works offline, grace period recommended; online = immediate revocation but fails with no connection. The standard hybrid: <strong>first-time activation is online</strong> (exchange the license key for a signed token bound to a device), then <strong>verify offline</strong> thereafter, <strong>refreshing the token in the background</strong> when connectivity returns; use a <strong>grace period</strong> instead of hard lockout on expiry.</p>
+
+<h3>What the vendors give you out of the box</h3>
+
+<p><strong>ExtPay / ExtensionPay</strong> — purpose-built for browser extensions, <em>no server needed</em>, Stripe on the backend. You drop in the open-source <code>ExtPay.js</code>, call <code>extpay.openPaymentPage()</code>, and read paid status via <code>extpay.getUser()</code> → <code>{ paid, paidAt, trialStartedAt, subscriptionStatus }</code>; cross-device via <code>extpay.openLoginPage()</code> (magic-link email); react to purchase via <code>extpay.onPaid.addListener()</code>. It is a <strong>data fetch</strong> to ExtensionPay servers (cached via <code>chrome.storage</code>), <strong>not remote code</strong> — so MV3-safe. It removes the need to build <em>any</em> server. Trade-off: it's <strong>online by design</strong> (<code>getUser</code> is a network call; offline persistence / cache duration are not strongly documented — handle <code>getUser().catch()</code>), and it's a dependency on ExtensionPay's service staying up — a slight tension with Totem's "nothing can shut down" pitch.</p>
+
+<p><strong>Lemon Squeezy license keys</strong> — merchant-of-record (handles VAT / sales tax). Keys are managed via <strong>activate / validate / deactivate</strong> API endpoints with an <strong>instance/activation limit</strong> (bind to N devices), online by default. Online validation, but you can wrap it: activate once, then trust a locally cached/signed result.</p>
+
+<p><strong>Polar license keys</strong> — also merchant-of-record. <strong>Activation limit</strong> per key (e.g. 3 instances), separate <strong>activate/deactivate</strong> calls so users can move machines, <strong>automatic revocation</strong> when a subscription is cancelled, and JSON <strong>conditions</strong> (IP/MAC/version) checked server-side. Caveat: Polar's license validation is <strong>online — every check is a live API call, with no signed offline artifact or built-in grace period</strong> by default (LicenseSeat critique). Good for revocation, bad for "works offline forever."</p>
+
+<p><strong>Keygen / Keyforge</strong> — purpose-built licensing. Both support <strong>signed/encrypted offline license files</strong> verifiable with just your public key (Keygen: Ed25519/RSA, AES-256-GCM optional, tamper-proof embedded snapshot with expiry — designed for air-gapped/offline use). Keyforge issues signed-JWT tokens for offline verify and supports Stripe / Polar / Lemon Squeezy as the payment layer. These give the <strong>best offline story</strong> but add a licensing-vendor dependency.</p>
+
+<h3>Recommendation on the online/offline axis</h3>
+
+<div class="takeaway"><div class="takeaway-label">DECISION (superseded)</div> The research leaned toward offline-verified signed keys. The <strong>shipped decision is online-validate-then-cache</strong> (validate once, cache, read offline from cache, re-check with fail-open) — it gives the same "don't phone home on every launch" resilience while adding device management and provider-side revocation. See Ch. 4–5.</div>
+
+<p>Either way, Totem should <em>not</em> phone home on <em>every</em> launch — that contradicts the local-first, no-telemetry promise. The buyer activates once; thereafter Pro is read from the local cache and only re-checked occasionally in the background, failing open so an outage never revokes access. The online check (vs a fully-offline signed key) is what lets the provider count devices and revoke a refunded/charged-back order — both impossible to do offline.</p>
+
+<h2>The MV3 constraint: data fetch ✅, remote code ❌</h2>
+
+<p>MV3 program policy: <strong>"an extension can only execute JavaScript that is included within its package"</strong> — no remotely-hosted code (JS from your server, CDN libraries, or bundled libs that dynamically fetch remote code).</p>
+
+<p>Crucially, the policy <strong>distinguishes code from data</strong>: extensions <em>may</em> fetch <strong>configuration data</strong> (e.g. a JSON file) to toggle features and change behavior at runtime; what's forbidden is fetching and <em>executing</em> code (Chrome docs, and the chromium-extensions thread clarifying remote config JSON is allowed).</p>
+
+<p><strong>Implications for license validation — both valid approaches are MV3-compliant:</strong></p>
+
+<ol>
+<li><strong>Pure local crypto</strong> — verify a pasted signed key with the embedded public key via <code>@noble/ed25519</code>: no network at all, trivially compliant. <span class="tag">MV3-SAFE</span></li>
+<li><strong>Data fetch</strong> — call ExtPay / Lemon Squeezy / Polar / Keygen license API, receive a JSON validation result or signed token: this is fetching <strong>data</strong>, not code — explicitly allowed. <span class="tag">MV3-SAFE</span> (exactly how ExtPay operates — <code>getUser()</code> is a data fetch).</li>
+</ol>
+
+<div class="callout">What you may <strong>not</strong> do: download a JS "license validator" module from a server and <code>eval</code> / import it at runtime. Keep all verification logic in the shipped bundle; only ever move <strong>data</strong> across the wire.</div>
+
+<h2>Recommended license architecture for Totem</h2>
+
+<h3>Summary</h3>
+
+<p><span class="hl">Shipped design: provider-issued license keys, validated online once at activation and cached locally</span> (read offline from cache, re-checked in the background with fail-open), with a hosted merchant-of-record handling checkout, tax, issuance, and device counting. No Totem server. No per-launch phone-home. Honest, published "this is crackable and that's okay" stance. <em>(The offline-signed-key exploration that follows was considered and set aside — see the decision banner above.)</em></p>
+
+<h3>Where the key comes from</h3>
+
+<ul>
+<li><strong>Issuance (private side):</strong> a merchant-of-record handles checkout + tax. Two viable setups:
+<ul>
+<li><strong>(A) Keyforge/Keygen-style signing</strong> wired to <strong>Lemon Squeezy or Polar</strong> checkout: on successful order, the vendor (or a tiny serverless function / the licensing vendor itself) signs an Ed25519 license payload and emails the key to the buyer. Keyforge explicitly supports Stripe / Polar / Lemon Squeezy as payment and issues offline-verifiable signed tokens.</li>
+<li><strong>(B) DIY issuance:</strong> keep the Ed25519 <strong>private key</strong> in a single serverless endpoint (or even an offline signing script you run on orders). It signs <code>base64(json).base64(sig)</code> per Keygen's format. This is the cheapest, most "no-vendor-lock-in" option and fits Totem's ethos, at the cost of running one small signer.</li>
+</ul>
+</li>
+<li>The <strong>public key</strong> is embedded in the extension bundle (safe to ship; it can only verify, not sign).</li>
+</ul>
+
+<h3>Exact verification mechanism</h3>
+
+<p>In the extension's service worker (the API boundary), on key entry:</p>
+
+<pre><code>import * as ed from '@noble/ed25519';
+const PUBKEY = /* 32-byte ed25519 public key, hardcoded in bundle */;
+
+async function verifyLicense(key) {
+  const [b64data, b64sig] = key.trim().split('.');
+  if (!b64data || !b64sig) return null;
+  const data = JSON.parse(atobUtf8(b64data));            // {email, plan, exp, feat, ...}
+  const msg  = new TextEncoder().encode(b64data);        // sign/verify over the encoded data
+  const sig  = base64ToBytes(b64sig);
+  const ok   = await ed.verify(sig, msg, PUBKEY);        // pure local crypto, no network
+  if (!ok) return null;
+  if (data.exp &amp;&amp; new Date(data.exp) &lt; new Date()) return null; // null exp = lifetime
+  return data;                                            // valid entitlement
+}</code></pre>
+
+<p>Mirrors Keygen's offline verify pattern and <code>@noble/ed25519</code>'s <code>verify(sig, msg, pubkey)</code> API.</p>
+
+<h3>Online vs offline decision</h3>
+
+<ul>
+<li><strong>Shipped: online-validate-then-cache.</strong> Validate the key with the provider once at activation (counts the device), then read <code>isPro</code> from the local cache on every launch — no per-launch network. Preserves the local-first, zero-telemetry feel while enabling device management.</li>
+<li><strong>Background re-check, fail-open:</strong> at most weekly, Totem re-validates (or fetches a small revocation-list JSON) to catch refunds/charge-backs — a <strong>data fetch</strong>, MV3-legal. No network → <strong>stay Pro</strong>. The re-check is non-blocking and never the gate for a normal launch.</li>
+</ul>
+
+<h3>What's stored where</h3>
+
+<ul>
+<li><strong><code>chrome.storage.local</code>:</strong> the verified entitlement — <code>{ isPro: true, plan, email, order, feat, verifiedAt }</code>. Survives cache/history clears and is shared across service worker + extension pages.</li>
+<li><strong>The raw signed key:</strong> also stored in <code>chrome.storage.local</code> so it can be re-verified on demand and re-displayed.</li>
+<li><strong>Runtime:</strong> <code>isPro</code> mirrored into the Zustand store (matching Totem's existing state pattern) so React gates read it synchronously.</li>
+<li><strong>Re-verification:</strong> re-run the signature check on each startup from the stored key (cheap, offline) rather than trusting a bare boolean — so a flipped <code>isPro</code> in storage alone (without a valid key) doesn't unlock. (Caveat: a recompile still bypasses this — accepted.)</li>
+</ul>
+
+<h3>How revocation works</h3>
+
+<ul>
+<li><strong>Lifetime, no subscription</strong> → the dominant case never needs revocation.</li>
+<li><strong>Refund / chargeback</strong> → optional revocation-list fetch, fail-open. Worst case: a refunded user keeps Pro. Acceptable leakage.</li>
+<li><strong>If Totem ever adds a subscription tier</strong>, switch that tier to a <strong>short-<code>exp</code> signed token refreshed online</strong> (Keyforge model — revocation arrives at next refresh; grace period to avoid offline lockout). Not needed for the recommended $19 lifetime.</li>
+</ul>
+
+<h3>The honest stance (ship this copy)</h3>
+
+<p>Publish, in the README and the upgrade screen, the stance statement: open source, patchable, no DRM arms race, $19 funds the work, free tier stays whole. This is on-brand trust for Totem's audience and converts the "it's crackable" weakness into a feature.</p>
+
+<h2>End-to-end sequence: purchase → unlock</h2>
+
+<ol>
+<li><strong>PURCHASE</strong> — Buyer clicks "Upgrade to Pro – $19 lifetime" → opens hosted checkout (Lemon Squeezy / Polar = merchant-of-record, handles card + VAT).</li>
+<li><strong>LICENSE ISSUED</strong> — On successful order, issuer signs an Ed25519 license payload <code>{ email, plan:"pro-lifetime", order, exp:null, feat:[...] }</code> → <code>base64(payload).base64(sig)</code>. Emailed to buyer (+ shown on success page).</li>
+<li><strong>ENTERED / ACTIVATED</strong> — Buyer pastes the key into Totem's "Enter license" field (extension Options / upgrade screen). No account, no login required.</li>
+<li><strong>VERIFIED (offline, local crypto)</strong> — Service worker: <code>ed.verify(sig, encodedPayload, EMBEDDED_PUBKEY)</code> + check <code>exp</code>. Pure local computation, zero network. <span class="tag">MV3-SAFE</span></li>
+<li><strong>isPro = true</strong> — On valid signature → entitlement object derived from <code>payload.feat</code>.</li>
+<li><strong>PERSISTED</strong> — <code>{ isPro, plan, email, order, feat, verifiedAt }</code> + raw key → <code>chrome.storage.local</code> (survives restarts/cache clears), mirrored into Zustand for synchronous React reads.</li>
+<li><strong>GATES UNLOCK</strong> — Export (MD/CSV/JSONL), deleted-tweet preservation, bulk ops, advanced filters, annotations check <code>isPro</code> from the store. Re-verified from stored key on each startup (offline).</li>
+<li><strong>(optional) BEST-EFFORT REVOCATION</strong> — weekly fetch of static revocation-list JSON; fail-open. Never blocks offline users.</li>
+</ol>
+
+<h2>Concrete recommendation</h2>
+
+<p><em>(Final decision — this supersedes the offline-key recommendation explored above.)</em> Ship <strong>provider-issued license keys validated online and cached</strong>: sell through a merchant-of-record (Lemon Squeezy or Polar) that handles checkout, tax, key issuance, and device counting; on activation the service worker calls the provider's <strong>validate/activate</strong> endpoint once (a public, no-secret <strong>data</strong> fetch — MV3-legal), then persists the result to <code>chrome.storage.local</code> + Zustand and <strong>reads from that cache on every launch</strong> (no per-launch network). Re-validate weekly in the background, <strong>failing open</strong> so an outage never revokes a paying user, which also catches refunds/charge-backs. Set a generous <strong>device limit (~5)</strong> with self-serve deactivation. Use <strong>lifetime keys</strong> so there is no subscription to manage — and publish the honest, on-brand stance that <span class="hl">the check is patchable by design</span>, because for a $19 one-time tool the cracker's experience is worse than just paying, and Totem's privacy-first audience will trust the absence of DRM more than they'd respect its presence.</p>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix · Market Research</div>
+  <h1>Appendix H · 2026 Market Discourse</h1>
+<p class="lead">What builders actually said in the last six months of 2026 about charging for Chrome extensions: one-time versus subscription, the conversion numbers behind it, and the backlash waiting for anyone who bolts a paywall onto a free tool.</p>
+
+<h2>The headline signal: one-time wins for tools, subscriptions win for server-cost</h2>
+<p>The strongest recurring theme across 2026 builder posts is that <span class="hl">subscription fatigue is real for client-side utility extensions</span>, and one-time / lifetime pricing converts materially better for them. The crucial qualifier: this is category-dependent, not universal. Subscriptions still dominate the high-revenue and professional/server-cost tiers.</p>
+
+<div class="callout">Pattern across every 2026 source: one-time wins for self-contained client-side utilities; subscription wins where there is ongoing or server-backed value.</div>
+
+<h3>First-party builder evidence (highest weight)</h3>
+<p><strong>"Real Numbers: Freemium Chrome Extension Monetization After 6 Months"</strong> — DEV Community, by ktg0215, ~May 6 2026. A solo dev running <strong>5 extensions on ExtensionPay</strong>. <span class="tag">VERIFIED</span> Real numbers:</p>
+<ul>
+<li>Overall free→paid conversion: <strong>0.8%</strong> across all 5 extensions; best (Japanese Font Finder) <strong>~1.4%</strong>, worst (PaletteGrab) <strong>0.3%</strong>.</li>
+<li><strong>MRR ~$180/mo</strong>, up from <strong>$60/mo</strong> three months prior, <strong>$0</strong> six months prior.</li>
+<li>Payment-flow completion: <strong>~60–70%</strong> of users who click "Upgrade" finish paying.</li>
+<li>Pricing spread: Procshot $4.99/mo (free: 2 guides/mo), Japanese Font Finder $2.99/mo (free: 30 inspections/day), <strong>PaletteGrab $3.99 one-time</strong> (free: 10 colors), AdLegalCheck $9.99/mo (free: 3 scans/mo).</li>
+</ul>
+<blockquote>One-time pricing for utility tools increased conversions 60% over monthly subscriptions for PaletteGrab.<span class="cite"> - DEV "Real Numbers", ktg0215, May 6 2026</span></blockquote>
+<p>On upgrade-prompt copy: prompt→upgrade conversion was <strong>2% with a basic alert, 8% when the prompt showed a value proposition with benefits listed</strong> — a 4x lift from copy alone.</p>
+<blockquote>The free limit should be just below the threshold for your power user's typical session.<span class="cite"> - DEV "Real Numbers", May 6 2026</span></blockquote>
+
+<p><strong>"Why Lifetime Pricing Converts Better Than Subscriptions for Chrome Extensions"</strong> — Medium, by Soraia, <strong>March 2 2026</strong>. Builder of the MiroMiro extension (design-asset extraction, 5,000+ installs). Was subscriptions-only at €5/mo; adding a prominent lifetime option produced <strong>"5 paying customers in a row"</strong> where conversions previously came "weeks or months" apart.</p>
+<blockquote>People don't cancel because they're unhappy. They cancel because they look at subscriptions and think, "wait, what is this again?"<span class="cite"> - Soraia, Medium, Mar 2 2026</span></blockquote>
+<blockquote>Chrome extensions aren't SaaS apps. They're tools. And people prefer to buy tools once.<span class="cite"> - Soraia, Medium, Mar 2 2026</span></blockquote>
+
+<p><strong>ExtPay user quote</strong> (chromium-extensions Google Group, ExtPay 3.1 announcement thread, posted <strong>March 24 2025</strong>; also reproduced on extensionpay.com):</p>
+<blockquote>It took less than an hour to set up and test it. It hasn't been under a year and I'm already going to pass $4,000 in annual subscriptions.<span class="cite"> - chromium-extensions Google Group, Mar 24 2025</span></blockquote>
+<p>Another commonly cited line: a builder "wouldn't have tried to monetize using Stripe directly" but found ExtPay easy.</p>
+
+<h3>The counter-signal: don't over-index on lifetime</h3>
+<p>Subscriptions clearly still dominate the high-revenue tier and professional/server-cost categories. <strong>NicheCheck, "Most Profitable Chrome Extensions: 2026 Revenue Breakdown by Category"</strong> (Feb 22 2026) reports top-10% performers:</p>
+<table class="striped">
+<thead><tr><th>Category</th><th>Top-10% revenue</th><th>Model</th></tr></thead>
+<tbody>
+<tr><td>SEO &amp; Marketing</td><td>$10k–$50k/mo</td><td>subscription $15–$30/mo</td></tr>
+<tr><td>Developer Tools</td><td>$5k–$30k/mo</td><td>subscription $6–$8/mo</td></tr>
+<tr><td>AI-Powered</td><td>$5k–$25k/mo</td><td>subscription $10–$20/mo</td></tr>
+<tr><td>Productivity</td><td>$3k–$15k/mo</td><td>freemium $3–$7/mo</td></tr>
+<tr><td>Privacy &amp; Security</td><td>$1k–$8k/mo</td><td>hybrid (freemium + donations + enterprise)</td></tr>
+</tbody>
+</table>
+<p>NicheCheck states "recurring subscriptions dominate profitable extensions" and that <strong>"Annual plans (typically at a 30–40% discount) reduce churn by 50–60%."</strong> Freemium conversion benchmark: <strong>1–3% of the active user base</strong> (not installs).</p>
+
+<p><strong>chromegoldmine, "Chrome Extension Revenue Benchmarks by User Count"</strong> (March 26 2026) — benchmark by active users:</p>
+<table class="compact">
+<thead><tr><th>Active users</th><th>Freemium</th><th>Subscription</th><th>One-time / LTD</th></tr></thead>
+<tbody>
+<tr><td>2k–10k</td><td>$50–$500/mo</td><td>$100–$1,500/mo</td><td>$1,000–$10,000 cumulative</td></tr>
+<tr><td>10k–50k</td><td>—</td><td>$500–$7,500/mo</td><td>$5,000–$30,000</td></tr>
+<tr><td>50k–200k+</td><td>—</td><td>$20k–$200k+/mo</td><td>"less practical at scale"</td></tr>
+</tbody>
+</table>
+<p>Named high-revenue extensions (all subscription/affiliate, not one-time): <strong>GMass ~$5.4M/yr (~$200k MRR)</strong>, <strong>Browse AI $1.3M/yr</strong>, <strong>Momentum ~$996k/yr</strong>, <strong>SkyVerge $4.2M/yr</strong>. Reddit case cited: <strong>50,000 users → $21K ARR (~$1,750/mo), sub-1% conversion.</strong></p>
+<blockquote>Your revenue-per-user goes up as you get better at converting, not as your user count grows.<span class="cite"> - chromegoldmine, Mar 26 2026</span></blockquote>
+<p>Conversion mechanics: users shown a paywall <strong>mid-task convert at "3–5x the rate"</strong> of install-time prompts.</p>
+
+<p><strong>ExtensionPay's "8 extensions with impressive revenue" roundup</strong> (older data, instructive by category): CSS Scan <strong>$100k+ on a $69 one-time</strong> (dev tool — one-time worked); Spider <strong>$10k in 2 months at $38 one-time</strong>; versus subscription winners GMass ($130k/mo at $8–$20/mo), Closet Tools ($42k/mo at $30/mo), BlackMagic by Tony Dinh (~$3k/mo subscription).</p>
+
+<div class="takeaway"><div class="takeaway-label">SYNTHESIS</div> A local-first, low-marginal-cost client-side tool sits squarely in the bucket where one-time/lifetime converts best — but one-time structurally caps revenue at "new buyers per month" and is explicitly "less practical at scale." The conventional escape hatch: keep the core unlock one-time, layer a small separate subscription only on a genuinely server-backed feature later.</div>
+
+<h2>Free-tier gating that converts without backlash</h2>
+<p>Clear, repeated 2026 consensus on how to introduce paid tiers:</p>
+<ol>
+<li><strong>Launch freemium from day one — never bolt a paywall onto an already-free extension.</strong> ExtensionFast (Dec 5 2025): "Adding a paywall retroactively generates negative reviews." Launch with the free/paid split from the first public version.</li>
+<li><strong>Feature-gating beats usage caps for most tools.</strong> ExtensionFast (Feb 22 2026): "Feature gating works better than usage limits in most cases. Locking a specific high-value feature behind the paid tier is clearer and less frustrating" than punishing caps like "5 uses/day."</li>
+<li><strong>Trigger the upsell at the moment of delight or pain, mid-workflow — not at install.</strong> Contextual prompts convert <strong>3–5x</strong> better (chromegoldmine, Fungies, NicheCheck, all 2026). ExtensionFast example copy: "Liked that? Unlock unlimited conversions for just $4/month."</li>
+<li><strong>Upsell copy matters as much as placement</strong> — recall the DEV "Real Numbers" jump from <strong>2%→8%</strong> purely by listing benefits instead of a bare alert.</li>
+<li><strong>Set the free limit just below the power-user's typical session</strong> (DEV "Real Numbers") — but feature-gating is preferred over any cap.</li>
+</ol>
+
+<div class="callout">⚠️ Retroactive-paywall risk for a currently-free, open-source tool: the move from free→freemium must <strong>grandfather existing users</strong> and gate only genuinely new value, or it invites 1-star reviews. ExtensionFast, Dec 2025.</div>
+
+<h3>Realistic internal expectations</h3>
+<p>Freemium converts <strong>~1–3% of active users</strong> (0.8% observed across one real 5-extension portfolio); payment-flow completion <strong>~60–70%</strong>. Do not model off install counts.</p>
+
+<h2>Contradictions that challenge the "lifetime always wins" brief</h2>
+<ol>
+<li><strong>"Lifetime always wins" is too strong.</strong> It wins for client-side utility tools but subscriptions dominate every high-revenue professional category (SEO, dev tools, AI) and the entire $5k–$200k/mo tier; one-time is explicitly "less practical at scale." (NicheCheck, chromegoldmine, 2026.)</li>
+<li><strong>Retroactive paywalls cause review backlash</strong> — the single biggest execution risk for a currently free and open-source tool. (ExtensionFast, Dec 2025.)</li>
+<li><strong>Open-source + paid is a tension.</strong> If code is on GitHub, a license check is trivially bypassable; the moat becomes convenience, trust/updates, and data that only accrues for active paid users. Builders lean on merchant-of-record + "support the maintainer" framing over hard DRM. Polar.sh explicitly positions for OSS monetization.</li>
+<li><strong>ExtPay is convenient but is itself a hosted third party and not a merchant of record</strong> — a subtle ethos compromise for a "no server, local-first" brand, and it leaves global tax on you.</li>
+<li><strong>Polar's 2026 repricing</strong> erodes the "cheapest developer-first MoR" narrative — the flat 4% is now gated behind a $20–$400/mo plan; re-check live fees before committing. (Dodo review, 2026.)</li>
+</ol>
+
+<h2>Source index</h2>
+<ul>
+<li>DEV — Real Numbers: Freemium after 6 months — ~May 6 2026 — <code>dev.to/ktg0215/real-numbers-freemium-chrome-extension-monetization-after-6-months-5hga</code></li>
+<li>Medium (Soraia) — Why Lifetime Converts Better — Mar 2 2026</li>
+<li>chromium-extensions Google Group — ExtPay 3.1 / "$4,000 in annual subscriptions" — Mar 24 2025</li>
+<li>chromegoldmine — Revenue Benchmarks by User Count — Mar 26 2026</li>
+<li>NicheCheck — Most Profitable Extensions by Category — Feb 22 2026</li>
+<li>ExtensionPay — 8 Extensions with Impressive Revenue</li>
+<li>ExtensionFast — How to Price Your Chrome Extension — Feb 22 2026</li>
+<li>ExtensionFast — First $100 (gating/paywall placement) — Dec 5 2025</li>
+</ul>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix · Market Research</div>
+  <h1>Appendix I · CWS Policy &amp; Paywall UX</h1>
+<p class="lead">Totem is MV3, local-first, free and open source today. Shipping a $19 one-time Pro unlock (founders $14) introduces the product's first outbound network call — a license check. This appendix records the Chrome Web Store policy that governs that move and the paywall UX that converts a privacy-conscious, anti-subscription, local-first audience without burning their trust.</p>
+
+<h2>Native Web Store payments are dead — an external processor is mandatory</h2>
+
+<p>Chrome Web Store's built-in payments (the "Chrome Web Store Payments" / Google-Wallet-for-extensions API and <code>chrome.payments</code>) were <strong>deprecated and fully shut down on 1 February 2021.</strong> There is no native, Google-provided in-extension purchase flow anymore.</p>
+
+<p>The consequence is unavoidable: <span class="hl">all billing, tax/VAT, refunds, and license management must run through an external payment processor</span> and your own (or a third party's) infrastructure. Commonly used: Stripe, Paddle / Lemon Squeezy (merchant-of-record handles VAT), Gumroad, or the extension-specific wrapper <strong>ExtensionPay</strong> (<code>extpay</code>).</p>
+
+<p>The <strong>Chrome Web Store Developer Agreement</strong> explicitly allows charging fees but makes the developer <strong>solely responsible for all transactions, tax, and chargebacks.</strong> Free trial versions with an upsell to a full version are explicitly permitted and encouraged.</p>
+
+<div class="takeaway"><div class="takeaway-label">FOR TOTEM</div> The purchase flow happens off-extension — a checkout page on <code>usetotem.xyz</code> (or processor-hosted). For a one-time lifetime unlock, a merchant-of-record (Paddle / Lemon Squeezy) removes the global-tax burden vs. raw Stripe. The extension only ever <em>reads back a license result</em>.</div>
+
+<h2>MV3 "no remotely hosted code" — fetching a license is fine; executing fetched code is not</h2>
+
+<p>This is the single most important architectural constraint, and the good news is that it does <strong>not</strong> block license validation. The exact policy wording:</p>
+
+<blockquote>The full functionality of an extension must be easily discernible from its submitted code, unless otherwise exempt.<span class="cite"> - CWS Program Policies, Additional Requirements for MV3</span></blockquote>
+
+<h3>Prohibited (counts as Remotely Hosted Code / RHC)</h3>
+<ul>
+<li>Including a <code>&lt;script&gt;</code> tag that points to a resource that is not within the extension's package.</li>
+<li>Using JavaScript's <code>eval()</code> method or other mechanisms to execute a string fetched from a remote source.</li>
+<li>Building an interpreter to run complex commands fetched from a remote source, even if those commands are fetched as data.</li>
+</ul>
+
+<h3>Explicitly allowed (same policy page)</h3>
+<ul>
+<li>Syncing user account data with a remote server.</li>
+<li>Fetching a remote configuration file for A/B testing or determining enabled features, where all logic for the functionality is contained within the extension package.</li>
+<li>Fetching remote resources that are not used to evaluate logic, such as images.</li>
+<li>Performing server-side operations with data (such as for the purposes of encryption with a private key).</li>
+</ul>
+
+<blockquote>Remotely hosted code, or RHC, is what the Chrome Web Store calls anything that is executed by the browser that is loaded from someplace other than the extension's own files. Things like JavaScript and WASM. It does not include data or things like JSON or CSS.<span class="cite"> - CWS, Deal with remote hosted code violations</span></blockquote>
+
+<p>What this means for the license check:</p>
+<ul>
+<li>A network call that returns <strong>JSON</strong> ("is this license key valid? → <code>{valid: true, tier: 'pro', features: [...]}</code>") is <span class="hl">data, not code — fully compliant.</span> The Chrome docs literally name "determining enabled features" via a fetched remote config as an allowed pattern.</li>
+<li>The <strong>gating logic must live inside the shipped extension</strong> — the extension decides "if <code>tier === pro</code>, enable export." You must NOT fetch a JS blob that <em>implements</em> export, NOR build a mini-interpreter that runs server-sent commands.</li>
+<li>Compliant license design: extension sends a license key / token to your endpoint (or to the processor's verify endpoint, or ExtensionPay's API) → endpoint returns signed JSON (ideally a signed token / JWT or Ed25519-signed payload so the result can be cached and offline-verified) → extension stores the entitlement in <code>chrome.storage.local</code> and flips local feature flags. All feature code is already in the package and merely toggled.</li>
+</ul>
+
+<div class="callout">Reviewer-facing nuance: even allowed remote communication "must still be possible to determine the full functionality of your extension and the interaction must still comply with user data policies." Keep the request/response minimal and documented.</div>
+
+<h2>Single-purpose policy — adding Pro features must not broaden the purpose</h2>
+
+<p>Extensions must have a <strong>single, narrow purpose.</strong> "Extensions are assumed to utilize each of the permissions they request," and "excessive permissions unrelated to an extension's single purpose … will be viewed as enabling unrelated functionalities, resulting in a policy violation."</p>
+
+<p>New-tab override extensions get <strong>extra scrutiny</strong> — Google updated the <strong>Quality Guidelines FAQ on 22 Jan 2025</strong> specifically to clarify how the Single Purpose Policy applies to new tab pages (vertical vs. horizontal functionality). Totem already overrides the new tab; the Pro features (export, annotations, preservation, search filters, bulk ops) are all the <span class="hl">same single purpose — "reading / searching / exporting your X bookmarks"</span> — so they are safe <em>as long as the framing stays "bookmark management"</em> and you don't bolt on an unrelated AI chat or a second product.</p>
+
+<div class="takeaway"><div class="takeaway-label">ACTION</div> The single-purpose description in the Privacy practices tab should describe the whole feature set (free + pro) as one coherent purpose. Don't list "monetization" as a purpose.</div>
+
+<h2>Privacy policy + data-use disclosures triggered by the new license call</h2>
+
+<p>Adding any outbound call that includes user-identifiable data (email, license key, possibly account identifier) interacts with the <strong>Limited Use</strong> and <strong>User Data</strong> policies and the <strong>Privacy practices tab.</strong></p>
+
+<h3>Privacy practices tab — required fields</h3>
+<ol>
+<li><strong>Single purpose description.</strong></li>
+<li><strong>Permission justification</strong> — one justification per requested permission and per host permission.</li>
+<li><strong>Remote code declaration</strong> — must declare whether the extension uses remote code. For Totem the honest answer is <span class="tag">NO</span> (license response is data, not code) — declaring No correctly is important and defensible.</li>
+<li><strong>Data usage disclosure checkboxes</strong> — first group: which data types are collected (e.g. <em>personally identifiable information</em> like email, <em>authentication information</em>, <em>website content</em>). Second group: certifications.</li>
+<li><strong>Three Limited-Use certifications</strong> — certify you (a) do not sell user data / use it for unrelated purposes, (b) do not use/transfer data for ads or creditworthiness, (c) limit use to disclosed practices.</li>
+<li><strong>Privacy policy URL</strong> — required; must be consistent with the URL on the developer account.</li>
+</ol>
+
+<blockquote>Limit your use of user data to providing or improving your single purpose. … The privacy policy must, together with any in-Product disclosures, comprehensively disclose how your Product collects, uses and shares user data and all parties the user data will be shared with.<span class="cite"> - CWS, Limited Use policy</span></blockquote>
+
+<p>Limited Use bans: personalized ads, selling to data brokers, creditworthiness. Data sharing with third parties is only allowed where necessary for the purpose, legal compliance, or with explicit consent.</p>
+
+<p><strong>Implication for Totem (currently no server / no PII collection):</strong></p>
+<ul>
+<li>Adding a license check that transmits an <strong>email + license key to a payment processor and/or a Totem endpoint</strong> changes the data-collection answer from "none" to "personally identifiable information + authentication information." The disclosures and the privacy policy on <code>usetotem.xyz</code> must be updated to name Stripe / Paddle / ExtensionPay (or whoever) as a third party that receives the license/email data, and to state it is used solely for license validation — not for ads, not sold.</li>
+<li>Keep bookmark content <strong>out</strong> of the license call. Totem's whole pitch is local-first; the license payload should be license-key / email only, never bookmark data. This keeps "web browsing activity / website content" <em>not transmitted</em>, preserving the strongest privacy claim.</li>
+</ul>
+
+<h2>Permissions + CSP for the license endpoint</h2>
+
+<p>The license endpoint host must be reachable. Two options:</p>
+<ul>
+<li><strong><code>host_permissions</code></strong> entry for the endpoint domain (e.g. <code>https://api.usetotem.xyz/*</code>) if you call it from a content script / need broad access, <strong>or</strong></li>
+<li>Simpler / cleaner: call it from the <strong>service worker via <code>fetch()</code></strong>, which under MV3 generally does <span class="hl">not require a <code>host_permissions</code> grant</span> for a plain cross-origin <code>fetch</code> to your own HTTPS API from the background context. Prefer this to avoid adding scary host-permission warnings.</li>
+</ul>
+
+<p>Any host permission you DO add must be <strong>justified in the Privacy practices tab</strong> and tied to the single purpose; unjustified / broad host permissions are a top rejection reason. Do not request <code>&lt;all_urls&gt;</code> for a license check — scope to the exact license host. If you use a strict <code>content_security_policy</code>, the <code>extension_pages</code> policy controls <code>connect-src</code>; ensure the license host is permitted there if you tighten CSP.</p>
+
+<h2>Paywalling / free-trial / "limited functionality" rules</h2>
+
+<p>There is <strong>no rule against gating features behind payment.</strong> Free trials + upsell to a full version are explicitly allowed and encouraged. The binding constraints are <span class="hl">honesty / anti-deception</span>, not the existence of a paywall:</p>
+<ul>
+<li><strong>Deceptive Installation Tactics:</strong> you must not gate <em>advertised</em> features behind unrelated actions, must not use misleading CTAs, and must "clearly state" the product's features in marketing. The Web Store listing and any install-time copy must truthfully say what's free vs. what costs money.</li>
+<li><strong>"No cheating … by misleading users …"</strong> (Best Practices): misrepresenting what the extension does — including pretending a paid thing is free or vice versa — risks a ban.</li>
+</ul>
+
+<div class="takeaway"><div class="takeaway-label">ACTION</div> The store listing must disclose that Totem is free with an optional one-time Pro unlock, and list which features are Pro. Don't advertise "export your bookmarks!" as a headline benefit and then reveal at the moment of use that it's paid without prior disclosure — that edges toward the deceptive-tactics line. You <em>can</em> gate export behind Pro; you just have to have been upfront that export is a Pro feature.</div>
+
+<h2>CWS compliance checklist — shipping Totem Pro</h2>
+
+<h3>Payments / architecture</h3>
+<ul>
+<li>Use an external processor (Paddle / Lemon Squeezy as merchant-of-record recommended for one-time + global VAT; or Stripe + own tax handling; or ExtensionPay wrapper). No native CWS payments.</li>
+<li>Checkout happens off-extension (web page / processor-hosted), not inside an extension UI flow that pretends to be a native purchase.</li>
+<li>License validation returns <strong>JSON / data only</strong> (signed token preferred). No fetched JS/WASM, no <code>eval</code>, no server-command interpreter.</li>
+<li>All Pro feature <em>logic</em> ships inside the extension package; the license result only flips local feature flags.</li>
+<li>Validate the key online once, then <strong>cache the result</strong> in <code>chrome.storage.local</code> and read it locally — with a fail-open background re-check — so Pro keeps working without a per-launch network call.</li>
+</ul>
+
+<h3>Single purpose / permissions</h3>
+<ul>
+<li>Pro features stay within the existing single purpose (bookmark reading / search / export / preservation). No unrelated functionality.</li>
+<li>License call made from the service worker via <code>fetch</code> to a narrowly scoped host; avoid <code>&lt;all_urls&gt;</code>; add <code>host_permissions</code> only if strictly necessary and justify it.</li>
+<li>If CSP is tightened, allow the license host in <code>connect-src</code> of <code>extension_pages</code>.</li>
+</ul>
+
+<h3>Privacy / data</h3>
+<ul>
+<li>Update the Privacy practices tab: single-purpose description (free + pro as one purpose), per-permission justifications, remote-code = <strong>No</strong>, data-collected checkboxes now include <strong>PII (email) + authentication info (license key)</strong>, and the 3 Limited-Use certifications.</li>
+<li>Update the privacy policy on <code>usetotem.xyz</code> to disclose: license/email sent to &lt;processor&gt; for validation; not sold, not used for ads; bookmark data never transmitted.</li>
+<li>Keep the Limited-Use affirmative statement and ensure the privacy-policy URL matches the developer-account URL.</li>
+<li>Ensure no bookmark / browsing content is included in the license request (preserve "no web browsing activity transmitted").</li>
+</ul>
+
+<h3>Listing / honesty</h3>
+<ul>
+<li>Store listing clearly states: free core + optional <strong>one-time</strong> Pro unlock; lists which features are Pro.</li>
+<li>No misleading CTAs; don't gate an <em>advertised headline</em> feature without prior disclosure (Deceptive Installation Tactics).</li>
+<li>No nagging / forced-action dark patterns at install.</li>
+</ul>
+
+<h2>The macro data: one-time vs. subscription, soft vs. hard gates</h2>
+
+<p><strong>RevenueCat 2026 benchmark</strong> (115k+ apps, $16B revenue): hard paywalls convert ~<strong>10.7%</strong>, freemium ~<strong>2.1%.</strong> Hard gates win per-user economics; freemium wins on volume / word-of-mouth. <span class="hl">Trial-format screens beat visual-only paywalls in 64.5% of experiments.</span></p>
+
+<p><strong>But Totem's audience is the exception that breaks the funnel-maximizing playbook.</strong> For privacy / local-first / anti-subscription communities (r/selfhosted, r/nosurf, HN), the open-source + free-core + <em>optional one-time</em> model is itself the trust signal. A pure hard paywall would nuke the goodwill that makes these communities <em>evangelize</em> a tool. The right model here is <strong>freemium with a generous free core + a one-time unlock</strong>, optimized not for raw % conversion but for trust-preserving conversion + word-of-mouth.</p>
+
+<div class="callout">The conversion lever that matters most is the "wow moment" before the ask. Totango: users who achieve at least one meaningful outcome are <strong>5x more likely to convert.</strong> Show the upgrade prompt only after the user has felt value.</div>
+
+<h2>The reference model: Obsidian, the gold standard this audience already trusts</h2>
+
+<p>Plain Markdown files on device, <strong>no account, no cloud dependency, no telemetry, no data sold.</strong> Paid add-ons (Sync / Publish) are optional; the <strong>Catalyst license is a one-time payment framed as a "tip jar" / support-the-developers</strong> with perks (early betas, badge). This is repeatedly cited as "one of the most honest pricing models in productivity software."</p>
+
+<div class="takeaway"><div class="takeaway-label">LESSON FOR TOTEM</div> Lean into the same posture — "your data stays local, the app stays free and open source, Pro is a one-time unlock that funds the work." Frame Pro partly as <em>support</em>, not <em>feature ransom</em>. The one-time (not subscription) structure is the single biggest trust-aligner with this crowd.</div>
+
+<h2>Anti-patterns that trigger backlash — the DON'T list</h2>
+
+<ul>
+<li><strong>Nagging.</strong> Repeated upgrade pop-ups after the user declined = the #1 anger trigger; people mute, uninstall, and post screenshots. One contextual prompt, dismissible, that stays dismissed.</li>
+<li><strong>Crippleware / bait-and-switch on existing free features.</strong> Taking a feature that's <em>currently free</em> (Totem already ships export-ish, search, sync) and moving it behind Pro for existing users feels like theft. <span class="hl">Grandfather current free features;</span> only gate genuinely new Pro capabilities, or clearly new/enhanced versions.</li>
+<li><strong>Forced action / fake "free trial" that demands a card up front.</strong> This crowd reads a card-required trial as a trap. If you trial Pro, make it <strong>no-card</strong> or just use a generous free tier instead.</li>
+<li><strong>Dark-pattern checkout</strong> (hidden recurring charge, pre-checked add-ons, confusing "cancel"). For a one-time purchase this is mostly avoided — but make crystal clear it is one-time, not a sub.</li>
+<li><strong>Surprise paywall at the moment of need with no prior disclosure</strong> (also a CWS deceptive-tactics risk).</li>
+<li><strong>Telemetry / "phone home" creep.</strong> Any new network call is scrutinized. Be loud that the license check sends only email + key (+ a device id), never bookmarks, and runs only at activation plus an occasional background re-check — not on every launch.</li>
+<li><strong>Manipulative urgency / scarcity</strong> ("only 3 left!") — reads as scammy to a technical audience. The founders price is fine <em>if framed honestly</em> ("$14 founders price, going to $19" — a real, time-boxed thing, not a fake countdown).</li>
+</ul>
+
+<h2>Patterns that convert without backlash — the DO list</h2>
+
+<ul>
+<li><strong>Soft gates with lock badges, not walls.</strong> Show the Pro features <em>in the UI</em>, visible but with a small lock / "Pro" badge, so users see what they'd get. Visible-but-locked teases create "something concrete to miss."</li>
+<li><strong>"Try before you buy" via a free allowance, not a time bomb.</strong> Let users <strong>export the first N bookmarks free</strong> (e.g. 25 rows of CSV / Markdown), preview the full export, then unlock unlimited. They feel the value on <em>their own data</em> before paying — the highest-trust analog of a trial for a one-time product.</li>
+<li><strong>Contextual prompt at the moment of value, exactly once.</strong> The upgrade ask appears <em>when the user reaches for the locked capability</em> (clicks Export, selects 50 bookmarks for a bulk op, opens a deleted-tweet they'd lose). The documented highest-intent moment.</li>
+<li><strong>Honest "what you're paying for" framing</strong> — solve the "no server, why does it cost money?" objection head-on: <em>"You're paying for the work, not a subscription — Totem stays free and open source. Pro is a one-time unlock that funds ongoing development. Your data never leaves your machine."</em> Tie price to <strong>outcomes</strong> (own your archive forever, never lose a deleted tweet), not to infra.</li>
+<li><strong>Reverse-trial option (optional):</strong> give new installs a short window where Pro is fully on, then drop to free. Exposure to Pro creates a concrete thing to upgrade <em>back</em> to. Only do this <strong>no-card.</strong></li>
+<li><strong>Status / support framing</strong> (Obsidian Catalyst): a small "Founding supporter" badge or changelog credit makes Pro feel like patronage, not extortion.</li>
+<li><strong>Trial-format / value-first screen beats a bare price wall</strong> (64.5% win rate) — a screen that shows what Pro does + the free allowance result, not just "$19, pay now."</li>
+</ul>
+
+<h2>Recommended in-product upgrade moments for Totem</h2>
+
+<p>Ranked by intent. Each fires <strong>once, contextually, dismissible</strong>, after the user has felt value.</p>
+
+<table class="striped">
+<thead><tr><th>#</th><th>Moment</th><th>Trigger &amp; copy</th><th>Why it works</th></tr></thead>
+<tbody>
+<tr><td>1</td><td><strong>At export, after a free preview</strong> <span class="tag">PRIMARY</span></td><td>User clicks "Export → Markdown / CSV / JSONL." Export/preview the first ~25 items free, show the full count behind a soft gate: <em>"Export all 3,412 bookmarks → Unlock Pro ($14 founders / $19)."</em></td><td>Highest intent — they're actively trying to get their data out.</td></tr>
+<tr><td>2</td><td><strong>Deleted / unavailable tweet opened</strong> <span class="tag">SECONDARY</span></td><td><em>"This tweet was deleted on X. Totem kept your copy. Pro preserves every deleted bookmark automatically."</em></td><td>Emotional, unique-value moment (loss aversion) — very strong for this audience.</td></tr>
+<tr><td>3</td><td><strong>Bulk operation</strong></td><td>User multi-selects (e.g. 50 bookmarks) to tag / delete / move: <em>"Bulk actions are a Pro feature."</em></td><td>They've already invested effort selecting — high intent.</td></tr>
+<tr><td>4</td><td><strong>Advanced search filter use</strong></td><td>User opens filters (by date / author / media / folder): show the filters with a lock badge; selecting one prompts upgrade.</td><td>Shows the capability before charging for it.</td></tr>
+<tr><td>5</td><td><strong>First annotation</strong></td><td>User tries to add a note / highlight to a bookmark.</td><td>Intent to deepen use of their own archive.</td></tr>
+</tbody>
+</table>
+
+<div class="callout">Cross-cutting placement rules: one persistent, quiet "Upgrade to Pro" / "Support Totem" entry in settings or a corner (always available, never a pop-up); never auto-popup on new-tab load; never re-prompt the same context after dismissal in a session; always state <strong>one-time, not subscription</strong> and <strong>data stays local</strong> in the prompt.</div>
+
+<h2>Presenting the $19 one-time unlock without feeling scammy</h2>
+
+<ul>
+<li><strong>Headline the model, not the price:</strong> "Totem Pro — one-time unlock. No subscription. Ever." Subscription-fatigue is the documented pain point for this crowd.</li>
+<li><strong>Pre-empt the "no server, why pay?" question</strong> with the funds-the-work / stays-open-source line.</li>
+<li><strong>Founders price done honestly:</strong> "$14 founders price (rising to $19)" — real and time-boxed, no fake countdown timers or "3 left."</li>
+<li><strong>Reassure on the license check:</strong> a small line near checkout — <em>"Pro is verified by a one-time license check (email + key only). Your bookmarks never leave your device."</em></li>
+<li><strong>Receipt of ownership:</strong> make the license restorable across machines via the key / email; <span class="hl">"buy once, use on all your browsers"</span> reinforces ownership, the core anti-subscription value.</li>
+</ul>
+</section>
+
+<section class="chapter">
+  <div class="chapter-num">Appendix J · References</div>
+  <h1>References &amp; Method</h1>
+<p class="lead">
+  This document synthesizes a nine-agent deep dive of the Totem codebase and the 2026 payments/extension market, plus an adversarial verification pass. The appendices reproduce the underlying research records.
+</p>
+
+<h2>Method</h2>
+<p>Five agents read the codebase along independent seams (data &amp; sync, features &amp; export, build &amp; release, site &amp; distribution, UI state &amp; upsell). Four agents researched the market (payments, license architecture, recent discourse, Chrome Web Store policy &amp; UX). A final reviewer adversarially re-checked the load-bearing code claims against the live repository and red-teamed the strategy. The nine raw reports are condensed in Appendices A–I; the verification pass is Chapter 11.</p>
+
+<h2>A. Source reports</h2>
+<table class="compact">
+  <thead><tr><th>Report</th><th>Focus</th><th>Appendix</th></tr></thead>
+  <tbody>
+    <tr><td><code>cb-data-sync.md</code></td><td>Entitlement storage + reactive channel</td><td>A</td></tr>
+    <tr><td><code>cb-features-export.md</code></td><td>Export gate + feature inventory</td><td>B</td></tr>
+    <tr><td><code>cb-build-release.md</code></td><td>Pipeline + manifest + CWS mechanics</td><td>C</td></tr>
+    <tr><td><code>cb-site-distribution.md</code></td><td>Astro static site + checkout pages</td><td>D</td></tr>
+    <tr><td><code>cb-ui-state-upsell.md</code></td><td>usePro / ProGate / upsell mounts</td><td>E</td></tr>
+    <tr><td><code>rs-payments.md</code></td><td>Gateway comparison</td><td>F</td></tr>
+    <tr><td><code>rs-license-arch.md</code></td><td>License-key architecture + DRM stance (explored offline keys; plan chose online-validate-then-cache)</td><td>G</td></tr>
+    <tr><td><code>rs-recent-discourse.md</code></td><td>2026 builder evidence, lifetime vs subscription</td><td>H</td></tr>
+    <tr><td><code>rs-cws-policy-ux.md</code></td><td>CWS compliance + paywall UX</td><td>I</td></tr>
+  </tbody>
+</table>
+<p>The synthesized plan lives at <code>plans/premium-conversion-plan.md</code>; raw reports at <code>plans/research/premium-monetization/raw/</code>; strategy context at <code>plans/gtm-research-report-2026-06-16.md</code>.</p>
+
+<h2>B. Glossary</h2>
+<p><strong>MoR (Merchant of Record)</strong> — a payment provider that becomes the legal seller and remits global VAT/GST on your behalf (Lemon Squeezy, Polar, Gumroad). Removes the tax-registration burden from a solo developer.</p>
+<p><strong>MV3</strong> — Chrome Manifest V3. Bans remotely-hosted <em>code</em> but allows fetching remote <em>data</em>; an online license <strong>validate</strong> call returns JSON data (not code), so it is compliant.</p>
+<p><strong>Entitlement</strong> — the device-global fact "this install is Pro." Stored authoritatively in <code>CS_ENTITLEMENT</code> (service-worker-owned <code>chrome.storage.local</code>), independent of account or reset.</p>
+<p><strong>License key</strong> — a key the merchant-of-record mints on a paid order. The extension <strong>validates</strong> it against the provider's license API once at activation (a no-secret, public data call), caches the result in <code>CS_ENTITLEMENT</code>, and reads it locally thereafter — re-checking in the background with fail-open.</p>
+<p><strong>Cache + fail-open</strong> — the resilience rule for online verification: validate once, store the result, read from the store on every launch, and if a background re-check can't reach the network, keep Pro on (never lock out a paying user over an outage).</p>
+<p><strong>Activation / device limit</strong> — the provider caps how many devices a key can activate (recommend ~5) and exposes activate/deactivate so a user can free a slot themselves. This is how multi-browser activation is managed, and it requires the online check.</p>
+<p><strong>Grandfathering</strong> — granting existing users full features free, forever, so the paywall only ever applies to new installs. The primary backlash mitigation.</p>
+<p><strong>Hydration</strong> — Totem's existing engine that fetches and caches tweet detail, already classifying deleted/protected tweets — the basis of the "deleted-tweet preservation" Pro feature.</p>
+<p><strong>CWS</strong> — Chrome Web Store. Native in-extension payments were removed Feb 1, 2021; an external processor is mandatory.</p>
+
+<h2>C. Acknowledgements</h2>
+<p>Compiled from automated codebase and market research agents over the Totem repository, reconciled into a single executable plan and verified adversarially before delivery.</p>
+</section>
+
+</body>
+</html>

--- a/plans/research/totem-gtm-research-2026-06-16.html
+++ b/plans/research/totem-gtm-research-2026-06-16.html
@@ -1,0 +1,2198 @@
+<!DOCTYPE html>
+<!-- ==================================================================
+     Totem GTM Research Report · long-doc-en · parchment design system
+     16 June 2026 · 8 chapters: bets → personas → communities →
+     post formats → pricing → features → blog → niche
+     ================================================================== -->
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Totem GTM Research Report — June 2026</title>
+<meta name="author" content="Ankit">
+<meta name="description" content="16-agent community research sweep covering personas, communities, pricing, features, and blog ideas for Totem.">
+<meta name="keywords" content="totem, gtm, twitter bookmarks, chrome extension, growth, community research">
+<meta name="generator" content="Kami">
+<style>
+  @page {
+    size: A4;
+    margin: 20mm 22mm 22mm 22mm;
+    background: #f5f4ed;
+    @top-right {
+      content: string(section-title);
+      font-family: Charter, Georgia, Palatino, serif;
+      font-size: 8pt;
+      color: #6b6a64;
+    }
+    @bottom-center {
+      content: counter(page) "  ·  Totem GTM Research · June 2026";
+      font-family: Charter, Georgia, Palatino, serif;
+      font-size: 9pt;
+      color: #6b6a64;
+    }
+  }
+  @page:first {
+    @top-right  { content: ""; }
+    @bottom-center { content: ""; }
+  }
+
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  :root {
+    --parchment: #f5f4ed;
+    --ivory:     #faf9f5;
+    --near-black:#141413;
+    --dark-warm: #3d3d3a;
+    --olive:     #504e49;
+    --stone:     #6b6a64;
+    --brand:     #1B365D;
+    --brand-lt:  #2a527f;
+    --border:    #e8e6dc;
+    --border-soft:#e5e3d8;
+    --tag-bg:    #E4ECF5;
+    --tag-green: #e2f0e8;
+    --tag-green-fg: #1a5c38;
+    --tag-amber: #fef3e2;
+    --tag-amber-fg: #7a4a00;
+    --tag-red:   #fce8e8;
+    --tag-red-fg:#7a1a1a;
+
+    --serif: Charter, Georgia, Palatino, "Times New Roman", serif;
+    --sans:  var(--serif);
+    --mono:  "SF Mono", "Fira Code", Consolas, Monaco, monospace;
+
+    --rhythm-module:  14pt;
+    --rhythm-section: 18pt;
+  }
+
+  html, body { background: var(--parchment); }
+
+  @media screen {
+    body { max-width: 860px; margin: 0 auto; padding: 40px 52px; }
+  }
+
+  body {
+    color: var(--near-black);
+    font-family: var(--serif);
+    font-size: 10.5pt;
+    line-height: 1.55;
+    widows: 3; orphans: 3;
+  }
+
+  /* ---------- COVER ---------- */
+  .cover {
+    min-height: 240mm;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 40mm 0 0 0;
+    break-after: page;
+  }
+  @media screen {
+    .cover { min-height: 80vh; padding-top: 80px; margin-bottom: 60px; }
+  }
+  .cover-eyebrow {
+    font-size: 10pt;
+    color: var(--brand);
+    letter-spacing: 2pt;
+    text-transform: uppercase;
+    font-weight: 500;
+    margin-bottom: 18pt;
+  }
+  .cover-title {
+    font-size: 40pt;
+    font-weight: 500;
+    color: var(--near-black);
+    line-height: 1.12;
+    letter-spacing: -0.5pt;
+    margin-bottom: 16pt;
+  }
+  .cover-sub {
+    font-size: 14pt;
+    color: var(--olive);
+    line-height: 1.45;
+    max-width: 85%;
+    margin-bottom: 30pt;
+  }
+  .cover-meta {
+    font-size: 10pt;
+    color: var(--stone);
+    line-height: 1.7;
+    font-variant-numeric: tabular-nums;
+    border-top: 0.5pt solid var(--border);
+    padding-top: 14pt;
+    margin-top: 30pt;
+  }
+  .cover-meta strong { color: var(--dark-warm); font-weight: 500; }
+
+  /* ---------- TOC ---------- */
+  .toc { break-after: page; }
+  @media screen { .toc { margin-bottom: 60px; } }
+  .toc h2 {
+    font-size: 22pt;
+    font-weight: 500;
+    margin-bottom: var(--rhythm-module);
+    border-left: 2.5pt solid var(--brand);
+    border-radius: 1.5pt;
+    padding-left: 10pt;
+  }
+  .toc-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    padding: 7pt 0;
+    border-bottom: 0.3pt dotted var(--border);
+    font-size: 11pt;
+  }
+  .toc-item:last-of-type { border-bottom: none; }
+  .toc-num { color: var(--brand); font-weight: 500; min-width: 36pt; }
+  .toc-title { flex: 1; color: var(--near-black); padding-left: 6pt; }
+  .toc-sub {
+    font-size: 9pt;
+    color: var(--stone);
+    display: block;
+    padding-left: 42pt;
+    padding-top: 2pt;
+    padding-bottom: 4pt;
+  }
+
+  /* ---------- CHAPTER ---------- */
+  .chapter { break-before: page; }
+  @media screen { .chapter { margin-bottom: 64px; padding-top: 48px; border-top: 1px solid var(--border); } }
+
+  .chapter-num {
+    font-size: 10pt;
+    color: var(--brand);
+    letter-spacing: 1pt;
+    text-transform: uppercase;
+    font-weight: 500;
+    margin-bottom: 6pt;
+  }
+
+  /* ---------- HEADINGS ---------- */
+  h1 {
+    font-size: 26pt;
+    font-weight: 500;
+    line-height: 1.15;
+    letter-spacing: -0.3pt;
+    margin: 0 0 12pt 0;
+    border-left: 3pt solid var(--brand);
+    border-radius: 1.5pt;
+    padding-left: 10pt;
+    color: var(--near-black);
+    break-after: avoid;
+  }
+  h2 {
+    font-size: 16pt;
+    font-weight: 500;
+    line-height: 1.25;
+    margin: 28pt 0 8pt 0;
+    color: var(--near-black);
+    break-after: avoid;
+    string-set: section-title content();
+  }
+  h3 {
+    font-size: 13pt;
+    font-weight: 500;
+    line-height: 1.3;
+    margin: 18pt 0 6pt 0;
+    color: var(--dark-warm);
+    break-after: avoid;
+  }
+  h4 {
+    font-size: 11pt;
+    font-weight: 500;
+    margin: 12pt 0 4pt 0;
+    color: var(--dark-warm);
+    break-after: avoid;
+  }
+
+  /* ---------- PARAGRAPHS ---------- */
+  p { margin: 0 0 10pt 0; line-height: 1.55; color: var(--near-black); widows: 2; orphans: 2; }
+  .lead { font-size: 12pt; line-height: 1.55; color: var(--dark-warm); margin-bottom: var(--rhythm-module); }
+  .hl { color: var(--brand); font-weight: 500; }
+  strong { font-weight: 500; }
+
+  /* ---------- LISTS ---------- */
+  ul, ol { margin: 6pt 0 10pt 0; padding-left: 20pt; line-height: 1.55; }
+  ul li::marker { color: var(--brand); }
+  ol li::marker { color: var(--brand); font-weight: 500; }
+  li { margin-bottom: 4pt; }
+  li:last-child { margin-bottom: 0; }
+
+  /* ---------- QUOTE ---------- */
+  blockquote {
+    border-left: 2pt solid var(--brand);
+    margin: 14pt 0;
+    padding: 4pt 0 4pt 16pt;
+    color: var(--olive);
+    line-height: 1.55;
+    break-inside: avoid;
+    font-style: italic;
+  }
+  blockquote .cite {
+    display: block;
+    font-style: normal;
+    font-size: 9pt;
+    color: var(--stone);
+    margin-top: 5pt;
+  }
+
+  /* ---------- CODE ---------- */
+  code {
+    font-family: var(--mono);
+    font-size: 9pt;
+    background: var(--ivory);
+    padding: 1pt 4pt;
+    border-radius: 2pt;
+    color: var(--dark-warm);
+  }
+
+  /* ---------- TABLE ---------- */
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 9.5pt;
+    margin: 14pt 0;
+    break-inside: avoid;
+  }
+  th {
+    text-align: left;
+    font-weight: 500;
+    color: var(--dark-warm);
+    padding: 6pt 9pt;
+    border-bottom: 1pt solid var(--border);
+    background: var(--ivory);
+  }
+  td {
+    padding: 5pt 9pt;
+    border-bottom: 0.3pt solid var(--border-soft);
+    vertical-align: top;
+    line-height: 1.45;
+  }
+  tr:last-child td { border-bottom: none; }
+  table.striped tbody tr:nth-child(even) td { background: var(--ivory); }
+
+  /* ---------- CALLOUT ---------- */
+  .callout {
+    background: var(--ivory);
+    border-left: 2.5pt solid var(--brand);
+    padding: 10pt 16pt;
+    border-radius: 3pt;
+    margin: 14pt 0;
+    line-height: 1.55;
+    break-inside: avoid;
+  }
+  .callout p { margin-bottom: 6pt; }
+  .callout p:last-child { margin-bottom: 0; }
+
+  /* ---------- TAKEAWAY ---------- */
+  .takeaway {
+    background: var(--ivory);
+    border-radius: 4pt;
+    padding: 12pt 16pt;
+    margin: 16pt 0;
+    break-inside: avoid;
+    border: 0.5pt solid var(--border);
+  }
+  .takeaway-label {
+    font-size: 9pt;
+    color: var(--brand);
+    letter-spacing: 1pt;
+    text-transform: uppercase;
+    font-weight: 500;
+    margin-bottom: 6pt;
+  }
+
+  /* ---------- TAGS ---------- */
+  .tag {
+    display: inline-block;
+    background: var(--tag-bg);
+    color: var(--brand);
+    font-size: 8.5pt;
+    font-weight: 500;
+    padding: 1.5pt 6pt;
+    border-radius: 3pt;
+    letter-spacing: 0.4pt;
+    text-transform: uppercase;
+    margin-right: 4pt;
+    margin-bottom: 2pt;
+    white-space: nowrap;
+  }
+  .tag.green { background: var(--tag-green); color: var(--tag-green-fg); }
+  .tag.amber { background: var(--tag-amber); color: var(--tag-amber-fg); }
+  .tag.red   { background: var(--tag-red);   color: var(--tag-red-fg); }
+
+  /* ---------- PERSONA CARD ---------- */
+  .persona-card {
+    border: 0.5pt solid var(--border);
+    border-radius: 5pt;
+    padding: 16pt 18pt;
+    margin: 16pt 0;
+    break-inside: avoid;
+    background: var(--ivory);
+  }
+  .persona-rank {
+    font-size: 9pt;
+    font-weight: 500;
+    color: var(--brand);
+    letter-spacing: 1pt;
+    text-transform: uppercase;
+    margin-bottom: 4pt;
+  }
+  .persona-name {
+    font-size: 15pt;
+    font-weight: 500;
+    color: var(--near-black);
+    margin-bottom: 6pt;
+  }
+  .persona-line {
+    font-size: 10.5pt;
+    color: var(--olive);
+    margin-bottom: 12pt;
+    font-style: italic;
+  }
+  .persona-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 10pt;
+    margin-bottom: 10pt;
+  }
+  @media screen and (max-width: 600px) {
+    .persona-grid { grid-template-columns: 1fr; }
+  }
+  .persona-field label {
+    display: block;
+    font-size: 8.5pt;
+    color: var(--brand);
+    font-weight: 500;
+    letter-spacing: 0.8pt;
+    text-transform: uppercase;
+    margin-bottom: 2pt;
+  }
+  .persona-field p {
+    font-size: 9.5pt;
+    color: var(--dark-warm);
+    margin: 0;
+    line-height: 1.45;
+  }
+  .convert-line {
+    background: #edf2f8;
+    border-left: 2pt solid var(--brand);
+    padding: 8pt 12pt;
+    border-radius: 2pt;
+    margin-top: 10pt;
+    font-size: 9.5pt;
+    color: var(--near-black);
+    font-style: italic;
+    break-inside: avoid;
+  }
+  .convert-line span {
+    display: block;
+    font-size: 8.5pt;
+    color: var(--stone);
+    font-style: normal;
+    margin-bottom: 3pt;
+    font-weight: 500;
+    letter-spacing: 0.5pt;
+    text-transform: uppercase;
+  }
+
+  /* ---------- COMMUNITY CARD ---------- */
+  .community-card {
+    border: 0.5pt solid var(--border);
+    border-radius: 5pt;
+    padding: 14pt 18pt;
+    margin: 14pt 0;
+    break-inside: avoid;
+  }
+  .community-header {
+    display: flex;
+    align-items: baseline;
+    gap: 10pt;
+    margin-bottom: 8pt;
+    flex-wrap: wrap;
+  }
+  .community-name {
+    font-size: 13pt;
+    font-weight: 500;
+    color: var(--near-black);
+  }
+  .example-title {
+    background: #f0f4f9;
+    border-left: 2pt solid var(--brand-lt);
+    padding: 6pt 10pt;
+    border-radius: 2pt;
+    font-size: 9.5pt;
+    color: var(--brand);
+    margin: 8pt 0;
+    font-style: italic;
+  }
+  .example-title span {
+    display: block;
+    font-size: 8.5pt;
+    font-style: normal;
+    color: var(--stone);
+    font-weight: 500;
+    letter-spacing: 0.5pt;
+    text-transform: uppercase;
+    margin-bottom: 3pt;
+  }
+  .not-todo {
+    background: var(--tag-red);
+    border-radius: 3pt;
+    padding: 6pt 10pt;
+    font-size: 9.5pt;
+    color: var(--tag-red-fg);
+    margin-top: 8pt;
+    break-inside: avoid;
+  }
+  .not-todo strong { color: var(--tag-red-fg); }
+
+  /* ---------- FEATURE CARD ---------- */
+  .feature-card {
+    border-left: 3pt solid var(--brand);
+    padding: 12pt 0 12pt 16pt;
+    margin: 14pt 0;
+    break-inside: avoid;
+  }
+  .feature-num {
+    font-size: 8.5pt;
+    font-weight: 500;
+    color: var(--brand);
+    letter-spacing: 1pt;
+    text-transform: uppercase;
+    margin-bottom: 3pt;
+  }
+  .feature-title {
+    font-size: 12.5pt;
+    font-weight: 500;
+    color: var(--near-black);
+    margin-bottom: 6pt;
+  }
+  .feature-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4pt;
+    margin-bottom: 8pt;
+  }
+  .feature-evidence {
+    font-size: 9.5pt;
+    color: var(--olive);
+    font-style: italic;
+    margin-top: 6pt;
+    border-top: 0.3pt solid var(--border-soft);
+    padding-top: 6pt;
+  }
+
+  /* ---------- BLOG CARD ---------- */
+  .blog-card {
+    border: 0.5pt solid var(--border);
+    border-radius: 4pt;
+    padding: 12pt 16pt;
+    margin: 12pt 0;
+    break-inside: avoid;
+  }
+  .blog-num {
+    font-size: 8.5pt;
+    font-weight: 500;
+    color: var(--brand);
+    letter-spacing: 1pt;
+    text-transform: uppercase;
+    margin-bottom: 3pt;
+  }
+  .blog-title {
+    font-size: 12pt;
+    font-weight: 500;
+    color: var(--near-black);
+    margin-bottom: 6pt;
+    font-style: italic;
+  }
+  .blog-evidence {
+    font-size: 9.5pt;
+    color: var(--stone);
+    margin: 4pt 0;
+    line-height: 1.45;
+  }
+
+  /* ---------- DIVIDER ---------- */
+  hr {
+    border: none;
+    border-top: 0.5pt solid var(--border);
+    margin: 18pt 0;
+  }
+
+  /* ---------- UTILITIES ---------- */
+  .mt { margin-top: 16pt; }
+  .small { font-size: 9pt; color: var(--stone); }
+  .two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 14pt;
+  }
+  @media screen and (max-width: 600px) {
+    .two-col { grid-template-columns: 1fr; }
+  }
+
+  /* ---------- TODO SYSTEM ---------- */
+  .todo-check {
+    appearance: none; -webkit-appearance: none;
+    width: 13pt; height: 13pt;
+    border: 1.5pt solid var(--border);
+    border-radius: 2.5pt;
+    cursor: pointer; flex-shrink: 0;
+    background: white;
+    vertical-align: middle;
+    transition: background 0.12s, border-color 0.12s;
+  }
+  .todo-check:checked {
+    background: var(--brand);
+    border-color: var(--brand);
+    background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 10 8' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M1 4l3 3 5-6' stroke='%23fff' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-size: 65%; background-position: center; background-repeat: no-repeat;
+  }
+  .todo-check:hover:not(:checked) { border-color: var(--brand-lt); }
+
+  tr.todo-done td { opacity: 0.42; }
+  tr.todo-done td:first-child { opacity: 1; }
+  tr.todo-done td:nth-child(2) { text-decoration: line-through; text-decoration-color: var(--stone); }
+
+  .card-todo-done { opacity: 0.45; }
+  .card-todo-done .community-name { text-decoration: line-through; text-decoration-color: var(--stone); }
+
+  .todo-progress-bar {
+    background: var(--ivory);
+    border: 0.5pt solid var(--border);
+    border-radius: 4pt;
+    padding: 10pt 16pt;
+    margin-bottom: 16pt;
+    display: flex;
+    align-items: center;
+    gap: 12pt;
+    flex-wrap: wrap;
+  }
+  .todo-count { font-size: 11pt; color: var(--dark-warm); }
+  .todo-count strong { color: var(--brand); }
+  .todo-bar-track {
+    flex: 1; height: 5pt;
+    background: var(--border);
+    border-radius: 3pt;
+    min-width: 80pt;
+  }
+  .todo-bar-fill {
+    height: 100%; background: var(--brand);
+    border-radius: 3pt; transition: width 0.2s;
+  }
+  .todo-reset {
+    font-size: 8.5pt; color: var(--stone);
+    cursor: pointer; background: none;
+    border: none; padding: 0;
+    text-decoration: underline;
+    font-family: var(--serif);
+  }
+  .todo-reset:hover { color: var(--brand); }
+</style>
+</head>
+<body>
+
+<!-- ================================================================
+     COVER
+     ================================================================ -->
+<section class="cover">
+  <div>
+    <div class="cover-eyebrow">GTM Research · Community Sweep · 16 Agents</div>
+    <div class="cover-title">Totem GTM<br>Research Report</div>
+    <div class="cover-sub">Who pays, where they are, what to say, what to build, and which niche to own — grounded in 30-day community data across Reddit, HN, X, and PKM forums.</div>
+  </div>
+  <div class="cover-meta">
+    <strong>usetotem.xyz</strong> · Twitter bookmarks on every new tab, local-first<br>
+    June 16, 2026 · 16-agent research sweep · 282 tool calls · ~993k tokens<br>
+    Channels: Reddit (r/nosurf, r/ObsidianMD, r/selfhosted, r/degoogle, r/PKM, r/SideProject, r/productivity, r/DataHoarder, r/privacytoolsIO) · Hacker News · X/Twitter · Indie Hackers
+  </div>
+</section>
+
+<!-- ================================================================
+     TABLE OF CONTENTS
+     ================================================================ -->
+<section class="toc">
+  <h2>Contents</h2>
+  <div class="toc-item">
+    <span class="toc-num">01</span>
+    <span class="toc-title">The 3 Bets to Make Right Now</span>
+  </div>
+  <div class="toc-item">
+    <span class="toc-num">02</span>
+    <span class="toc-title">Who Actually Pays for This — 5 Ranked Personas</span>
+  </div>
+  <div class="toc-item">
+    <span class="toc-num">03</span>
+    <span class="toc-title">Community Playbook — Where to Show Up</span>
+  </div>
+  <div class="toc-item">
+    <span class="toc-num">04</span>
+    <span class="toc-title">What Kind of Post Works — Format Analysis</span>
+  </div>
+  <div class="toc-item">
+    <span class="toc-num">05</span>
+    <span class="toc-title">Pricing — One-Time vs Subscription</span>
+  </div>
+  <div class="toc-item">
+    <span class="toc-num">06</span>
+    <span class="toc-title">Features to Build — Demand-Validated</span>
+  </div>
+  <div class="toc-item">
+    <span class="toc-num">07</span>
+    <span class="toc-title">Blog Posts to Write Next — Real Problems</span>
+  </div>
+  <div class="toc-item">
+    <span class="toc-num">08</span>
+    <span class="toc-title">The Niche to Own</span>
+  </div>
+</section>
+
+<!-- ================================================================
+     01 · THE 3 BETS
+     ================================================================ -->
+<section class="chapter">
+  <div class="chapter-num">01 · The 3 Bets</div>
+  <h1>The 3 Bets to Make Right Now</h1>
+  <p class="lead">Sixteen agents across ten research angles converge on three moves. Everything else is sequenced after these. The window for the Pocket/Omnivore displacement cohort is open <span class="hl">right now</span> — they are actively shopping.</p>
+
+  <div class="persona-card" style="border-left: 4pt solid var(--brand); border-top: none; border-right: none; border-bottom: none; border-radius: 0; background: var(--parchment);">
+    <div style="display: flex; gap: 16pt; align-items: flex-start; margin-bottom: 18pt; flex-wrap: wrap;">
+      <div style="background: var(--brand); color: #fff; font-size: 20pt; font-weight: 500; width: 36pt; height: 36pt; display: flex; align-items: center; justify-content: center; border-radius: 50%; flex-shrink: 0;">1</div>
+      <div style="flex: 1; min-width: 200px;">
+        <div style="font-size: 13pt; font-weight: 500; margin-bottom: 5pt;">Ship the $19 lifetime Pro tier this week</div>
+        <p>Gate it on Markdown/CSV/JSONL export + deleted tweet caching. The Pocket/Omnivore displacement cohort is actively shopping right now and a one-time price is a conversion trigger, not a consideration.</p>
+        <div style="margin-top: 8pt;"><span class="tag green">Revenue</span><span class="tag">Week 1</span><span class="tag amber">Complexity: Low</span></div>
+      </div>
+    </div>
+
+    <div style="display: flex; gap: 16pt; align-items: flex-start; margin-bottom: 18pt; flex-wrap: wrap;">
+      <div style="background: var(--brand); color: #fff; font-size: 20pt; font-weight: 500; width: 36pt; height: 36pt; display: flex; align-items: center; justify-content: center; border-radius: 50%; flex-shrink: 0;">2</div>
+      <div style="flex: 1; min-width: 200px;">
+        <div style="font-size: 13pt; font-weight: 500; margin-bottom: 5pt;">Post r/nosurf founder story + Show HN the same week</div>
+        <p>These two channels hit the top two paying personas at zero ad spend. r/nosurf: lead with <em>"I stopped opening X but kept reading the threads I saved"</em> — mention Totem once, near the end. Show HN: lead with GraphQL interception and IndexedDB, not what Totem does.</p>
+        <div style="margin-top: 8pt;"><span class="tag green">Acquisition</span><span class="tag">Week 1–2</span><span class="tag amber">Free</span></div>
+      </div>
+    </div>
+
+    <div style="display: flex; gap: 16pt; align-items: flex-start; flex-wrap: wrap;">
+      <div style="background: var(--brand); color: #fff; font-size: 20pt; font-weight: 500; width: 36pt; height: 36pt; display: flex; align-items: center; justify-content: center; border-radius: 50%; flex-shrink: 0;">3</div>
+      <div style="flex: 1; min-width: 200px;">
+        <div style="font-size: 13pt; font-weight: 500; margin-bottom: 5pt;">Lead with thread-aware full capture in GTM</div>
+        <p>Totem already captures thread detail into <code>TweetDetailCache</code> through the existing GraphQL detail flow, renders it in the reader, and includes it in full export hydration. This is not a core build blocker anymore — it is proof for the Obsidian/PKM persona that Totem exports the reading experience, not just raw bookmarked URLs.</p>
+        <div style="margin-top: 8pt;"><span class="tag green">Retention</span><span class="tag">Already built</span><span class="tag green">Use in launch copy</span></div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ================================================================
+     02 · PERSONAS
+     ================================================================ -->
+<section class="chapter">
+  <div class="chapter-num">02 · Personas</div>
+  <h1>Who Actually Pays for This</h1>
+  <p class="lead">Five personas ranked by (buying signal × community size × fit with current product). All five have <span class="hl">high or medium-high</span> willingness to pay — the question is sequencing. Hit personas 1–3 first; 4–5 are one feature away.</p>
+
+  <!-- Persona 1 -->
+  <div class="persona-card">
+    <div class="persona-rank">Rank 1 · High Buying Signal</div>
+    <div class="persona-name">The Nosurf Intentional Reader</div>
+    <div class="persona-line">Uses X for curated signal from researchers and thinkers — refuses to open the app because the feed pulls them back.</div>
+    <div class="persona-grid">
+      <div class="persona-field">
+        <label>Specific Pain</label>
+        <p>They have already decided the content is worth reading. The platform architecture is what stops them. Every workaround (Feedbin RSS at $5/mo, Following-only mode) adds friction or still fires the algorithm.</p>
+      </div>
+      <div class="persona-field">
+        <label>Feature Hook</label>
+        <p>New tab reader mode. Bookmarks surface on the first screen they see. No X session, no feed, no negotiation.</p>
+      </div>
+      <div class="persona-field">
+        <label>Communities</label>
+        <p>r/nosurf <strong>302K</strong>, r/digitalminimalism <strong>199K</strong>, r/getoffmyphone</p>
+      </div>
+      <div class="persona-field">
+        <label>Ideal Price</label>
+        <p>$5–9 one-time lifetime or $2–3/month</p>
+      </div>
+    </div>
+    <div class="convert-line">
+      <span>The line that converts them</span>
+      "Read your Twitter bookmarks on every new tab without ever opening X. The content you saved is already waiting — the feed never touches you."
+    </div>
+    <div style="margin-top: 10pt; font-size: 9.5pt; color: var(--stone);">
+      <strong>Evidence:</strong> r/nosurf documents the "irony problem" — members who need X professionally but refuse to open the app. Totem solves the irony problem with less friction than every documented workaround.
+    </div>
+  </div>
+
+  <!-- Persona 2 -->
+  <div class="persona-card">
+    <div class="persona-rank">Rank 2 · High Buying Signal</div>
+    <div class="persona-name">The PKM Builder Escaping Readwise</div>
+    <div class="persona-line">Obsidian power user who wants Twitter bookmarks in their vault without paying $120/year for Readwise's bundled features they don't use.</div>
+    <div class="persona-grid">
+      <div class="persona-field">
+        <label>Specific Pain</label>
+        <p>Every plugin (Tweet to Markdown, X Bookmarks Sync) broke after April 2023 API changes. Readwise costs $120/year and they use maybe 40% of it. Post-Omnivore and post-Pocket they are actively shopping for something reliable.</p>
+      </div>
+      <div class="persona-field">
+        <label>Feature Hook</label>
+        <p>Markdown + JSONL export with YAML frontmatter. Drop files into Obsidian vault, DataView picks them up. No API key, no cloud step.</p>
+      </div>
+      <div class="persona-field">
+        <label>Communities</label>
+        <p>r/ObsidianMD, r/PKM, r/Zettelkasten, r/selfhosted, r/logseq<br><strong>1,900+ GitHub stars</strong> on kbravh/obsidian-tweet-to-markdown — that's the addressable audience quantified.</p>
+      </div>
+      <div class="persona-field">
+        <label>Ideal Price</label>
+        <p>$9–15 one-time or $3–5/month</p>
+      </div>
+    </div>
+    <div class="convert-line">
+      <span>The line that converts them</span>
+      "Export every Twitter bookmark to Markdown with YAML frontmatter — no API key, no subscription, no data leaving your machine. Drop it straight into your Obsidian vault."
+    </div>
+  </div>
+
+  <!-- Persona 3 -->
+  <div class="persona-card">
+    <div class="persona-rank">Rank 3 · High Buying Signal · Shopping NOW</div>
+    <div class="persona-name">The Privacy-First Local Hoarder</div>
+    <div class="persona-line">Post-Pocket refugee who learned the lesson: you don't own what you don't host.</div>
+    <div class="persona-grid">
+      <div class="persona-field">
+        <label>Specific Pain</label>
+        <p>Watched Pocket shut down July 8, 2025. Data deleted by November. Omnivore went dark November 2024. They treat any cloud-hosted tool as a liability. X's November 2024 terms (data shared with third parties for AI training) compounded their distrust.</p>
+      </div>
+      <div class="persona-field">
+        <label>Feature Hook</label>
+        <p>100% local IndexedDB storage with JSONL export. "No server" is not a feature — it is an existential guarantee. The architecture <em>is</em> the product.</p>
+      </div>
+      <div class="persona-field">
+        <label>Communities</label>
+        <p>r/selfhosted, r/degoogle <strong>400K+</strong>, r/privacytoolsIO, r/DataHoarder, Hacker News. Activity spikes around X policy announcements.</p>
+      </div>
+      <div class="persona-field">
+        <label>Ideal Price</label>
+        <p>$5–10 one-time or free with optional paid tier</p>
+      </div>
+    </div>
+    <div class="convert-line">
+      <span>The line that converts them</span>
+      "Your Twitter bookmarks, stored 100% in your browser. No Totem server. No account. No cloud vendor that can shut down and take your data. IndexedDB in your browser profile is the only place your saves live."
+    </div>
+    <div style="margin-top: 10pt; font-size: 9.5pt; color: var(--stone);">
+      <strong>Evidence:</strong> Pocket shutdown drove mass migration to r/selfhosted in May–July 2025. The behavioral conclusion across HN and Reddit: "You don't own what you don't host." Totem is the only Twitter bookmark tool that satisfies this without requiring Docker or a VPS.
+    </div>
+  </div>
+
+  <!-- Persona 4 -->
+  <div class="persona-card">
+    <div class="persona-rank">Rank 4 · High Buying Signal · One Feature Away</div>
+    <div class="persona-name">The Developer with a Bookmark Graveyard</div>
+    <div class="persona-line">Saves dozens of threads per week about architecture and tooling — can never find them again when the problem actually comes up.</div>
+    <div class="persona-grid">
+      <div class="persona-field">
+        <label>Specific Pain</label>
+        <p>X's bookmark search returns irrelevant results even with exact phrases. They want a searchable knowledge base with no API dependency — ideally pluggable into Claude Desktop or Cursor via MCP. ContextBolt is winning their attention today specifically because of MCP integration.</p>
+      </div>
+      <div class="persona-field">
+        <label>Feature Hook</label>
+        <p>Local full-text search now, MCP endpoint next. The test: does future-them find the half-remembered thread in five seconds?</p>
+      </div>
+      <div class="persona-field">
+        <label>Communities</label>
+        <p>Hacker News (primary), r/selfhosted, r/webdev, r/MachineLearning. Ask HN #37009892 and #40609664 document this demand directly.</p>
+      </div>
+      <div class="persona-field">
+        <label>Ideal Price</label>
+        <p>$15–29 one-time or $4–8/month</p>
+      </div>
+    </div>
+    <div class="convert-line">
+      <span>The line that converts them</span>
+      "Full-text search across every Twitter thread you ever saved, instantly, without opening X, without a server, without an API key. Your bookmark backlog becomes a searchable knowledge base."
+    </div>
+  </div>
+
+  <!-- Persona 5 -->
+  <div class="persona-card">
+    <div class="persona-rank">Rank 5 · Medium-High Buying Signal</div>
+    <div class="persona-name">The Solo Newsletter Researcher</div>
+    <div class="persona-line">Uses X as a primary research layer — bookmarks 20–50 threads per week, can never find the specific thread at writing time.</div>
+    <div class="persona-grid">
+      <div class="persona-field">
+        <label>Specific Pain</label>
+        <p>The gap between "saved on X" and "usable in writing" requires manual reconstruction every time. Tweetsmash exports to Notion at $14/month but has no search and requires manual triggering.</p>
+      </div>
+      <div class="persona-field">
+        <label>Feature Hook</label>
+        <p>Reader mode with full thread context — complete threads in clean reading order, ready to copy into a draft or export to Markdown.</p>
+      </div>
+      <div class="persona-field">
+        <label>Communities</label>
+        <p>Indie Hackers, r/Newsletters, r/indiehackers, r/content_marketing. The Substack/Beehiiv creator community on X itself is the highest-leverage channel.</p>
+      </div>
+      <div class="persona-field">
+        <label>Ideal Price</label>
+        <p>$8–15 one-time or $4–6/month. Tweetsmash proved this persona pays at $14/month.</p>
+      </div>
+    </div>
+    <div class="convert-line">
+      <span>The line that converts them</span>
+      "Stop losing research in your Twitter bookmark graveyard. Search your entire save history in seconds, read full threads in reader mode, export to Markdown — without ever opening X or losing thread context."
+    </div>
+  </div>
+</section>
+
+<!-- ================================================================
+     03 · COMMUNITY PLAYBOOK
+     ================================================================ -->
+<section class="chapter">
+  <div class="chapter-num">03 · Community Playbook</div>
+  <h1>Where to Show Up</h1>
+  <p class="lead">Thirteen communities mapped. Six to hit immediately, four to queue after first-wave traction. Every entry has the exact angle, a real post title, rules, threads to find, and what not to do.</p>
+
+  <h2>Post Now</h2>
+
+  <!-- r/nosurf -->
+  <div class="community-card">
+    <div class="community-header">
+      <div class="community-name">r/nosurf</div>
+      <span class="tag green">Post Now</span>
+      <span class="tag">302K Members</span>
+      <span class="tag amber">No Direct Promo</span>
+    </div>
+    <p><strong>Angle:</strong> Operationalizing the nosurf philosophy for X specifically. You haven't quit Twitter because it has real signal — you just cannot access that signal without the feed pulling you back. Totem solves the architecture problem, not the discipline problem. Use Cal Newport language: "zero-sum antagonism," "extract value and exit."</p>
+    <div class="example-title">
+      <span>Example post title</span>
+      "I stopped opening Twitter but kept reading the threads I saved — here's the one change that made it stick"
+    </div>
+    <p><strong>Format:</strong> Personal transformation story. Mention Totem once, near the end, as "this is what worked for me." Build comment karma in the subreddit 2–4 weeks before posting.</p>
+    <p><strong>Threads to find and reply:</strong> "How do I use Twitter intentionally?", "RSS alternative to Twitter", "digital detox but still need Twitter for work." When commenters mention Feedbin as a workaround, reply with Totem as the zero-friction Chrome alternative.</p>
+    <div class="not-todo"><strong>Do not:</strong> Open with "I built a Chrome extension." Frame it as a productivity tool. Use words like "supercharge," "boost," or "optimize." Post without prior comment history.</div>
+  </div>
+
+  <!-- Show HN -->
+  <div class="community-card">
+    <div class="community-header">
+      <div class="community-name">Hacker News — Show HN</div>
+      <span class="tag green">Post Now</span>
+      <span class="tag amber">Tue–Thu 7–9am PT</span>
+    </div>
+    <p><strong>Angle:</strong> Technical architecture first. Passive GraphQL interception, no Totem server, IndexedDB storage, no account required. Explain why GraphQL instead of the API ($100/month, requires keys, breaks constantly). Mention MV3 compliance explicitly — this community is anxious about it.</p>
+    <div class="example-title">
+      <span>Example post title</span>
+      "Show HN: Totem – Twitter bookmarks on every new tab, local-only, no account, GraphQL interception"
+    </div>
+    <p><strong>Format:</strong> Technical explanation. Engage every comment within the first 30 minutes — HN momentum is entirely front-loaded. Show HN is the designated self-promotion vehicle; use it once for initial launch.</p>
+    <p><strong>Threads to reply to:</strong> Ask HN "How do you organize your Twitter/X bookmarks?" (id=40609664) and "Do You Want a Twitter Bookmark Organizer?" (id=37009892) — post a brief factual description and a link.</p>
+    <div class="not-todo"><strong>Do not:</strong> Use "revolutionary" or "game-changing." Post and disappear — Show HN success is determined in the first 60 minutes. Hide pricing or the technical approach.</div>
+  </div>
+
+  <!-- r/ObsidianMD -->
+  <div class="community-card">
+    <div class="community-header">
+      <div class="community-name">r/ObsidianMD</div>
+      <span class="tag green">Post Now</span>
+      <span class="tag">Include Markdown Screenshot</span>
+    </div>
+    <p><strong>Angle:</strong> Lead with the export workflow, not the new tab feature. Every Twitter plugin broke after April 2023 API changes. Readwise costs $120/year for a cloud service that owns their data. The ideal workflow (save on X → Markdown in Obsidian vault with YAML frontmatter) doesn't exist without a paid intermediary. Totem is free, local, exports JSONL and Markdown, and works without an API key.</p>
+    <div class="example-title">
+      <span>Example post title</span>
+      "Free local-first alternative to Readwise for Twitter bookmarks → Obsidian (no API key, no cloud, YAML frontmatter export)"
+    </div>
+    <p><strong>Format:</strong> Tool recommendation, not product launch. Include a screenshot of actual Markdown output with YAML frontmatter.</p>
+    <p><strong>Threads to find:</strong> "Tweet to Markdown broken," "Twitter API changes plugin," "Readwise alternative," "X bookmarks sync Obsidian." Reply with a factual explanation of Totem's export.</p>
+    <div class="not-todo"><strong>Do not:</strong> Lead with the new tab feature. Claim Obsidian integration if it requires manual steps. Ignore questions about YAML frontmatter schema compatibility.</div>
+  </div>
+
+  <!-- r/selfhosted -->
+  <div class="community-card">
+    <div class="community-header">
+      <div class="community-name">r/selfhosted</div>
+      <span class="tag green">Post Now</span>
+      <span class="tag amber">High BS Detection</span>
+    </div>
+    <p><strong>Angle:</strong> IndexedDB browser storage is the serverless version of self-hosting. Zero infrastructure, zero ops burden, zero monthly fee. Position against Wallabag (requires Docker), Karakeep (requires server), and Readwise (cloud subscription). <em>No account = no breach surface, no server = nothing to subpoena.</em></p>
+    <div class="example-title">
+      <span>Example post title</span>
+      "After Pocket died I wanted Twitter bookmarks without another cloud service — so the browser IS the server (local IndexedDB, no account)"
+    </div>
+    <p><strong>Format:</strong> Problem/solution. Be precise about IndexedDB — data in the user's browser profile directory, does not leave the device, no telemetry. Link the GitHub repo if available — this community values auditability above all else.</p>
+    <div class="not-todo"><strong>Do not:</strong> Describe Totem as a SaaS or "service." Mention any cloud components. Say "we store your data securely" — the reaction will be "why are you storing anything?"</div>
+  </div>
+
+  <!-- r/SideProject -->
+  <div class="community-card">
+    <div class="community-header">
+      <div class="community-name">r/SideProject</div>
+      <span class="tag green">Post Now</span>
+      <span class="tag">Self-Promo OK</span>
+    </div>
+    <p><strong>Angle:</strong> Pure founder story with specific numbers. Open with the pain (save 50 threads a week, never read them, opening X means 90 minutes of feed). Then describe what you built and what happened. Include install count or star rating.</p>
+    <div class="example-title">
+      <span>Example post title</span>
+      "I built a Chrome extension that puts my Twitter bookmarks on every new tab so I actually read them — 1,200 installs later here's what I learned"
+    </div>
+    <p><strong>Format:</strong> Founder story. Self-promotion is core to this subreddit. Stay in comments for at least 2 hours after posting.</p>
+    <div class="not-todo"><strong>Do not:</strong> Post and disappear. Use generic productivity language without specifics. Claim features not yet built.</div>
+  </div>
+
+  <!-- X Thread -->
+  <div class="community-card">
+    <div class="community-header">
+      <div class="community-name">X / Twitter — Indie Maker Niche</div>
+      <span class="tag green">Post Now</span>
+      <span class="tag">Thread Format</span>
+    </div>
+    <p><strong>Angle:</strong> Thread starting with a specific relatable number: <em>"I had 847 bookmarks on Twitter. I had read maybe 12 of them."</em> Walk through why people save but never read. What you built (one sentence). How the new tab changes the habit loop. CTA at tweet 8–10. The 2026 X algorithm weights replies at 27× more than likes — optimize for a provocation that makes people reply.</p>
+    <div class="example-title">
+      <span>Example tweet 1</span>
+      "I had 847 bookmarks on Twitter. I had read maybe 12 of them. So I built something. 🧵"
+    </div>
+    <div class="not-todo"><strong>Do not:</strong> Lead with the product in tweets 1–2. Put the link in tweet 1 — the algorithm down-ranks posts with early external links. Ignore replies in the first 30 minutes.</div>
+  </div>
+
+  <h2>Post Later — After First-Wave Traction</h2>
+
+  <table class="striped">
+    <thead>
+      <tr>
+        <th>Community</th>
+        <th>Angle</th>
+        <th>Example Title</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>r/PKM</strong></td>
+        <td>Twitter bookmarks as the missing first stage of the PKM pipeline — free capture layer before Obsidian/Notion</td>
+        <td>"The missing piece for Twitter → Obsidian without Readwise (free, local, JSONL + Markdown)"</td>
+      </tr>
+      <tr>
+        <td><strong>r/degoogle</strong></td>
+        <td>Most bookmark managers require OAuth to a third-party server. Totem adds zero new tracking surface.</td>
+        <td>"Organize your Twitter bookmarks without handing data to another third party — browser-only, IndexedDB only"</td>
+      </tr>
+      <tr>
+        <td><strong>r/DataHoarder</strong></td>
+        <td>X has no native bookmark export. Account suspended = bookmarks gone. Totem creates a local JSONL archive.</td>
+        <td>"Twitter/X still has no bookmark export — here's how to build a local archive (no API key)"</td>
+      </tr>
+      <tr>
+        <td><strong>r/productivity</strong></td>
+        <td>Workflow post: "here's how I actually read saved Twitter threads instead of letting them pile up." Mention Totem in comments when asked.</td>
+        <td>"How I actually read my saved Twitter threads instead of letting them pile up (changed one thing)"</td>
+      </tr>
+      <tr>
+        <td><strong>Indie Hackers</strong></td>
+        <td>Milestone post with specific metrics: first 30 days on Chrome Web Store, what worked, what didn't</td>
+        <td>"Launched a Twitter bookmark Chrome extension with zero paid marketing — here's what happened in 30 days"</td>
+      </tr>
+      <tr>
+        <td><strong>r/logseq</strong></td>
+        <td>logseq-twitter-extractor plugin broken since 2023 API changes. Totem's Markdown export as the working replacement.</td>
+        <td>"Free alternative to the broken Logseq Twitter plugin — browser-based, no API key, Markdown for graph import"</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ================================================================
+     04 · POST FORMAT ANALYSIS
+     ================================================================ -->
+<section class="chapter">
+  <div class="chapter-num">04 · Post Formats</div>
+  <h1>What Kind of Post Works</h1>
+  <p class="lead">Four formats that spread, four failure modes that die, and three exact post templates you can use this week.</p>
+
+  <h2>What Spreads</h2>
+
+  <div class="feature-card">
+    <div class="feature-title">Personal transformation story with a specific behavior at the center</div>
+    <p>The post structure that consistently earns upvotes in r/nosurf, r/digitalminimalism, and r/productivity: (1) name the behavior everyone recognizes, (2) explain why it happens structurally — not a discipline problem, (3) describe what changed, (4) mention the tool once near the end as a component of a system. The Totem story: <em>"I had 847 bookmarks, I read 12, I built something."</em> This format succeeds because readers share it before they even reach the product mention.</p>
+    <div class="feature-meta"><span class="tag">r/nosurf</span><span class="tag">r/digitalminimalism</span><span class="tag">r/productivity</span></div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-title">Problem/solution post with a screenshot in the first comment</div>
+    <p>In r/ObsidianMD, r/PKM, and r/selfhosted, posts that include a screenshot of actual output — real Markdown with YAML frontmatter, real IndexedDB storage, real search results — convert faster than any amount of prose. The community can evaluate the claim immediately without clicking a link.</p>
+    <div class="feature-meta"><span class="tag">r/ObsidianMD</span><span class="tag">r/PKM</span><span class="tag">r/selfhosted</span></div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-title">Technical architecture post on HN</div>
+    <p>The Show HN that explains how something works before explaining what it does. "Passive GraphQL interception" is a better HN opener than "Twitter bookmark manager." The mechanism signals trust: you understand the system you built, you are not hiding how it works, the community can audit it.</p>
+    <div class="feature-meta"><span class="tag">Hacker News</span><span class="tag">Developers</span></div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-title">Replies in high-traffic threads before standalone posts</div>
+    <p>A well-placed reply in an Ask HN thread with 200+ upvotes or a r/nosurf thread with 1K upvotes outperforms a standalone post on a new thread. Find threads where the question is "how do I get X without the feed?" and answer it honestly, with Totem as one option among others you name.</p>
+    <div class="feature-meta"><span class="tag green">Highest ROI</span><span class="tag">Zero Risk</span></div>
+  </div>
+
+  <h2>What Dies</h2>
+
+  <table>
+    <thead><tr><th>Format</th><th>Why it fails</th><th>Affected communities</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><strong>Feature-list posts</strong></td>
+        <td>"New tab + reader mode + local search + export" reads as advertising without a human problem at the center. Communities reject it immediately.</td>
+        <td>All</td>
+      </tr>
+      <tr>
+        <td><strong>"I built" openers</strong></td>
+        <td>"I built a Chrome extension" as the first line triggers skepticism in communities that haven't seen you before. The product must earn its mention.</td>
+        <td>r/productivity, r/nosurf</td>
+      </tr>
+      <tr>
+        <td><strong>Productivity language in minimalism communities</strong></td>
+        <td>"Supercharge," "boost," "streamline," "optimize" are hard stops in r/nosurf and r/digitalminimalism. The framing is attention protection, not productivity.</td>
+        <td>r/nosurf, r/digitalminimalism</td>
+      </tr>
+      <tr>
+        <td><strong>Posts without numbers</strong></td>
+        <td>In r/SideProject and Indie Hackers, vague "launched my side project" posts earn no comments. Specific metrics drive engagement.</td>
+        <td>r/SideProject, Indie Hackers</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>Three Templates Ready to Use</h2>
+
+  <div class="callout">
+    <strong>The nosurf format:</strong><br><br>
+    <em>"I've been a r/nosurf member for [time]. I still use Twitter — [specific reason: following researchers, watching a niche]. The problem: every time I opened it to read my bookmarks, I lost 40 minutes to the For You page. [Describe what you tried that didn't work]. [What changed]. [One-sentence mention of Totem]. This is obviously not the only way to handle this, but it's what worked for me."</em>
+  </div>
+
+  <div class="callout">
+    <strong>The Obsidian format:</strong><br><br>
+    <em>"Every plugin that connected Twitter to Obsidian stopped working in April 2023 when Twitter killed the API. Here's what I've found that still works without an API key or a Readwise subscription. [Screenshot of Markdown output]. The frontmatter fields are: [list them]. DataView query that works: [show it]. Works because [one-sentence technical explanation]. Happy to answer questions about the export format."</em>
+  </div>
+
+  <div class="callout">
+    <strong>The HN Show HN format:</strong><br><br>
+    <em>"Totem replaces your Chrome new tab with your X/Twitter bookmark queue. No Totem server, no account, no OAuth grant to a third party. Data lives in IndexedDB in your browser profile. The sync mechanism: passive interception of the GraphQL responses your browser already receives when you visit X. I went this route because [specific reason API didn't work]. MV3 compliant. Export: Markdown, CSV, JSONL. Happy to answer questions about the architecture."</em>
+  </div>
+</section>
+
+<!-- ================================================================
+     05 · PRICING
+     ================================================================ -->
+<section class="chapter">
+  <div class="chapter-num">05 · Pricing</div>
+  <h1>One-Time vs Subscription</h1>
+  <p class="lead">This is not a close call. The structural evidence is clear. Target communities have <span class="hl">documented, acute subscription fatigue</span> and a strong preference for paying once for tools with no server-side costs.</p>
+
+  <div class="takeaway">
+    <div class="takeaway-label">The Recommendation</div>
+    <p><strong>Freemium with a $19 one-time lifetime Pro unlock.</strong> Founders price: <strong>$14 for the first 60 days of launch.</strong></p>
+  </div>
+
+  <h2>Free Tier (Permanent, No Time Limit)</h2>
+  <ul>
+    <li>New tab reading queue</li>
+    <li>Full local-first sync via browser session interception</li>
+    <li>Reader mode for threads</li>
+    <li>Local full-text search across all bookmarks</li>
+    <li>No bookmark count cap</li>
+    <li>No account required</li>
+  </ul>
+
+  <h2>Pro Tier — $19 One-Time Lifetime</h2>
+  <ul>
+    <li>Markdown, CSV, JSONL export</li>
+    <li>Deleted tweet caching and preservation</li>
+    <li>Bulk operations</li>
+    <li>Advanced search filters (author, date range, media type)</li>
+    <li>Inline annotations and highlights on each bookmark</li>
+    <li>Thread-aware capture and full export hydration</li>
+  </ul>
+
+  <h2>Why One-Time, Not Subscription</h2>
+  <p>Totem has no server costs. There is no AI inference bill, no cloud storage, no ongoing compute. A subscription for a Chrome extension that runs entirely in the user's browser will face immediate HN scrutiny: <em>"You are just storing data in my own browser — what am I paying for each month?"</em></p>
+
+  <blockquote>
+    "People tend to impulse-buy one-time things all the time. At $19, the question is 'is this worth a one-time payment?' At $9.99/month, it's 'do I want to pay for this forever?'"
+    <span class="cite">— r/webdev research, multiple threads</span>
+  </blockquote>
+
+  <p>The HN Verso launch ($14.99 one-time, 36 points) framed "no subscription" as a feature in the headline. The r/BuyItForLife framing — "pay once, use forever" — is the exact emotional register this audience responds to. 47% of SaaS tool subscribers churn by month 4–8.</p>
+
+  <h2>Why $19 Specifically</h2>
+  <table>
+    <thead><tr><th>Comparable Tool</th><th>Price</th><th>Model</th></tr></thead>
+    <tbody>
+      <tr><td>Readwise</td><td>$120/year</td><td>Subscription</td></tr>
+      <tr><td>ContextBolt</td><td>$6/month (~$72/year)</td><td>Subscription</td></tr>
+      <tr><td>TweetSmash</td><td>$14/month</td><td>Subscription</td></tr>
+      <tr><td>Verso (comparable indie)</td><td>$14.99 one-time</td><td>One-time</td></tr>
+      <tr><td>XArchive</td><td>$4.69/year</td><td>Annual</td></tr>
+      <tr><td><strong>Totem Pro (recommended)</strong></td><td><strong>$19 one-time</strong></td><td><strong>Lifetime</strong></td></tr>
+    </tbody>
+  </table>
+  <p>$19 sits above the $4.99 utility floor and below the $29 threshold where buyers begin demanding enterprise-level feature parity. Readwise charges $120/year partly for the Markdown export Totem provides for $19 once. The comparison writes itself.</p>
+
+  <h2>Why Export Is the Right Paywall</h2>
+  <ol>
+    <li>It requires no ongoing cost to provide</li>
+    <li>It is high-value to the PKM/Obsidian/power-user cohort willing to pay</li>
+    <li>It does not feel artificial — it clearly took engineering effort to build</li>
+    <li>The emotional framing is clean: <em>"Pay once, own your data forever."</em></li>
+  </ol>
+
+  <div class="callout">
+    <strong>Do NOT say "2 years of updates."</strong> The r/selfhosted and r/privacy communities are acutely aware of tool shutdowns (Pocket July 2025, Omnivore November 2024). A "2 years of updates" qualifier raises the question "what happens in year 3?" and implies potential abandonment. Use "lifetime" with no expiry qualifier. If Totem is truly local-first, the tool works forever even if development slows — because there is no service to shut down.
+  </div>
+
+  <h2>Fallback After 90 Days</h2>
+  <p>If freemium conversion stays below 1% after 90 days: move to a 14-day free trial of the full product followed by the $19 one-time gate. This forces the conversion decision while still allowing word-of-mouth discovery. Do not pivot to subscription.</p>
+</section>
+
+<!-- ================================================================
+     06 · FEATURES
+     ================================================================ -->
+<section class="chapter">
+  <div class="chapter-num">06 · Features</div>
+  <h1>Feature Bets — Demand-Validated</h1>
+  <p class="lead">Ranked by (revenue impact × acquisition impact) ÷ remaining complexity. Every feature is grounded in specific research evidence — not speculation. Some items are already production-built; those should be used as Pro packaging and launch proof, not treated as net-new engineering work.</p>
+
+  <div class="feature-card">
+    <div class="feature-num">01 · Already Built · Unlocks Pro Gate</div>
+    <div class="feature-title">Thread-Aware Full Capture</div>
+    <div class="feature-meta">
+      <span class="tag green">Revenue</span><span class="tag green">Acquisition</span>
+      <span class="tag green">Production-ready</span>
+      <span class="tag">Writers</span><span class="tag">PKM</span><span class="tag">Researchers</span>
+    </div>
+    <p>When Totem fetches tweet detail for a saved post, it parses the surrounding thread, stores the full thread in IndexedDB, renders it in reader view, and includes it in full export hydration. Export produces one coherent Markdown document per thread instead of a disconnected single-tweet record.</p>
+    <div class="feature-evidence">
+      <strong>Evidence:</strong> Verified in code: <code>src/api/core/posts.ts</code> stores <code>detail.thread</code>, <code>src/stores/hydration-store.ts</code> walks bookmarks missing tweet details for full export hydration, and <code>src/lib/export/tweet-export.ts</code> appends thread tweets in reading order. kbravh/obsidian-tweet-to-markdown (1,900+ GitHub stars) was built specifically for this problem. <em>"Copy-paste produces tweets out of sequence, broken by reply indentation, with quote-tweets collapsed into dead links."</em>
+    </div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-num">02 · Build Now · Core Pro Feature</div>
+    <div class="feature-title">Deleted Tweet Preservation &amp; Local Content Caching</div>
+    <div class="feature-meta">
+      <span class="tag green">Revenue</span>
+      <span class="tag amber">Complexity: Medium</span>
+      <span class="tag">Researchers</span><span class="tag">DataHoarder</span>
+    </div>
+    <p>At sync time, capture full tweet content (text, author, media URLs, thread structure, timestamp) into IndexedDB. If the source tweet is later deleted, Totem's local copy persists. Reader view surfaces cached content with a subtle "original deleted" badge.</p>
+    <div class="feature-evidence">
+      <strong>Evidence:</strong> <em>"If the original author deletes the tweet, your bookmark will instantly become invalid, which can be a massive loss for anyone doing content research"</em> (twillot.com, 2026). Dewey's broken sync has left this position vacant. Every competitor offering deletion protection relies on cloud sync — Totem undercuts with pure local caching. HN thread April 2026: <em>"You legitimately cannot export your bookmarks from X. If that happens, your bookmarks will be lost."</em>
+    </div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-num">03 · Already Built · Pro Monetization Gate</div>
+    <div class="feature-title">Inline Annotation &amp; Highlights on Bookmarks</div>
+    <div class="feature-meta">
+      <span class="tag green">Revenue</span><span class="tag green">Retention</span>
+      <span class="tag green">Production-ready</span>
+      <span class="tag">PKM/Obsidian</span><span class="tag">Writers</span>
+    </div>
+    <p>Users can already highlight passages within each bookmark's reader view and attach personal notes. Highlights and notes are stored locally in IndexedDB, attached to tweet ID, searchable alongside full-text content, and exported in Markdown and JSONL.</p>
+    <div class="feature-evidence">
+      <strong>Evidence:</strong> <em>"No meaningful extension does Readwise-style highlighting on x.com."</em> Readwise losing Twitter users specifically because "Readwise's focus has shifted towards their Reader app." Totem's $19 lifetime vs. $120/year for the same output is a clear narrative. The Obsidian export preset on the roadmap makes annotation-to-Markdown the natural companion feature.
+    </div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-num">04 · Acquisition Feature · Low Effort</div>
+    <div class="feature-title">Context Menu + Keyboard Shortcut for Quick-Save</div>
+    <div class="feature-meta">
+      <span class="tag green">Acquisition</span>
+      <span class="tag green">Complexity: Low</span>
+      <span class="tag">Nosurf</span><span class="tag">Researchers</span>
+    </div>
+    <p>Right-click context menu item ("Save to Totem") on any x.com or twitter.com link anywhere on the web. Keyboard shortcut (cmd/ctrl+shift+T) saves the currently highlighted tweet URL. Immediate add to reading queue without requiring navigation to X. Toast confirmation.</p>
+    <div class="feature-evidence">
+      <strong>Evidence:</strong> <em>"Bookmarking should be as frictionless as taking a screenshot — clicking a hotkey"</em> (Ask HN #37009892). ContextBolt winning comparisons "specifically on automatic capture vs manual export step." This is the nosurf use case — users encounter X links in newsletters or HN comments and want to save them without triggering an X session. The extension already has host_permissions for x.com — context menu registration is a single-day addition.
+    </div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-num">05 · Acquisition Surface · Genuinely Differentiated</div>
+    <div class="feature-title">Universal Tweet Preview on External Sites</div>
+    <div class="feature-meta">
+      <span class="tag green">Acquisition</span>
+      <span class="tag amber">Complexity: Medium</span>
+      <span class="tag">Nosurf</span><span class="tag">Researchers</span>
+    </div>
+    <p>When the user visits any webpage containing x.com or twitter.com links, inject an inline preview of tweet content served from local IndexedDB cache — no request to X required. If the tweet is in saved bookmarks, show a "Saved in Totem" badge. Works even when X blocks logged-out embeds (since 2023).</p>
+    <div class="feature-evidence">
+      <strong>Evidence:</strong> <em>"I absolutely refuse to go to Twitter links anymore; they don't usually work unless you're logged in."</em> X has permanently blocked public tweet embeds for logged-out users since 2023 — every newsletter that references a tweet now shows a broken embed. This is a visible daily utility that exposes Totem to users who have never opened X in the current browser session. No competing bookmark tool has shipped this.
+    </div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-num">06 · Developer Acquisition · Competitive Necessity</div>
+    <div class="feature-title">MCP (Model Context Protocol) Endpoint</div>
+    <div class="feature-meta">
+      <span class="tag amber">Complexity: High</span>
+      <span class="tag">Developers</span><span class="tag">AI Power Users</span>
+    </div>
+    <p>Expose Totem's local IndexedDB bookmark corpus as an MCP server that AI tools (Claude Desktop, Cursor, Windsurf) can query in real time. Users ask their AI assistant "what did I save about vector databases?" and get answers pulled directly from their Totem library. MCP server runs locally as a companion process.</p>
+    <div class="feature-evidence">
+      <strong>Evidence:</strong> ContextBolt was named top Twitter bookmark manager in a 2026 nine-tool roundup <em>specifically because of MCP integration.</em> An HN builder created an MCP-connected bookmark manager in March 2026 because "X's are useless." MCP adoption among developers is the sharpest growth curve in developer tools in 2025–2026. An MCP endpoint from local IndexedDB is architecturally trivial — the data store already exists.
+    </div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-num">07 · Retention · Power User Conversion</div>
+    <div class="feature-title">Semantic Search Over Local Corpus</div>
+    <div class="feature-meta">
+      <span class="tag amber">Complexity: High</span>
+      <span class="tag">Developers</span><span class="tag">PKM</span><span class="tag">500+ Bookmarks</span>
+    </div>
+    <p>AI-powered semantic search alongside existing full-text search. Natural language queries over local IndexedDB corpus. Implement using <code>transformers.js</code> with <code>all-MiniLM-L6-v2</code> running entirely in the browser — no API key, no cloud, no cost per query.</p>
+    <div class="feature-evidence">
+      <strong>Evidence:</strong> <em>"Sometimes even when you enter exact keywords the tweet is nowhere to be found"</em> (Twillot blog, multiple 2025–2026 sources). ContextBolt named best in category in 2026 roundup specifically for semantic search. ContextBolt's free tier caps at 150 bookmarks — users with large collections are underserved. transformers.js has matured to under 50ms per query in browser extension context. Local-first semantic search with no usage cap is a genuine moat.
+    </div>
+  </div>
+
+  <div class="feature-card">
+    <div class="feature-num">08 · Revenue · Now</div>
+    <div class="feature-title">One-Time Pro Pricing Unlock ($19 Lifetime)</div>
+    <div class="feature-meta">
+      <span class="tag green">Revenue</span>
+      <span class="tag green">Complexity: Low</span>
+      <span class="tag">All Users</span>
+    </div>
+    <p>Ship the Pro tier. Gate: Markdown/CSV/JSONL export, deleted tweet caching, bulk operations, advanced filters. Free tier remains fully functional. $14 founders price for 60 days.</p>
+    <div class="feature-evidence">
+      <strong>Evidence:</strong> All pricing research converges. "Dominant sentiment across Reddit and HN is strong preference for one-time payment over subscription for Chrome extensions — driven by acute subscription fatigue." The Pocket/Omnivore displacement cohort is primed to pay one-time for tools they trust. Every day without a Pro tier is revenue left on the table while the features to gate behind it are being built anyway.
+    </div>
+  </div>
+</section>
+
+<!-- ================================================================
+     07 · BLOG POSTS
+     ================================================================ -->
+<section class="chapter">
+  <div class="chapter-num">07 · Blog Posts</div>
+  <h1>Blog Posts to Write Next</h1>
+  <p class="lead">Nine post ideas grounded in actual user behavior found in the research. Each one emerges from a real pain point — not keyword volume. Voice filter: behavioral hook, honest about scope, terse, specific. Totem appears near the end, never the top.</p>
+
+  <div class="blog-card">
+    <div class="blog-num">01 · r/nosurf · r/productivity · High Share Potential</div>
+    <div class="blog-title">"Your Twitter Bookmarks Are a Graveyard. Here's Why That's Not a Willpower Problem."</div>
+    <p><strong>Angle:</strong> The behavioral loop that turns saved tweets into a pile you never touch is structural, not personal. The bookmark tab is buried, opening X means the feed, and there is no surface that brings saved things back. Architecture problem, not discipline problem.</p>
+    <div class="blog-evidence"><strong>Real demand:</strong> "I saved so many tweets that I couldn't even scroll back to the beginning, eventually stopping use of bookmarks completely because they turned into a giant pile of random content" (Twillot blog, 2025). DEV Community post "Your Read Later list is a graveyard" resonated heavily with developers.</div>
+    <div style="margin-top: 6pt;"><span class="tag">r/nosurf</span><span class="tag">r/productivity</span><span class="tag">r/digitalminimalism</span><span class="tag green">High viral potential</span></div>
+  </div>
+
+  <div class="blog-card">
+    <div class="blog-num">02 · r/ObsidianMD · r/PKM · HN · SEO + Community</div>
+    <div class="blog-title">"Twitter Bookmarks to Obsidian: What Actually Works in 2026 (After the API Broke Everything)"</div>
+    <p><strong>Angle:</strong> Every plugin that connected X to Obsidian stopped working in April 2023. This post maps what still works, what broke, and why browser-session-based tools are the only reliable path now.</p>
+    <div class="blog-evidence"><strong>Real demand:</strong> "Due to changes to the Twitter API in April 2023, users must sign up for their own Twitter bearer token to use this application" (Tweet to Markdown plugin docs — widely cited frustration). kbravh/obsidian-tweet-to-markdown has 1,900+ GitHub stars. Multiple active GitHub forks on the same problem.</div>
+    <div style="margin-top: 6pt;"><span class="tag">r/ObsidianMD</span><span class="tag">r/PKM</span><span class="tag">Obsidian Forum</span><span class="tag green">HN Candidate</span></div>
+  </div>
+
+  <div class="blog-card">
+    <div class="blog-num">03 · r/nosurf · r/digitalminimalism · Short Post</div>
+    <div class="blog-title">"Reading Twitter Without Opening Twitter"</div>
+    <p><strong>Angle:</strong> X has content worth reading, but visiting X means surrendering to the feed. The communities that have figured this out share one principle: extract content before the algorithm extracts you.</p>
+    <div class="blog-evidence"><strong>Real demand:</strong> Cal Newport's "zero-sum antagonism" framing is the dominant lens in r/nosurf (302K members) and r/digitalminimalism (199K members). Feedbin RSS at $5/month is the current cited workaround.</div>
+    <div style="margin-top: 6pt;"><span class="tag">r/nosurf</span><span class="tag">r/digitalminimalism</span><span class="tag green">Also a good X thread</span></div>
+  </div>
+
+  <div class="blog-card">
+    <div class="blog-num">04 · r/selfhosted · r/degoogle · HN · Trust + Conversion</div>
+    <div class="blog-title">"What Pocket's Shutdown Taught Us About Saving Things on the Internet"</div>
+    <p><strong>Angle:</strong> Mozilla shut down Pocket on July 8, 2025. Data export window closed November 12, 2025. The lesson is not "don't use read-later apps" — it is that "where does this live?" matters more than "how good is the interface?"</p>
+    <div class="blog-evidence"><strong>Real demand:</strong> "After Pocket's shutdown in July 2025, interest in self-hosted bookmark tools spiked sharply — users learned that you don't own what you don't host." Omnivore acquihired October 2024, went dark November 15, 2024. This behavioral conclusion is the #1 insight across r/selfhosted, r/degoogle, and HN right now.</div>
+    <div style="margin-top: 6pt;"><span class="tag">r/selfhosted</span><span class="tag">r/degoogle</span><span class="tag">HN</span></div>
+  </div>
+
+  <div class="blog-card">
+    <div class="blog-num">05 · r/Twitter · r/journalism · SEO: "twitter bookmark disappeared"</div>
+    <div class="blog-title">"The Twitter Bookmark You Saved Is Gone. Here's Why."</div>
+    <p><strong>Angle:</strong> When someone deletes their tweet, every bookmark pointing to it silently breaks. No notification, no cached copy, just a dead link. This is happening to research libraries at scale every day.</p>
+    <div class="blog-evidence"><strong>Real demand:</strong> "If the original author deletes the tweet, your bookmark will instantly become invalid, which can be a massive loss for anyone doing content research" (archivlyx.com, twillot.com, getdewey.co, 2025–2026). This mechanism is under-explained — genuine SERP gap.</div>
+    <div style="margin-top: 6pt;"><span class="tag">r/Twitter</span><span class="tag">r/journalism</span><span class="tag green">SEO gap</span></div>
+  </div>
+
+  <div class="blog-card">
+    <div class="blog-num">06 · r/PKM · r/ObsidianMD · r/productivity · Conversion Post</div>
+    <div class="blog-title">"Readwise Is Overkill for Twitter Bookmarks"</div>
+    <p><strong>Angle:</strong> Readwise costs ~$120/year and bundles Kindle highlights, PDF sync, spaced repetition. Most people who use it for Twitter bookmarks don't use 60–70% of what they're paying for. This is not a hit piece — it's honest scoping.</p>
+    <div class="blog-evidence"><strong>Real demand:</strong> "The cost and complexity of Readwise just for tweets is hard to justify. Readwise's focus has shifted towards their Reader app and the original 1.0 app has seen little in terms of updates." Multiple Reddit threads confirm pricing as the top complaint. Readwise alternatives searches spiking in 2025–2026.</div>
+    <div style="margin-top: 6pt;"><span class="tag">r/PKM</span><span class="tag">r/ObsidianMD</span><span class="tag green">High conversion potential</span></div>
+  </div>
+
+  <div class="blog-card">
+    <div class="blog-num">07 · r/Twitter · r/productivity · SEO: "twitter bookmark search not working"</div>
+    <div class="blog-title">"Why Twitter Bookmark Search Still Does Not Work (Even After X Added It)"</div>
+    <p><strong>Angle:</strong> X launched bookmark search in late 2024. Users report it returns wrong results even with exact keywords. Android still has no search as of 2026. What's actually broken, why the constraint is real, and what local full-text search looks like in comparison.</p>
+    <div class="blog-evidence"><strong>Real demand:</strong> "The search function is still incredibly difficult to use, sometimes even when you enter exact keywords the tweet is nowhere to be found" (Twillot blog, multiple 2025–2026 sources). "Android has no bookmark search at all as of 2026."</div>
+    <div style="margin-top: 6pt;"><span class="tag">r/Twitter</span><span class="tag green">SEO long-tail</span></div>
+  </div>
+
+  <div class="blog-card">
+    <div class="blog-num">08 · r/ObsidianMD · r/PKM · r/logseq · r/Notion · Multi-Community</div>
+    <div class="blog-title">"Twitter Bookmarks for Obsidian, Logseq, and Notion: A Workflow Comparison"</div>
+    <p><strong>Angle:</strong> Three PKM communities, three different workflows. Maps current state for each: what plugins exist, what broke in 2023, what still works without an API key, what you actually get in each export format.</p>
+    <div class="blog-evidence"><strong>Real demand:</strong> r/ObsidianMD: "Is there an elegant solution for capturing content from Twitter?" r/logseq: logseq-twitter-extractor plugin requires API credentials, increasingly broken. Multiple GitHub repos with active forks across all three platforms.</div>
+    <div style="margin-top: 6pt;"><span class="tag">r/ObsidianMD</span><span class="tag">r/PKM</span><span class="tag">r/logseq</span><span class="tag">r/Notion</span><span class="tag">Obsidian Forum</span></div>
+  </div>
+
+  <div class="blog-card">
+    <div class="blog-num">09 · r/privacy · r/selfhosted · r/degoogle · HN · Trust Building</div>
+    <div class="blog-title">"What 'Local-First' Actually Means for a Browser Extension"</div>
+    <p><strong>Angle:</strong> Every tool that handles Twitter bookmarks makes a choice about where data lives. Most don't explain this choice clearly. "Local-first" gets used as marketing language — but the practical difference between IndexedDB in your browser and a cloud database owned by a company is concrete and consequential.</p>
+    <div class="blog-evidence"><strong>Real demand:</strong> "Zero data collection with no accounts or telemetry — this is what makes a browser extension trustworthy in 2025" (HN thread on trusting browser extensions). Strava API lock-in post: 1,698 upvotes, 296 comments on r/selfhosted. "BookmarkQ became impractical due to the Twitter API costing $100 per month" — showing systemic risk of cloud-dependent tools.</div>
+    <div style="margin-top: 6pt;"><span class="tag">r/privacy</span><span class="tag">r/selfhosted</span><span class="tag">HN</span><span class="tag green">Trust signal</span></div>
+  </div>
+</section>
+
+<!-- ================================================================
+     08 · THE NICHE TO OWN
+     ================================================================ -->
+<section class="chapter">
+  <div class="chapter-num">08 · The Niche</div>
+  <h1>The Niche to Own</h1>
+  <p class="lead">All five personas, all thirteen communities, and all eight features point at the same position. The research is unusually convergent.</p>
+
+  <div class="callout" style="font-size: 11.5pt; line-height: 1.6; padding: 16pt 20pt;">
+    <p>Totem should own the position of <strong>the Twitter bookmark tool for people who have already decided the feed is not worth the cost.</strong></p>
+    <p style="margin-top: 10pt;">This is a specific, real, and large group — not an abstract persona. It is the person who follows 40 accounts carefully, saves threads compulsively, and then never reads them because accessing bookmarks means triggering the For You page. It is the Obsidian user who has tried three broken plugins and still has no reliable path from X to their vault. It is the r/selfhosted member who watched Pocket die and is now treating every cloud-hosted tool as a liability. These three populations overlap heavily and share one belief: <strong>the content on X is worth something, but the platform is not their friend.</strong></p>
+    <p style="margin-top: 10pt;">The tools they currently use are all compromises: Feedbin RSS is powerful but technical. Readwise is expensive and overkill. Dewey is broken. ContextBolt requires a monthly fee and has a bookmark cap. Every free plugin broke in April 2023. Totem wins this position by being the only tool that treats the browser itself as the infrastructure — no server to shut down, no API to break, no subscription to resent — while being as frictionless as a new tab.</p>
+    <p style="margin-top: 10pt;">They will pay $19 once because they have already paid more than that in broken tools, wasted time, and, after Pocket, in content they can no longer access.</p>
+  </div>
+
+  <div class="takeaway">
+    <div class="takeaway-label">The Positioning Line</div>
+    <p>Not: "Twitter made better."</p>
+    <p style="margin-top: 6pt; font-size: 12pt; font-weight: 500; color: var(--brand);">"The content you saved, in the first screen you open, without touching the platform that holds it hostage."</p>
+  </div>
+
+  <h2>The Sequenced Plan</h2>
+  <table class="striped">
+    <thead><tr><th>Week</th><th>Action</th><th>Impact</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><strong>Week 1</strong></td>
+        <td>Ship $19 Pro tier (gate: export + deleted tweet caching). Set $14 founders price.</td>
+        <td>Revenue opens</td>
+      </tr>
+      <tr>
+        <td><strong>Week 1–2</strong></td>
+        <td>Post r/nosurf founder story. Same week: Show HN with GraphQL interception angle.</td>
+        <td>Top 2 personas reached</td>
+      </tr>
+      <tr>
+        <td><strong>Month 1</strong></td>
+        <td>Promote thread-aware full capture. Post r/ObsidianMD with Markdown screenshot. Reply to existing HN threads.</td>
+        <td>PKM persona converts</td>
+      </tr>
+      <tr>
+        <td><strong>Month 1–2</strong></td>
+        <td>Write "Twitter Bookmarks Are a Graveyard" + "What Pocket's Shutdown Taught Us." Post r/selfhosted + r/degoogle.</td>
+        <td>Privacy persona + SEO</td>
+      </tr>
+      <tr>
+        <td><strong>Month 2–3</strong></td>
+        <td>Build context menu quick-save + universal tweet preview. Write Obsidian/Logseq/Notion workflow comparison.</td>
+        <td>Acquisition surface expands</td>
+      </tr>
+      <tr>
+        <td><strong>Month 3+</strong></td>
+        <td>MCP endpoint (closes ContextBolt gap for developers). Semantic search (closes ContextBolt gap for power users).</td>
+        <td>Developer persona converts</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <hr>
+  <p class="small" style="text-align: center; margin-top: 20pt;">
+    Totem GTM Research Report · June 16, 2026 · Generated by 16-agent research sweep · 282 tool calls<br>
+    usetotem.xyz · <a href="https://chromewebstore.google.com/detail/acpkgdfhoaalmnhjifhneghcgfnjkglo" style="color: var(--brand);">Chrome Web Store</a>
+  </p>
+</section>
+
+<!-- ==================================================================
+     09 · ACTION CHECKLIST
+     Code-grounded todo list — every item verified against the codebase
+     by a 5-agent parallel investigation (June 16, 2026)
+     ================================================================ -->
+<section class="chapter" id="todo-section">
+  <div class="chapter-num">09 · Action Checklist</div>
+  <h1>What to Build, Post, and Decide</h1>
+  <p class="lead">Everything below is grounded in 5-agent parallel code investigation. Several features the GTM report listed as "medium complexity to build" are already fully implemented. The real gaps are smaller and faster to close than the research implied.</p>
+
+  <!-- ── REALITY CHECK BOX ── -->
+  <div class="callout" style="margin-bottom: 20pt;">
+    <p><strong>What the code investigation changed:</strong> Highlights &amp; annotations, full-text search, Markdown export with YAML frontmatter, thread parsing, and the complete reader are <em>already production-built</em>. The GTM report's feature list describes the product as more incomplete than it is. The real engineering gaps are: (1) a tombstone write for deleted tweets — half a day in <code>posts.ts:93</code>; (2) background thread hydration — 1–2 days; (3) a paywall — no infrastructure exists yet; (4) context menu — not started; and (5) semantic search and MCP — genuinely large bets.</p>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════════
+       SECTION A — THIS WEEK
+       ══════════════════════════════════════════════════════════ -->
+  <h2>A — This Week (Critical Path)</h2>
+  <p>These have zero or near-zero engineering cost and are blocking downstream actions. Do them before anything else.</p>
+
+  <div class="community-card" style="margin-bottom: 12pt;">
+    <div class="community-header">
+      <span class="community-name">1. Fix the Chrome Web Store listing title</span>
+      <span class="tag red">Blocking</span>
+      <span class="tag amber">Manual — no code</span>
+    </div>
+    <p>The live CWS title is still the old name (<em>Twitter Saver: Bookmarks on New Tab, Search &amp; Export</em>). The manifest is already updated to <em>Totem - Twitter Bookmarks on New Tab, Search &amp; Export</em> (v1.2.3) but the dashboard hasn't been changed. This is blocking the Featured badge submission because the pre-flight check fails on title mismatch.</p>
+    <ul>
+      <li>Log in to the Chrome Web Store Developer Dashboard</li>
+      <li>Update the <strong>Store listing → Name</strong> to: <em>Totem - Twitter Bookmarks on New Tab, Search &amp; Export</em></li>
+      <li>Update the <strong>Short description</strong> and <strong>Long description</strong> to the copy in <code>plans/chrome-web-store-listing.md</code></li>
+      <li>Save draft → Submit for review</li>
+    </ul>
+  </div>
+
+  <div class="community-card" style="margin-bottom: 12pt;">
+    <div class="community-header">
+      <span class="community-name">2. Post the Show HN</span>
+      <span class="tag red">High impact</span>
+      <span class="tag green">Draft ready</span>
+    </div>
+    <p>The Show HN draft is complete and noted as ready in <code>plans/next-release-growth-checklist.md</code>. Post is gated only on the CWS listing being live with the correct name. Once the dashboard update goes through:</p>
+    <ul>
+      <li>Post Tuesday–Thursday, 7–9 AM Pacific</li>
+      <li>Title: <em>Show HN: Totem – Twitter bookmarks on every new tab, local-only, no account, GraphQL interception</em></li>
+      <li>Lead with the technical architecture: passive GraphQL interception, MV3 compliance, IndexedDB, no Totem server. Explain why you didn't use the API ($100/month, breaks constantly).</li>
+      <li>Engage every comment within 30 minutes — HN momentum is entirely front-loaded</li>
+      <li>After posting: reply to existing threads at id=40609664 and id=37009892 with a brief factual description and link</li>
+    </ul>
+  </div>
+
+  <div class="community-card" style="margin-bottom: 12pt;">
+    <div class="community-header">
+      <span class="community-name">3. Post r/SideProject</span>
+      <span class="tag">Medium impact</span>
+      <span class="tag green">Draft ready</span>
+    </div>
+    <p>Draft is ready. This community explicitly exists for sharing what you are building. Lead with specific numbers (install count, star rating). Stay in comments for at least 2 hours after posting. Title format: <em>"I built a Chrome extension that puts my Twitter bookmarks on every new tab so I actually read them — [N] installs later here's what I learned."</em></p>
+  </div>
+
+  <div class="community-card" style="margin-bottom: 12pt;">
+    <div class="community-header">
+      <span class="community-name">4. Start the Pro paywall — choose a processor</span>
+      <span class="tag red">Revenue blocker</span>
+      <span class="tag amber">1–2 weeks total</span>
+    </div>
+    <p><strong>No payment infrastructure exists anywhere in the codebase.</strong> Not a single line. Every day without a Pro tier is revenue left on the table while several strong Pro features (export, highlights, local search, reader mode, and full export hydration) are already built. The remaining preservation gap is small. Decision to make today:</p>
+    <ul>
+      <li><strong>Recommended:</strong> LemonSqueezy — handles EU VAT automatically, lowest setup friction for one-time Chrome extension purchases, widely used by indie extension builders</li>
+      <li>Flow: User clicks "Unlock Pro" → LemonSqueezy checkout → on payment, LS webhook hits a Vercel edge function → edge function stores a HMAC-signed license key → extension checks key on startup via <code>chrome.storage.sync</code></li>
+      <li>Founders price: $14 for first 60 days, then $19 lifetime</li>
+      <li>Gate these features: full ZIP export, highlights, and full export hydration now; advanced search filters and deleted-tweet preservation after the specific gaps below are closed</li>
+      <li>Free tier stays: new tab reader, full-text search, reader mode, basic sync — no bookmark cap</li>
+    </ul>
+    <p style="margin-top: 8pt;"><em>Start the LemonSqueezy account setup today. The engineering is the shorter part once the account is ready.</em></p>
+  </div>
+
+  <div class="community-card" style="margin-bottom: 12pt;">
+    <div class="community-header">
+      <span class="community-name">5. Submit Featured badge application</span>
+      <span class="tag amber">Gated on #1</span>
+    </div>
+    <p>The pre-flight script (<code>pnpm cws:featured:preflight</code>) checks that the live listing title matches. Run it after the CWS dashboard update clears. Then submit via the Featured badge request form. The listing, screenshots, and promo tile are already confirmed ready in the checklist.</p>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════════
+       SECTION B — FEATURE WORK (code-grounded)
+       ══════════════════════════════════════════════════════════ -->
+  <h2>B — Feature Work (Ordered by Impact ÷ Effort)</h2>
+
+  <!-- B1: Deleted tweet tombstone -->
+  <h3>B1 · Fix Deleted Tweet Preservation — 0.5 day</h3>
+  <span class="tag green">Already 80% done</span>
+  <span class="tag">Effort: half a day</span>
+  <p style="margin-top: 8pt;">The types and DB schema for deleted tweet tombstoning are fully in place (<code>detailsStatus: "unavailable"</code>, <code>unavailableReason: "deleted"</code> in <code>src/types/index.ts:180</code>). The full tweet content (text, author, media) is already stored locally at sync time. <strong>The only gap: the tombstone is never written.</strong></p>
+  <p>When <code>parseTweetDetailPayload()</code> returns <code>{ focalTweet: null }</code>, the code currently throws an error instead of persisting a tombstone. Two files to change:</p>
+  <table class="striped">
+    <thead><tr><th>File</th><th>Change</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><code>src/api/core/posts.ts:93–101</code></td>
+        <td>Detect null focalTweet → write <code>{ tweetId, fetchedAt, focalTweet: null, thread: [], detailsStatus: "unavailable", unavailableReason: "deleted" }</code> to IDB via <code>upsertTweetDetailCache</code></td>
+      </tr>
+      <tr>
+        <td><code>src/components/BookmarkReader.tsx</code></td>
+        <td>When <code>detailsStatus === "unavailable"</code>, synthesize reader content from the cached <code>Bookmark</code> row (text, author, media) instead of showing the error screen. Add a subtle "original post deleted" badge.</td>
+      </tr>
+      <tr>
+        <td><code>src/components/reader/reader-error-view.ts</code></td>
+        <td>Optional: add a "deleted but cached" view variant distinct from "network error"</td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="callout">
+    <p><strong>Why this matters for conversion:</strong> "If the original author deletes the tweet, your bookmark instantly becomes invalid — a massive loss for content research." This is the #1 emotional driver for the Pro tier upgrade. The feature is half a day of work but unlocks the most compelling Pro narrative: <em>pay once, own your saves forever, even after deletion.</em></p>
+  </div>
+
+  <!-- B2: No-tab hydration -->
+  <h3>B2 · Optional No-Tab Hydration — defer</h3>
+  <span class="tag green">Full export hydration built</span>
+  <span class="tag">Effort: optional</span>
+  <p style="margin-top: 8pt;">Thread parsing, DB schema, types, reader rendering, export, and full-library export hydration are implemented. The <code>TweetDetailCache</code> with <code>thread: ThreadTweet[]</code> is stored and exported correctly, and <code>src/stores/hydration-store.ts</code> can walk bookmarks missing details without requiring the reader to be open. The only remaining optional gap is a service-worker or <code>chrome.alarms</code> version that keeps hydrating when no Totem tab is alive; the existing plan intentionally rejected that complexity because Totem is the new-tab page.</p>
+  <table class="striped">
+    <thead><tr><th>File</th><th>Change</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><code>src/stores/hydration-store.ts</code></td>
+        <td>Already provides the runtime hydration loop for full export: finds missing detail rows, fetches tweet detail, stores thread content, handles auth/rate-limit/storage pauses, and coordinates with a single-writer lock</td>
+      </tr>
+      <tr>
+        <td><code>src/service-worker/index.ts</code></td>
+        <td>Optional future enhancement only: add a <code>chrome.alarms</code>-triggered pass if you decide hydration must continue when no Totem tab is open</td>
+      </tr>
+    </tbody>
+  </table>
+  <p>No parser, type, export, or runtime hydration changes are needed for the current product promise. Treat this as a possible reliability enhancement, not a launch blocker.</p>
+
+  <!-- B3: Context menu + keyboard shortcut -->
+  <h3>B3 · Context Menu &amp; Keyboard Shortcut — 2–4 days</h3>
+  <span class="tag red">Not started</span>
+  <span class="tag amber">Effort: 2–4 days</span>
+  <p style="margin-top: 8pt;">Zero implementation exists. No <code>contextMenus</code> permission, no <code>commands</code> section in the manifest, no <code>chrome.contextMenus</code> or <code>chrome.commands</code> usage anywhere. This is the most impactful low-complexity feature not yet started — it turns Totem into a utility for the nosurf persona who encounters tweet links in newsletters and blogs without ever wanting to visit X.</p>
+  <table class="striped">
+    <thead><tr><th>What</th><th>Where</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>Add <code>"contextMenus"</code> to <code>permissions</code> and a <code>"commands"</code> section with <code>Cmd/Ctrl+Shift+S</code></td>
+        <td><code>public/manifest.json</code></td>
+      </tr>
+      <tr>
+        <td>Create <code>src/service-worker/context-menu.ts</code></td>
+        <td>Register menu item, <code>onClicked</code> handler, URL parsing to extract tweet ID from <code>x.com/*/status/*</code> or <code>twitter.com</code> patterns</td>
+      </tr>
+      <tr>
+        <td>Wire into <code>src/service-worker/index.ts</code></td>
+        <td>Register menu on install, add <code>chrome.commands.onCommand</code> listener alongside the existing handlers</td>
+      </tr>
+    </tbody>
+  </table>
+  <p><strong>Decision to make:</strong> Should a context-menu save also call the X CreateBookmark API (so it appears in X's own bookmarks too), or only save locally? Local-only = 2 days, API-backed = 3–4 days because you need to handle the auth-not-ready case gracefully when there's no UI to prompt re-auth.</p>
+
+  <!-- B4: Pro tier implementation -->
+  <h3>B4 · Pro Tier Gating in the Extension — 1 week (after B1 decision)</h3>
+  <span class="tag red">Not started</span>
+  <span class="tag amber">Effort: 1 week</span>
+  <p style="margin-top: 8pt;">Once LemonSqueezy is set up (see A4), the in-extension gating work:</p>
+  <ul>
+    <li>Add a <code>proLicense</code> field to <code>chrome.storage.sync</code> schema — syncs across user's browsers</li>
+    <li>Create a <code>src/lib/pro.ts</code> module: HMAC-verify the license key locally on load, expose an <code>isProUnlocked()</code> check</li>
+    <li>Gate in <code>ExportModal.tsx</code>: show "Pro" badge on export button, redirect to checkout if unlocked = false</li>
+    <li>Gate highlights visibility behind Pro (the UI is done; just add a check at the <code>useHighlights</code> hook entry)</li>
+    <li>Add an "Unlock Pro — $14 founders price" CTA in the settings modal and in the new-tab home</li>
+    <li>No new exports to implement — Markdown, CSV, JSONL are all already working</li>
+  </ul>
+  <div class="takeaway">
+    <div class="takeaway-label">Natural Pro Gate</div>
+    <p>Free: new tab reader, full-text search, reader mode, sync, basic stats. No cap on bookmark count.</p>
+    <p style="margin-top: 6pt;">Pro ($19 one-time, $14 founders): ZIP export (Markdown/CSV/JSONL), highlights &amp; notes, full export hydration, advanced search filters, deleted tweet preservation. Export, highlights, and full export hydration are already built; preservation needs the small implementation gap above before it becomes a clean Pro promise.</p>
+  </div>
+
+  <!-- B5: Universal tweet preview -->
+  <h3>B5 · Universal Tweet Preview on External Sites — assess before building</h3>
+  <span class="tag red">High complexity</span>
+  <span class="tag amber">Effort: 1–2 weeks + CWS review risk</span>
+  <p style="margin-top: 8pt;">No cross-site content script exists. Both current content scripts (<code>detect-user.js</code>, <code>mutation-hook.js</code>) are scoped to <code>x.com</code> only. The feature requires <code>&lt;all_urls&gt;</code> host permission, which triggers an additional Chrome Web Store manual review and requires a detailed privacy justification.</p>
+  <p><strong>Assess this before building:</strong></p>
+  <ul>
+    <li><strong>CWS risk:</strong> <code>&lt;all_urls&gt;</code> access is the permission most likely to cause CWS rejection or Featured badge denial. Consider using <code>optional_host_permissions</code> with a runtime permission request instead — user opts in, avoids the install-time flag.</li>
+    <li><strong>UI constraint:</strong> A content script cannot use React or the extension's build output. The hover card must be vanilla DOM with Shadow DOM isolation to avoid clashing with host page styles and z-index. Separate Vite entry point required (like <code>open-in-totem.ts</code>).</li>
+    <li><strong>t.co links:</strong> Most tweet links in newsletters and blogs come through t.co shorteners. Resolution adds a network round-trip per link — handle carefully to avoid slowing page loads.</li>
+    <li><strong>DB access:</strong> Content scripts cannot access the extension's IndexedDB directly (origin-scoped to <code>chrome-extension://</code>). Previews must round-trip through the service worker via <code>chrome.runtime.sendMessage</code> using the existing <code>FETCH_TWEET_DETAIL</code> message pattern.</li>
+  </ul>
+  <p><em>Defer until after Featured badge is secured. The <code>&lt;all_urls&gt;</code> permission could complicate the submission.</em></p>
+
+  <!-- B6: Semantic search -->
+  <h3>B6 · Semantic Search (transformers.js) — plan carefully</h3>
+  <span class="tag red">High complexity</span>
+  <span class="tag amber">Effort: 2 weeks</span>
+  <p style="margin-top: 8pt;">Not installed. The existing MiniSearch implementation is production-quality with fuzzy matching, BM25 scoring, recency decay, and rich query operators — it handles most user search needs well. Semantic search adds concept-retrieval when the user doesn't remember exact keywords.</p>
+  <p><strong>Key blockers to solve before starting:</strong></p>
+  <ul>
+    <li><strong>CSP blocker:</strong> The current <code>manifest.json</code> CSP is <code>script-src 'self'</code>. Loading a WASM-compiled model requires either <code>wasm-eval</code> or an <code>ArrayBuffer</code> instantiation approach. Adding <code>wasm-eval</code> to the CSP will trigger additional CWS scrutiny — same risk as <code>&lt;all_urls&gt;</code>. Check Chrome's current WASM-in-extension guidance before committing.</li>
+    <li><strong>Model size:</strong> <code>all-MiniLM-L6-v2</code> is 22MB WASM + weights. This must ship inside the extension ZIP, which increases install size and CWS review time.</li>
+    <li><strong>Initial indexing:</strong> At 20–50ms per embedding on modern hardware, 5,000 bookmarks = 100–250 seconds of blocking computation. Needs chunked background processing with a progress indicator.</li>
+    <li><strong>Storage:</strong> 5,000 bookmarks × 1.5KB per embedding = ~7.5MB of vector data in IndexedDB. Fine. 50,000 = 75MB — starts to matter.</li>
+  </ul>
+  <p>Best sequencing: build MiniSearch gaps first (<code>tag:</code> and <code>lang:</code> operators are stubs), ship context menu, then revisit semantic search after the paywall is in place and conversion data shows whether power users are paying for search.</p>
+
+  <!-- B7: MCP endpoint -->
+  <h3>B7 · MCP Endpoint — long bet, plan the architecture first</h3>
+  <span class="tag red">High complexity</span>
+  <span class="tag amber">Effort: 2–4 weeks</span>
+  <p style="margin-top: 8pt;">No MCP code exists. Chrome MV3 service workers cannot run a TCP or Unix socket server, so a direct MCP endpoint is architecturally impossible without a companion process. Options:</p>
+  <table class="striped">
+    <thead><tr><th>Approach</th><th>Pros</th><th>Cons</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><strong>Native messaging</strong> (recommended)</td>
+        <td>Fully local, no server, aligns with privacy story</td>
+        <td>User installs a companion binary; requires CWS <code>nativeMessaging</code> permission review; distribution is manual (no auto-update)</td>
+      </tr>
+      <tr>
+        <td><strong>Hosted MCP bridge</strong></td>
+        <td>No install friction</td>
+        <td>Breaks local-first story; data leaves the device; introduces a server dependency</td>
+      </tr>
+      <tr>
+        <td><strong>WebSocket bridge</strong></td>
+        <td>Simpler than native messaging</td>
+        <td>Local server must always be running; same distribution problem</td>
+      </tr>
+    </tbody>
+  </table>
+  <p>The bookmark data model is rich enough for MCP: <code>text</code>, <code>author</code>, <code>metrics</code>, <code>media</code>, <code>article</code> (full plainText), <code>thread</code> (full ThreadTweet[]). A <code>search_bookmarks</code> MCP tool over this corpus would close the ContextBolt gap for developers. Defer until after paywall is shipping and you have revenue to justify the engineering time.</p>
+
+  <!-- B8: Small search gaps -->
+  <h3>B8 · Fix Search Operator Stubs — 1 day</h3>
+  <span class="tag green">Quick win</span>
+  <span class="tag">Effort: 1 day</span>
+  <p style="margin-top: 8pt;">Two search operators in <code>src/lib/search/executor.ts</code> always return false and are documented as stubs:</p>
+  <ul>
+    <li><code>tag:value</code> — line 113: <code>case "tag": return false;</code> — tags are not in the data model yet</li>
+    <li><code>lang:value</code> — language is not extracted from tweet content</li>
+  </ul>
+  <p>For <code>lang:</code>: add language detection at parse time in <code>src/api/parsers.ts</code> using the <code>lang</code> field already present in the Twitter GraphQL response (it returns BCP-47 language codes). Store in the Bookmark type. Wire to executor. One day including tests.</p>
+  <p>For <code>tag:</code>: skip until a tagging UI is designed. The tag data model doesn't exist yet and designing it is a product decision, not a quick fix.</p>
+
+  <!-- ══════════════════════════════════════════════════════════
+       SECTION C — BLOG POSTS
+       ══════════════════════════════════════════════════════════ -->
+  <h2>C — Blog Posts to Add to Pipeline</h2>
+  <p>Nine ideas from the GTM research are not yet in <code>plans/blog-pipeline.md</code>. Run each through the topic filter in <code>plans/seo-agent-goal.md</code> before spending DataForSEO budget. Ordered by estimated acquisition impact.</p>
+
+  <table class="striped">
+    <thead>
+      <tr>
+        <th>Priority</th>
+        <th>Title / Angle</th>
+        <th>Primary channel</th>
+        <th>Why now</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><span class="tag red">P0</span></td>
+        <td><strong>"Your Twitter Bookmarks Are a Graveyard. Here's Why That's Not a Willpower Problem."</strong><br><span style="font-size: 9pt; color: var(--stone);">Behavior is structural (architecture problem, not discipline). New tab removes the architectural blocker.</span></td>
+        <td>r/nosurf, r/digitalminimalism, r/productivity</td>
+        <td>Highest share potential of any post. Works as a personal-story format with product mentioned once at the end. SEO long-tail: "twitter bookmarks never read."</td>
+      </tr>
+      <tr>
+        <td><span class="tag red">P0</span></td>
+        <td><strong>"Twitter Bookmarks to Obsidian: What Actually Works in 2026 (After the API Broke Everything)"</strong><br><span style="font-size: 9pt; color: var(--stone);">Every plugin broke in April 2023. Browser-session interception is the only reliable path now. Real Markdown output screenshot required.</span></td>
+        <td>r/ObsidianMD, r/PKM, Obsidian forum</td>
+        <td>kbravh/obsidian-tweet-to-markdown has 1,900+ GitHub stars — this is the addressable audience. Totem's JSONL/Markdown export is the working answer.</td>
+      </tr>
+      <tr>
+        <td><span class="tag red">P0</span></td>
+        <td><strong>"What Pocket's Shutdown Taught Us About Saving Things on the Internet"</strong><br><span style="font-size: 9pt; color: var(--stone);">Pocket died July 8, 2025. Data export window closed November 12. The lesson: "you don't own what you don't host."</span></td>
+        <td>r/selfhosted, r/privacy, r/degoogle, HN</td>
+        <td>Peak migration sentiment is NOW. r/selfhosted activity spiked massively in May–July 2025. This is the conversion post for the privacy persona.</td>
+      </tr>
+      <tr>
+        <td><span class="tag amber">P1</span></td>
+        <td><strong>"The Twitter Bookmark You Saved Is Gone. Here's Why."</strong><br><span style="font-size: 9pt; color: var(--stone);">When someone deletes a tweet, every bookmark pointing to it silently breaks. No notification. No cached copy.</span></td>
+        <td>r/Twitter, r/journalism, HN</td>
+        <td>Good SEO long-tail: "twitter bookmark disappeared," "twitter bookmark deleted." Pairs naturally with the B1 deleted-tweet preservation feature once it ships.</td>
+      </tr>
+      <tr>
+        <td><span class="tag amber">P1</span></td>
+        <td><strong>"Readwise Is Overkill for Twitter Bookmarks"</strong><br><span style="font-size: 9pt; color: var(--stone);">$120/year for Kindle + PDF + spaced repetition when you only want Twitter → Obsidian. Not a hit piece — Readwise is good. Wrong tool for Twitter-only users.</span></td>
+        <td>r/PKM, r/ObsidianMD, r/productivity</td>
+        <td>Readwise alternatives searches spiking. High commercial intent. Direct comparison: $120/year vs $19 once.</td>
+      </tr>
+      <tr>
+        <td><span class="tag amber">P1</span></td>
+        <td><strong>"Reading Twitter Without Opening Twitter"</strong><br><span style="font-size: 9pt; color: var(--stone);">Short observational piece. X has content worth reading. Visiting X means surrendering to the feed. The irony problem, named.</span></td>
+        <td>r/nosurf, r/digitalminimalism</td>
+        <td>Cal Newport language maps directly. Can double as an X thread for the indie maker community. Short enough to write in 2 hours.</td>
+      </tr>
+      <tr>
+        <td><span class="tag">P2</span></td>
+        <td><strong>"Why Twitter Bookmark Search Still Does Not Work (Even After X Added It)"</strong><br><span style="font-size: 9pt; color: var(--stone);">X launched search in late 2024. Returns wrong results even with exact keywords. Android has no search as of 2026.</span></td>
+        <td>r/Twitter, r/productivity</td>
+        <td>Good SEO target: "twitter bookmark search not working." Natural plug for Totem's local full-text search.</td>
+      </tr>
+      <tr>
+        <td><span class="tag">P2</span></td>
+        <td><strong>"Twitter Bookmarks for Obsidian, Logseq, and Notion: A Workflow Comparison"</strong><br><span style="font-size: 9pt; color: var(--stone);">Three PKM communities, three workflows. What exists, what broke in 2023, what works without an API key.</span></td>
+        <td>r/ObsidianMD, r/PKM, r/logseq, r/Notion</td>
+        <td>High share potential across three communities if the post is honest about each platform. Totem as the extraction layer, not a replacement for any PKM tool.</td>
+      </tr>
+      <tr>
+        <td><span class="tag">P2</span></td>
+        <td><strong>"What 'Local-First' Actually Means for a Browser Extension"</strong><br><span style="font-size: 9pt; color: var(--stone);">Every tool makes a choice about where the data lives. Most don't explain it clearly. Concrete difference between IndexedDB in your browser and a cloud database.</span></td>
+        <td>r/privacy, r/selfhosted, r/degoogle, HN</td>
+        <td>Trust argument made explicit for communities that respond to technical honesty. Strava API lock-in post had 1,698 upvotes — same sentiment register.</td>
+      </tr>
+    </tbody>
+  </table>
+  <p class="small" style="margin-top: 8pt;">Before drafting any of these: add them to <code>plans/blog-pipeline.md</code> → run through the topic filter in <code>plans/seo-agent-goal.md</code> → validate with <code>/dataforseo</code> → draft in <code>plans/blog-drafts/</code>.</p>
+
+  <!-- ══════════════════════════════════════════════════════════
+       SECTION D — COMMUNITY / GTM ACTIONS
+       ══════════════════════════════════════════════════════════ -->
+  <h2>D — Community &amp; GTM Actions</h2>
+  <p>Ordered by sequencing dependency. Some are blocked on the CWS listing update (Section A1); some require 2–4 weeks of comment history first.</p>
+
+  <table class="striped">
+    <thead>
+      <tr>
+        <th>Channel</th>
+        <th>Action</th>
+        <th>Gate</th>
+        <th>Priority</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>HN — existing threads</strong></td>
+        <td>Reply to Ask HN id=40609664 ("How do you organize your Twitter/X bookmarks?") and id=37009892 ("Do You Want a Twitter Bookmark Organizer?") with a brief factual description and link. Do this separately from the Show HN.</td>
+        <td>CWS listing live</td>
+        <td><span class="tag red">Now</span></td>
+      </tr>
+      <tr>
+        <td><strong>r/SideProject</strong></td>
+        <td>Post the pre-drafted founder story with specific install numbers. Stay in comments 2+ hours.</td>
+        <td>CWS listing live</td>
+        <td><span class="tag red">Now</span></td>
+      </tr>
+      <tr>
+        <td><strong>AlternativeTo</strong></td>
+        <td>Create the listing. Category: Twitter bookmark managers, alternatives to Dewey, Readwise (for Twitter), Twillot. Free to submit. Gets organic discovery traffic.</td>
+        <td>None</td>
+        <td><span class="tag red">Now</span></td>
+      </tr>
+      <tr>
+        <td><strong>bookmarksave.com</strong></td>
+        <td>Send the outreach email (already drafted in checklist). This is a directory listing, not a review site — low effort, passive acquisition.</td>
+        <td>None</td>
+        <td><span class="tag red">Now</span></td>
+      </tr>
+      <tr>
+        <td><strong>r/nosurf</strong></td>
+        <td>Build comment history first: contribute genuine, non-promotional replies in existing threads ("How do I use Twitter intentionally?", "RSS alternative to Twitter") for 2–4 weeks. Then post the personal transformation story. Never lead with the product.</td>
+        <td>2–4 weeks comment history</td>
+        <td><span class="tag amber">Week 2+</span></td>
+      </tr>
+      <tr>
+        <td><strong>r/ObsidianMD</strong></td>
+        <td>Post after the "Twitter Bookmarks to Obsidian" blog post is live. Lead with a screenshot of actual Markdown output with YAML frontmatter. Reply to every comment asking about DataView compatibility or specific YAML fields.</td>
+        <td>Blog post live + B2 hydration shipped</td>
+        <td><span class="tag amber">Month 1</span></td>
+      </tr>
+      <tr>
+        <td><strong>r/selfhosted</strong></td>
+        <td>Post after "What Pocket's Shutdown Taught Us" blog is live. Angle: IndexedDB is the serverless version of self-hosting. Be precise about what IndexedDB means technically — data in the user's browser profile directory. Link to the GitHub repo if public.</td>
+        <td>Blog post live</td>
+        <td><span class="tag amber">Month 1</span></td>
+      </tr>
+      <tr>
+        <td><strong>X / Twitter thread</strong></td>
+        <td>Thread starting with: "I had 847 bookmarks on Twitter. I had read maybe 12 of them." Walk through why (structural), what you built, how the new tab changes the habit loop. CTA at tweet 8–10. Do not put the link in tweet 1 — algorithm down-ranks external links early.</td>
+        <td>None</td>
+        <td><span class="tag amber">Month 1</span></td>
+      </tr>
+      <tr>
+        <td><strong>r/degoogle + r/PKM</strong></td>
+        <td>Post after r/selfhosted traction is confirmed. r/degoogle angle: no OAuth token, no third-party server, passive session interception. r/PKM angle: free local-first Readwise replacement for Twitter.</td>
+        <td>First-wave traction data</td>
+        <td><span class="tag">Month 2</span></td>
+      </tr>
+      <tr>
+        <td><strong>Product Hunt</strong></td>
+        <td>Gated on 20+ CWS reviews (per checklist). Run review prompt for 4–6 weeks to build review velocity first. Then launch with a Hunter who has 1,000+ followers.</td>
+        <td>20+ CWS reviews</td>
+        <td><span class="tag">Month 2–3</span></td>
+      </tr>
+      <tr>
+        <td><strong>HN — Technical thread</strong></td>
+        <td>Post a technical essay on the GraphQL interception architecture: passive header capture, 4-tier query ID resolution, MV3 constraints, why not the API. This is a P1 roadmap item — wait until it can be posted standalone (not as Show HN).</td>
+        <td>Separate from Show HN</td>
+        <td><span class="tag">Month 2–3</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <!-- ══════════════════════════════════════════════════════════
+       SECTION E — OPEN SOURCE DECISION
+       ══════════════════════════════════════════════════════════ -->
+  <h2>E — Open Source vs. Private Source</h2>
+  <p>The repository is currently private (confirmed: no LICENSE file, <code>"private": true</code> in package.json, no CONTRIBUTING.md, no community issue templates). The GTM report's trust signal argument for open-sourcing is real but the code investigation reveals a meaningful competitive moat worth protecting.</p>
+
+  <div class="persona-card">
+    <div class="persona-name" style="font-size: 13pt;">What's actually the moat</div>
+    <p style="margin-top: 6pt;">Two files contain the competitive advantage:</p>
+    <ul style="margin-top: 6pt;">
+      <li><code>src/service-worker/query-id.ts</code> — The 4-tier GraphQL query ID resolution chain (passive catalog from observed traffic → in-memory cache → bundle scraping → tab discovery). This is what keeps sync working when X rotates its internal API IDs. A competitor could adopt it within weeks of seeing it.</li>
+      <li><code>src/service-worker/auth.ts</code> — The auth capture mechanism. Most competing extensions have cruder approaches. This is a genuine edge.</li>
+    </ul>
+    <p style="margin-top: 8pt;">Everything else — the React UI, Zustand stores, MiniSearch engine, export pipeline, IndexedDB schema — is good engineering but reproducible. It is not the moat.</p>
+  </div>
+
+  <h3>Recommendation: Stay private through paywall launch. Then consider staged openness.</h3>
+
+  <table class="striped">
+    <thead><tr><th>Option</th><th>Pros</th><th>Cons</th><th>Verdict</th></tr></thead>
+    <tbody>
+      <tr>
+        <td><strong>Fully open source now</strong></td>
+        <td>Maximum trust signal for HN/CWS Featured; community backlinks; audit transparency</td>
+        <td>Competitors clone the sync engine immediately; forecloses Pro feature gating before paywall exists; no license means anyone can re-publish to CWS</td>
+        <td><span class="tag red">Don't</span></td>
+      </tr>
+      <tr>
+        <td><strong>Stay fully private</strong></td>
+        <td>Protects moat; paywall can gate anything; no CWS re-publishing risk</td>
+        <td>Weakens trust argument for privacy-first communities (r/selfhosted, r/degoogle ask for auditable code)</td>
+        <td><span class="tag amber">Default for now</span></td>
+      </tr>
+      <tr>
+        <td><strong>Open-source the export format spec</strong></td>
+        <td>Developer trust signal and backlinks with zero moat exposure; the export schema is public-facing anyway (<code>usetotem.xyz/export-format/v1</code>); already called out as a P2 play in the checklist</td>
+        <td>Small effort to write up as a standalone repo</td>
+        <td><span class="tag green">Do this</span></td>
+      </tr>
+      <tr>
+        <td><strong>Source-available UI layer</strong></td>
+        <td>Make the React/Zustand/search layer public, keep <code>src/service-worker/</code> private. Trust signal without full moat exposure.</td>
+        <td>Complex to maintain split; CWS may still not count it as "open source"</td>
+        <td><span class="tag">Consider post-paywall</span></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="callout">
+    <p><strong>What to do today on open source:</strong></p>
+    <ol style="margin-top: 6pt;">
+      <li>Add a <code>LICENSE</code> file — at minimum a proprietary "All Rights Reserved" notice to prevent forks from republishing to the CWS. Without any license, the legal status is ambiguous.</li>
+      <li>Create a separate public repo at <code>github.com/usetotem/export-format</code> with the export schema, field definitions, and example files. This gives HN credibility and backlinks without touching the sync engine.</li>
+      <li>After the paywall is live and revenue is positive: revisit source-available for the UI layer. The Show HN for that ("we open-sourced the UI, the sync engine stays private for now") is itself a distribution event.</li>
+    </ol>
+  </div>
+
+  <!-- ══════════════════════════════════════════════════════════
+       MASTER SEQUENCING TABLE
+       ══════════════════════════════════════════════════════════ -->
+  <h2>Master Sequencing Table</h2>
+  <p>Everything on one page, ordered by dependency and impact.</p>
+
+  <table class="striped">
+    <thead>
+      <tr>
+        <th>When</th>
+        <th>Action</th>
+        <th>Type</th>
+        <th>Effort</th>
+        <th>Impact</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>Day 1</strong></td>
+        <td>Fix CWS listing title + descriptions (manual dashboard update)</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>1 hour</td>
+        <td>Unblocks Featured badge, Show HN, r/SideProject</td>
+      </tr>
+      <tr>
+        <td><strong>Day 1</strong></td>
+        <td>Add LICENSE file to repo</td>
+        <td><span class="tag">Code</span></td>
+        <td>15 min</td>
+        <td>Legal clarity, required before any open-source decision</td>
+      </tr>
+      <tr>
+        <td><strong>Day 1–2</strong></td>
+        <td>Create LemonSqueezy account + product listing ($19 lifetime, $14 founders)</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>2 hours</td>
+        <td>Revenue infrastructure starts</td>
+      </tr>
+      <tr>
+        <td><strong>Day 1–2</strong></td>
+        <td>Post AlternativeTo listing + bookmarksave.com outreach</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>1 hour</td>
+        <td>Passive acquisition, no gate</td>
+      </tr>
+      <tr>
+        <td><strong>Day 2–3</strong></td>
+        <td>Post Show HN (after CWS listing live)</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>30 min to post, 2 hrs to engage</td>
+        <td>Developer persona acquisition, HN link equity</td>
+      </tr>
+      <tr>
+        <td><strong>Day 2–3</strong></td>
+        <td>Post r/SideProject</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>30 min</td>
+        <td>Maker community awareness</td>
+      </tr>
+      <tr>
+        <td><strong>Day 2–3</strong></td>
+        <td>Reply to HN threads id=40609664 and id=37009892</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>20 min</td>
+        <td>High-intent existing demand</td>
+      </tr>
+      <tr>
+        <td><strong>Day 3</strong></td>
+        <td>Submit Featured badge application (after CWS listing live)</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>30 min</td>
+        <td>CWS organic discovery</td>
+      </tr>
+      <tr>
+        <td><strong>Week 1</strong></td>
+        <td>B1: Fix deleted tweet tombstone (posts.ts:93–101 + BookmarkReader.tsx)</td>
+        <td><span class="tag">Code</span></td>
+        <td>1–1.5 days</td>
+        <td>Core Pro narrative: "pay once, own your saves forever"</td>
+      </tr>
+      <tr>
+        <td><strong>Week 1</strong></td>
+        <td>B4: Add Pro paywall gating to ExportModal + useHighlights + settings</td>
+        <td><span class="tag">Code</span></td>
+        <td>3–4 days</td>
+        <td>Revenue opens</td>
+      </tr>
+      <tr>
+        <td><strong>Week 1–2</strong></td>
+        <td>B2: Background thread hydration (prefetch-controller.ts + SW alarms)</td>
+        <td><span class="tag">Code</span></td>
+        <td>1–2 days</td>
+        <td>Export quality competitive with specialized thread tools</td>
+      </tr>
+      <tr>
+        <td><strong>Week 1–2</strong></td>
+        <td>B3: Context menu + keyboard shortcut (manifest + context-menu.ts)</td>
+        <td><span class="tag">Code</span></td>
+        <td>2–4 days</td>
+        <td>Nosurf persona: save from anywhere without opening X</td>
+      </tr>
+      <tr>
+        <td><strong>Week 1–2</strong></td>
+        <td>Start r/nosurf comment history (non-promotional replies)</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>Ongoing</td>
+        <td>Required gate for r/nosurf post in week 3–4</td>
+      </tr>
+      <tr>
+        <td><strong>Week 2–3</strong></td>
+        <td>Draft + publish "Twitter Bookmarks Are a Graveyard" blog post</td>
+        <td><span class="tag amber">Content</span></td>
+        <td>4–6 hours</td>
+        <td>r/nosurf + r/productivity acquisition</td>
+      </tr>
+      <tr>
+        <td><strong>Week 2–3</strong></td>
+        <td>Draft + publish "What Pocket's Shutdown Taught Us" blog post</td>
+        <td><span class="tag amber">Content</span></td>
+        <td>4–6 hours</td>
+        <td>r/selfhosted + r/privacy acquisition</td>
+      </tr>
+      <tr>
+        <td><strong>Week 3–4</strong></td>
+        <td>Draft + publish "Twitter Bookmarks to Obsidian" blog post (with real Markdown screenshot)</td>
+        <td><span class="tag amber">Content</span></td>
+        <td>4–6 hours</td>
+        <td>r/ObsidianMD PKM persona acquisition</td>
+      </tr>
+      <tr>
+        <td><strong>Week 3–4</strong></td>
+        <td>Post r/nosurf personal story (after 3–4 weeks comment history)</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>1 hour to post</td>
+        <td>Highest-reach persona channel</td>
+      </tr>
+      <tr>
+        <td><strong>Week 3–4</strong></td>
+        <td>Post r/ObsidianMD after blog post is live</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>30 min + comments</td>
+        <td>PKM persona, Readwise displacement</td>
+      </tr>
+      <tr>
+        <td><strong>Month 1–2</strong></td>
+        <td>Post r/selfhosted + r/degoogle after privacy blog posts live</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>1 hour</td>
+        <td>Privacy persona acquisition</td>
+      </tr>
+      <tr>
+        <td><strong>Month 1–2</strong></td>
+        <td>Post X thread: "I had 847 bookmarks on Twitter. I had read maybe 12 of them."</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>2 hours</td>
+        <td>Maker community, algorithm-amplified</td>
+      </tr>
+      <tr>
+        <td><strong>Month 1–2</strong></td>
+        <td>Create <code>github.com/usetotem/export-format</code> public repo (schema + example files)</td>
+        <td><span class="tag">Code</span></td>
+        <td>4 hours</td>
+        <td>Developer trust signal, backlinks</td>
+      </tr>
+      <tr>
+        <td><strong>Month 2–3</strong></td>
+        <td>B5: Universal tweet preview (assess CWS risk first — <code>&lt;all_urls&gt;</code> permission)</td>
+        <td><span class="tag">Code</span></td>
+        <td>1–2 weeks</td>
+        <td>Acquisition surface across the entire web</td>
+      </tr>
+      <tr>
+        <td><strong>Month 2–3</strong></td>
+        <td>Product Hunt launch (gate: 20+ CWS reviews)</td>
+        <td><span class="tag amber">Manual</span></td>
+        <td>1 day prep</td>
+        <td>Maker/tech community spike</td>
+      </tr>
+      <tr>
+        <td><strong>Month 3+</strong></td>
+        <td>B6: Semantic search (transformers.js — assess CSP/WASM risk first)</td>
+        <td><span class="tag">Code</span></td>
+        <td>2 weeks</td>
+        <td>Power user retention, closes ContextBolt gap</td>
+      </tr>
+      <tr>
+        <td><strong>Month 3+</strong></td>
+        <td>B7: MCP endpoint (native messaging companion binary)</td>
+        <td><span class="tag">Code</span></td>
+        <td>2–4 weeks</td>
+        <td>Developer persona, closes ContextBolt gap entirely</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="takeaway" style="margin-top: 20pt;">
+    <div class="takeaway-label">The One Number That Changes Everything</div>
+    <p>Every day the CWS listing shows the wrong title is a day the Featured badge application cannot be submitted. Fix that first — in 60 minutes — and every other action in this list becomes unlocked.</p>
+  </div>
+
+  <hr>
+  <p class="small" style="text-align: center; margin-top: 20pt;">
+    Action Checklist · June 16, 2026 · Code-grounded by 5-agent parallel investigation<br>
+    Every feature status verified against the live codebase at <code>src/</code>
+  </p>
+</section>
+
+<script>
+(function () {
+  const KEY = 'totem-todos-v1';
+  let state = {};
+  try { state = JSON.parse(localStorage.getItem(KEY) || '{}'); } catch (e) {}
+
+  const section = document.getElementById('todo-section');
+  if (!section) return;
+
+  /* ── Inject checkboxes into community cards (Section A) ── */
+  section.querySelectorAll('.community-card').forEach(function (card, i) {
+    const id = 'card-' + i;
+    const header = card.querySelector('.community-header');
+    if (!header) return;
+
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.className = 'todo-check';
+    cb.dataset.id = id;
+    cb.style.cssText = 'margin-right: 10pt; margin-top: 2pt; flex-shrink: 0;';
+    if (state[id]) { cb.checked = true; card.classList.add('card-todo-done'); }
+
+    header.style.display = 'flex';
+    header.style.alignItems = 'flex-start';
+    header.insertBefore(cb, header.firstChild);
+
+    cb.addEventListener('change', function () {
+      if (this.checked) state[id] = 1; else delete state[id];
+      card.classList.toggle('card-todo-done', this.checked);
+      save(); updateProgress();
+    });
+  });
+
+  /* ── Inject checkboxes into tables ── */
+  section.querySelectorAll('table.striped').forEach(function (table, ti) {
+    const thead = table.querySelector('thead tr');
+    if (thead) {
+      const th = document.createElement('th');
+      th.style.cssText = 'width:22pt; padding:6pt 4pt 6pt 0;';
+      thead.insertBefore(th, thead.firstChild);
+    }
+
+    table.querySelectorAll('tbody tr').forEach(function (row, ri) {
+      const id = 'tbl-' + ti + '-' + ri;
+      const td = document.createElement('td');
+      td.style.cssText = 'width:22pt; padding:5pt 4pt 5pt 0; vertical-align:middle; text-align:center;';
+
+      const cb = document.createElement('input');
+      cb.type = 'checkbox';
+      cb.className = 'todo-check';
+      cb.dataset.id = id;
+      if (state[id]) { cb.checked = true; row.classList.add('todo-done'); }
+
+      td.appendChild(cb);
+      row.insertBefore(td, row.firstChild);
+
+      cb.addEventListener('change', function () {
+        if (this.checked) state[id] = 1; else delete state[id];
+        row.classList.toggle('todo-done', this.checked);
+        save(); updateProgress();
+      });
+    });
+  });
+
+  /* ── Progress bar ── */
+  const lead = section.querySelector('.lead');
+  const bar = document.createElement('div');
+  bar.className = 'todo-progress-bar';
+  bar.innerHTML =
+    '<span class="todo-count">Completed: <strong id="td-done">0</strong> of <strong id="td-total">0</strong></span>' +
+    '<div class="todo-bar-track"><div class="todo-bar-fill" id="td-bar" style="width:0%"></div></div>' +
+    '<button class="todo-reset" id="td-reset">Reset all</button>';
+  if (lead) lead.after(bar);
+
+  document.getElementById('td-reset').addEventListener('click', function () {
+    if (!confirm('Reset all completed items?')) return;
+    state = {};
+    save();
+    section.querySelectorAll('.todo-check').forEach(function (cb) {
+      cb.checked = false;
+      const c = cb.closest('.community-card');
+      if (c) c.classList.remove('card-todo-done');
+      const r = cb.closest('tr');
+      if (r) r.classList.remove('todo-done');
+    });
+    updateProgress();
+  });
+
+  function updateProgress() {
+    const all = section.querySelectorAll('.todo-check');
+    const done = Array.from(all).filter(function (c) { return c.checked; }).length;
+    const dEl = document.getElementById('td-done');
+    const tEl = document.getElementById('td-total');
+    const bEl = document.getElementById('td-bar');
+    if (dEl) dEl.textContent = done;
+    if (tEl) tEl.textContent = all.length;
+    if (bEl) bEl.style.width = (all.length ? Math.round(done / all.length * 100) : 0) + '%';
+  }
+
+  function save() { localStorage.setItem(KEY, JSON.stringify(state)); }
+
+  updateProgress();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Restores `plans/research/premium-monetization/` — full HTML research report (model, features, tech stack, payments, license, compliance, paywall UX, rollout, adversarial review) plus 10 appendices and raw notes
- Restores `plans/research/totem-gtm-research-2026-06-16.html` — the GTM research report

Both were pruned in a2ac8577. Reviving them under `plans/research/` for active reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)