### PR TITLE
refactor(sync): extract pure decideCompletion, source mode/trigger from lease

### DIFF
--- a/src/api/core/sync.ts
+++ b/src/api/core/sync.ts
@@ -39,9 +39,7 @@ export async function reserveSyncRun(input: {
   return {
     allow: response.allow === true,
     mode:
-      response.mode === "full" ||
-      response.mode === "incremental" ||
-      response.mode === "quick"
+      response.mode === "full" || response.mode === "incremental"
         ? response.mode
         : null,
     reason: typeof response.reason === "string" ? response.reason : "unknown",

--- a/src/lib/constants/sync-policy.ts
+++ b/src/lib/constants/sync-policy.ts
@@ -1,6 +1,4 @@
 export const SYNC_PAGE_SIZE = 100;
-export const SYNC_MAX_PAGES_PER_JOB = 3;
-export const SYNC_MAX_BOOKMARKS_PER_JOB = 250;
 
 export const SYNC_LOCK_TTL_MS = 12 * 60 * 1000;
 export const SYNC_MANUAL_COOLDOWN_MS = 4_000;

--- a/src/service-worker/__tests__/decide-completion.test.ts
+++ b/src/service-worker/__tests__/decide-completion.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect } from "vitest";
+import {
+  decideCompletion,
+  type SyncCompletionDecision,
+  type SyncAccountState,
+  type SyncInFlight,
+} from "../sync";
+import type { SyncMode } from "../../types/sync";
+
+const NOW = 1_000_000;
+
+const inFlight = (overrides: Partial<SyncInFlight> = {}): SyncInFlight => ({
+  leaseId: "lease-1",
+  mode: "incremental",
+  trigger: "auto",
+  reason: "background_stale",
+  startedAt: 1_000,
+  ...overrides,
+});
+
+const account = (
+  overrides: Partial<SyncAccountState> = {},
+): SyncAccountState => ({
+  inFlight: inFlight(),
+  lastSuccessAt: 0,
+  lastFullSyncAt: 0,
+  lastIncrementalSyncAt: 0,
+  manualCooldownUntil: 0,
+  rateLimitBackoffUntil: 0,
+  rateLimitConsecutive: 0,
+  lastAttemptAt: 0,
+  lastCompletedAt: 0,
+  lastCompletedStatus: null,
+  lastDecisionAt: 0,
+  lastDecisionReason: null,
+  lastError: null,
+  lastFailureCode: null,
+  ...overrides,
+});
+
+function expectApplied(d: SyncCompletionDecision) {
+  if (d.kind !== "applied") throw new Error(`expected applied, got ${d.kind}`);
+  return d;
+}
+
+describe("decideCompletion — lease identity", () => {
+  it("ignores a completion whose leaseId does not match the in-flight lease, mutating nothing", () => {
+    const acct = account({ inFlight: inFlight({ leaseId: "A" }), lastFullSyncAt: 0 });
+    const d = decideCompletion({
+      account: acct,
+      leaseId: "B",
+      status: "success",
+      errorCode: "",
+      now: NOW,
+    });
+    expect(d).toEqual({ kind: "ignored", reason: "lease_mismatch" });
+    expect(acct.inFlight?.leaseId).toBe("A");
+    expect(acct.lastFullSyncAt).toBe(0);
+  });
+
+  it("treats an empty leaseId as a mismatch", () => {
+    expect(
+      decideCompletion({
+        account: account({ inFlight: inFlight({ leaseId: "A" }) }),
+        leaseId: "",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    ).toEqual({ kind: "ignored", reason: "lease_mismatch" });
+  });
+
+  it("returns missing_inflight when there is no lease to close", () => {
+    expect(
+      decideCompletion({
+        account: account({ inFlight: null }),
+        leaseId: "lease-1",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    ).toEqual({ kind: "ignored", reason: "missing_inflight" });
+    expect(
+      decideCompletion({
+        account: null,
+        leaseId: "lease-1",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    ).toEqual({ kind: "ignored", reason: "missing_inflight" });
+  });
+});
+
+describe("decideCompletion — lease-owned mode/trigger", () => {
+  it("stamps lastFullSyncAt only when the LEASE mode is full (cannot be spoofed by payload)", () => {
+    const incr = expectApplied(
+      decideCompletion({
+        account: account({ inFlight: inFlight({ mode: "incremental" }) }),
+        leaseId: "lease-1",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    );
+    expect(incr.mode).toBe("incremental");
+    expect(incr.next.lastFullSyncAt).toBe(0);
+    expect(incr.next.lastIncrementalSyncAt).toBe(NOW);
+
+    const full = expectApplied(
+      decideCompletion({
+        account: account({ inFlight: inFlight({ mode: "full" }) }),
+        leaseId: "lease-1",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    );
+    expect(full.mode).toBe("full");
+    expect(full.next.lastFullSyncAt).toBe(NOW);
+    expect(full.next.lastIncrementalSyncAt).toBe(0);
+  });
+
+  it("sets the manual success cooldown only when the LEASE trigger is manual", () => {
+    const auto = expectApplied(
+      decideCompletion({
+        account: account({ inFlight: inFlight({ trigger: "auto" }) }),
+        leaseId: "lease-1",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    );
+    expect(auto.trigger).toBe("auto");
+    expect(auto.next.manualCooldownUntil).toBe(0);
+
+    const manual = expectApplied(
+      decideCompletion({
+        account: account({ inFlight: inFlight({ trigger: "manual" }) }),
+        leaseId: "lease-1",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    );
+    expect(manual.trigger).toBe("manual");
+    expect(manual.next.manualCooldownUntil).toBeGreaterThan(NOW);
+  });
+
+  it("clears the in-flight slot on every applied completion", () => {
+    const d = expectApplied(
+      decideCompletion({
+        account: account(),
+        leaseId: "lease-1",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    );
+    expect(d.next.inFlight).toBeNull();
+  });
+});
+
+describe("decideCompletion — backoff math", () => {
+  it("escalates rate-limit backoff and floors manual cooldown to it on a RATE_LIMITED failure", () => {
+    const d = expectApplied(
+      decideCompletion({
+        account: account({
+          inFlight: inFlight({ trigger: "manual" }),
+          rateLimitConsecutive: 2,
+        }),
+        leaseId: "lease-1",
+        status: "failure",
+        errorCode: "RATE_LIMITED",
+        now: NOW,
+      }),
+    );
+    expect(d.next.rateLimitConsecutive).toBe(3);
+    // base 60_000 * 2^(3-1) = 240_000, below the 15-min cap.
+    expect(d.next.rateLimitBackoffUntil).toBe(NOW + 240_000);
+    expect(d.next.manualCooldownUntil).toBe(d.next.rateLimitBackoffUntil);
+    expect(d.next.lastFailureCode).toBe("RATE_LIMITED");
+  });
+
+  it("a non-rate-limited failure resets the rate-limit streak", () => {
+    const d = expectApplied(
+      decideCompletion({
+        account: account({ rateLimitConsecutive: 4, rateLimitBackoffUntil: NOW + 999 }),
+        leaseId: "lease-1",
+        status: "failure",
+        errorCode: "NETWORK_ERROR",
+        now: NOW,
+      }),
+    );
+    expect(d.next.rateLimitConsecutive).toBe(0);
+    expect(d.next.rateLimitBackoffUntil).toBe(0);
+  });
+});
+
+describe("decideCompletion — cache descriptor", () => {
+  it("incremental success: lastSync + lastSoftSync + clearSoftNeeded", () => {
+    const d = expectApplied(
+      decideCompletion({
+        account: account({ inFlight: inFlight({ mode: "incremental" }) }),
+        leaseId: "lease-1",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    );
+    expect(d.cache).toEqual({ lastSync: NOW, lastSoftSync: NOW, clearSoftNeeded: true });
+  });
+
+  it("full success: lastSync + clearSoftNeeded, NO lastSoftSync", () => {
+    const d = expectApplied(
+      decideCompletion({
+        account: account({ inFlight: inFlight({ mode: "full" }) }),
+        leaseId: "lease-1",
+        status: "success",
+        errorCode: "",
+        now: NOW,
+      }),
+    );
+    expect(d.cache).toEqual({ lastSync: NOW, clearSoftNeeded: true });
+    expect(d.cache.lastSoftSync).toBeUndefined();
+  });
+
+  it("timeout: lastSync ONLY — no clearSoftNeeded, no lastSoftSync (preserves the prior timeout cache stamp)", () => {
+    const d = expectApplied(
+      decideCompletion({
+        account: account({ inFlight: inFlight({ mode: "incremental" }) }),
+        leaseId: "lease-1",
+        status: "timeout",
+        errorCode: "",
+        now: NOW,
+      }),
+    );
+    expect(d.cache).toEqual({ lastSync: NOW });
+    expect(d.cache.clearSoftNeeded).toBeUndefined();
+    expect(d.cache.lastSoftSync).toBeUndefined();
+  });
+
+  it("failure and skipped request no cache write", () => {
+    expect(
+      expectApplied(
+        decideCompletion({
+          account: account(),
+          leaseId: "lease-1",
+          status: "failure",
+          errorCode: "",
+          now: NOW,
+        }),
+      ).cache,
+    ).toEqual({});
+    expect(
+      expectApplied(
+        decideCompletion({
+          account: account(),
+          leaseId: "lease-1",
+          status: "skipped",
+          errorCode: "",
+          now: NOW,
+        }),
+      ).cache,
+    ).toEqual({});
+  });
+});
+
+describe("SyncMode", () => {
+  it("is exactly 'full' | 'incremental' — 'quick' is gone (compile-time guard)", () => {
+    // @ts-expect-error 'quick' is no longer a member of SyncMode.
+    const reintroduced: SyncMode = "quick";
+    void reintroduced;
+    const members: SyncMode[] = ["full", "incremental"];
+    expect(members).toHaveLength(2);
+  });
+});

--- a/src/service-worker/__tests__/integration.test.ts
+++ b/src/service-worker/__tests__/integration.test.ts
@@ -272,7 +272,7 @@ describe("sync reservation → reconcile → completion → cooldown", () => {
       accountId: "12345",
       leaseId,
       trigger: "manual",
-      mode: "quick",
+      mode: "incremental",
       status: "failure",
       errorCode: "RATE_LIMITED",
     });
@@ -568,7 +568,7 @@ describe("cross-slice auth→sync→bookmarks flow", () => {
       accountId: "12345",
       leaseId: first.leaseId as string,
       trigger: "manual",
-      mode: "quick",
+      mode: "incremental",
       status: "success",
     });
 

--- a/src/service-worker/auth.ts
+++ b/src/service-worker/auth.ts
@@ -401,12 +401,7 @@ async function buildRuntimeSnapshot(
       inFlight: account?.inFlight
         ? {
             leaseId: account.inFlight.leaseId,
-            mode:
-              account.inFlight.mode === "full"
-                ? "full"
-                : account.inFlight.mode === "quick"
-                  ? "quick"
-                  : "incremental",
+            mode: account.inFlight.mode === "full" ? "full" : "incremental",
             trigger:
               account.inFlight.trigger === "manual" ? "manual" : "auto",
             startedAt: Number(account.inFlight.startedAt || 0),

--- a/src/service-worker/sync.ts
+++ b/src/service-worker/sync.ts
@@ -10,6 +10,7 @@
  */
 
 import type { MessageRequest } from "../types/messages";
+import type { SyncCompletionStatus } from "../types/sync";
 import type { HandlerMap } from "./index";
 import { getSessionSnapshot, buildRuntimeSnapshot } from "./auth";
 import { normalizeSyncAccountId } from "../lib/sw-pure";
@@ -56,7 +57,11 @@ const SYNC_ORCHESTRATOR_RATE_LIMIT_BACKOFF_MAX_MS = 15 * 60 * 1000;
 
 export interface SyncInFlight {
   leaseId: string;
-  mode: "full" | "quick" | "incremental";
+  // INVARIANT: mode and trigger are written once at reserve and are
+  // immutable for the lifetime of the lease. Completion sources them from
+  // here (the lease), never from the COMPLETE_SYNC payload — a tab cannot
+  // retroactively relabel a run it doesn't own.
+  mode: "full" | "incremental";
   trigger: "manual" | "auto";
   reason: string;
   startedAt: number;
@@ -144,12 +149,7 @@ function normalizeSyncOrchestratorState(raw: unknown): SyncOrchestratorState {
       inFlightRaw.leaseId
         ? {
             leaseId: inFlightRaw.leaseId,
-            mode:
-              inFlightRaw.mode === "full"
-                ? "full"
-                : inFlightRaw.mode === "quick"
-                  ? "quick"
-                  : "incremental",
+            mode: inFlightRaw.mode === "full" ? "full" : "incremental",
             trigger:
               inFlightRaw.trigger === "manual" ? "manual" : "auto",
             reason:
@@ -249,6 +249,114 @@ function defaultBuildRuntimeSnapshot(stateOverride: unknown) {
     null,
     defaultChromeStorage(),
   );
+}
+
+export interface SyncCompletionCacheWrite {
+  lastSync?: number;
+  lastSoftSync?: number;
+  clearSoftNeeded?: boolean;
+}
+
+export type SyncCompletionDecision =
+  | { kind: "ignored"; reason: "missing_inflight" | "lease_mismatch" }
+  | {
+      kind: "applied";
+      next: SyncAccountState;
+      mode: "full" | "incremental";
+      trigger: "manual" | "auto";
+      cache: SyncCompletionCacheWrite;
+    };
+
+/**
+ * Pure completion decision for an in-flight sync lease.
+ *
+ * Sources `mode` and `trigger` from the lease (`account.inFlight`), never
+ * from the caller — the COMPLETE_SYNC payload cannot relabel a run. Returns
+ * the next account state plus a cache-summary descriptor; the shell owns
+ * Date.now(), persistence, and the actual chrome.storage writes.
+ *
+ * The cache descriptor mirrors the legacy write contract exactly:
+ *   success     → lastSync + (incremental ? lastSoftSync) + clearSoftNeeded
+ *   timeout     → lastSync only (preserved stamp; no clear, no soft)
+ *   fail/skip   → no cache write
+ */
+export function decideCompletion(input: {
+  account: SyncAccountState | null | undefined;
+  leaseId: string;
+  status: SyncCompletionStatus;
+  errorCode: string;
+  now: number;
+}): SyncCompletionDecision {
+  const { account, leaseId, status, errorCode, now } = input;
+  if (!account || !account.inFlight)
+    return { kind: "ignored", reason: "missing_inflight" };
+  if (!leaseId || account.inFlight.leaseId !== leaseId)
+    return { kind: "ignored", reason: "lease_mismatch" };
+
+  const { mode, trigger } = account.inFlight;
+  const isRateLimited = errorCode === "RATE_LIMITED";
+  const isIncompleteFullSync = errorCode === "INCOMPLETE_FULL_SYNC";
+
+  const next: SyncAccountState = {
+    ...account,
+    inFlight: null,
+    lastCompletedAt: now,
+    lastCompletedStatus: status,
+  };
+
+  if (status === "success") {
+    next.lastSuccessAt = now;
+    if (mode === "full") {
+      next.lastFullSyncAt = now;
+    } else {
+      next.lastIncrementalSyncAt = now;
+    }
+    if (trigger === "manual") {
+      next.manualCooldownUntil =
+        now + SYNC_ORCHESTRATOR_MANUAL_SUCCESS_COOLDOWN_MS;
+    }
+    next.rateLimitConsecutive = 0;
+    next.rateLimitBackoffUntil = 0;
+    next.lastError = null;
+    next.lastFailureCode = null;
+  } else if (status !== "skipped") {
+    next.lastError = status;
+    next.lastFailureCode = errorCode || null;
+    if (trigger === "manual" && !isIncompleteFullSync) {
+      next.manualCooldownUntil = Math.max(
+        next.manualCooldownUntil,
+        now + SYNC_ORCHESTRATOR_MANUAL_FAILURE_RETRY_MS,
+      );
+    }
+    if (isRateLimited) {
+      const nextStreak = Math.max(1, next.rateLimitConsecutive + 1);
+      const backoffMs = Math.min(
+        SYNC_ORCHESTRATOR_RATE_LIMIT_BACKOFF_BASE_MS *
+          Math.pow(2, nextStreak - 1),
+        SYNC_ORCHESTRATOR_RATE_LIMIT_BACKOFF_MAX_MS,
+      );
+      next.rateLimitConsecutive = nextStreak;
+      next.rateLimitBackoffUntil = now + backoffMs;
+      next.manualCooldownUntil = Math.max(
+        next.manualCooldownUntil,
+        next.rateLimitBackoffUntil,
+      );
+    } else {
+      next.rateLimitConsecutive = 0;
+      next.rateLimitBackoffUntil = 0;
+    }
+  }
+
+  const cache: SyncCompletionCacheWrite = {};
+  if (status === "success") {
+    cache.lastSync = now;
+    cache.clearSoftNeeded = true;
+    if (mode === "incremental") cache.lastSoftSync = now;
+  } else if (status === "timeout") {
+    cache.lastSync = now;
+  }
+
+  return { kind: "applied", next, mode, trigger, cache };
 }
 
 export function createSyncHandlers(deps: SyncDeps = {}): HandlerMap {
@@ -538,106 +646,45 @@ export function createSyncHandlers(deps: SyncDeps = {}): HandlerMap {
       if (!accountKey)
         return { ok: true, ignored: true, reason: "no_account" };
 
-      const leaseId =
-        typeof msg.leaseId === "string" ? msg.leaseId : "";
-      const trigger =
-        msg.trigger === "manual" ? ("manual" as const) : ("auto" as const);
-      const mode =
-        msg.mode === "full"
-          ? ("full" as const)
-          : msg.mode === "quick"
-            ? ("quick" as const)
-            : ("incremental" as const);
-      const status =
+      const leaseId = typeof msg.leaseId === "string" ? msg.leaseId : "";
+      const status: SyncCompletionStatus =
         msg.status === "success" ||
         msg.status === "failure" ||
         msg.status === "timeout" ||
         msg.status === "skipped"
-          ? (msg.status as string)
+          ? msg.status
           : "failure";
       const errorCode =
         typeof msg.errorCode === "string" && msg.errorCode
           ? msg.errorCode.slice(0, 120)
           : "";
-      const isRateLimited = errorCode === "RATE_LIMITED";
-      const isIncompleteFullSync = errorCode === "INCOMPLETE_FULL_SYNC";
-
-      const state = await readState();
-      const account = state.accounts[accountKey];
-      if (!account || !account.inFlight) {
-        const snapshot = await buildSnapshot(state).catch(() => null);
-        if (snapshot) {
-          await persistRuntimeStateV2(snapshot).catch(() => {});
-        }
-        return { ok: true, ignored: true, reason: "missing_inflight" };
-      }
-      if (!leaseId || account.inFlight.leaseId !== leaseId) {
-        const snapshot = await buildSnapshot(state).catch(() => null);
-        if (snapshot) {
-          await persistRuntimeStateV2(snapshot).catch(() => {});
-        }
-        return { ok: true, ignored: true, reason: "lease_mismatch" };
-      }
 
       const now = Date.now();
-      const next: SyncAccountState = {
-        ...account,
-        inFlight: null,
-        lastCompletedAt: now,
-        lastCompletedStatus: status,
-      };
+      const state = await readState();
+      const decision = decideCompletion({
+        account: state.accounts[accountKey],
+        leaseId,
+        status,
+        errorCode,
+        now,
+      });
 
-      if (status === "success") {
-        next.lastSuccessAt = now;
-        if (mode === "full") {
-          next.lastFullSyncAt = now;
-        } else {
-          next.lastIncrementalSyncAt = now;
+      if (decision.kind === "ignored") {
+        const snapshot = await buildSnapshot(state).catch(() => null);
+        if (snapshot) {
+          await persistRuntimeStateV2(snapshot).catch(() => {});
         }
-        if (trigger === "manual") {
-          next.manualCooldownUntil =
-            now + SYNC_ORCHESTRATOR_MANUAL_SUCCESS_COOLDOWN_MS;
-        }
-        next.rateLimitConsecutive = 0;
-        next.rateLimitBackoffUntil = 0;
-        next.lastError = null;
-        next.lastFailureCode = null;
-      } else if (status !== "skipped") {
-        next.lastError = status;
-        next.lastFailureCode = errorCode || null;
-        if (trigger === "manual" && !isIncompleteFullSync) {
-          next.manualCooldownUntil = Math.max(
-            next.manualCooldownUntil,
-            now + SYNC_ORCHESTRATOR_MANUAL_FAILURE_RETRY_MS,
-          );
-        }
-        if (isRateLimited) {
-          const nextStreak = Math.max(
-            1,
-            next.rateLimitConsecutive + 1,
-          );
-          const backoffMs = Math.min(
-            SYNC_ORCHESTRATOR_RATE_LIMIT_BACKOFF_BASE_MS *
-              Math.pow(2, nextStreak - 1),
-            SYNC_ORCHESTRATOR_RATE_LIMIT_BACKOFF_MAX_MS,
-          );
-          next.rateLimitConsecutive = nextStreak;
-          next.rateLimitBackoffUntil = now + backoffMs;
-          next.manualCooldownUntil = Math.max(
-            next.manualCooldownUntil,
-            next.rateLimitBackoffUntil,
-          );
-        } else {
-          next.rateLimitConsecutive = 0;
-          next.rateLimitBackoffUntil = 0;
-        }
+        return { ok: true, ignored: true, reason: decision.reason };
       }
 
+      const { next, mode, trigger, cache } = decision;
       state.accounts[accountKey] = next;
       await writeState(state);
 
       // [TOTEM-DIAG] Complete — answers: "did the previous run stamp
       // lastFullSyncAt, which would push the next refresh to incremental?"
+      // mode/trigger are lease-sourced, so this reflects the reserved run,
+      // not whatever the completing tab claimed in its payload.
       console.debug("[TOTEM-DIAG] sync.complete", {
         trigger,
         mode,
@@ -654,15 +701,16 @@ export function createSyncHandlers(deps: SyncDeps = {}): HandlerMap {
       const cacheStorage = defaultChromeStorage();
       if (cacheStorage) {
         try {
-          if (status === "success") {
-            const cacheWrite: Record<string, number> = { [CS_LAST_SYNC]: now };
-            if (mode === "incremental") {
-              cacheWrite[CS_LAST_SOFT_SYNC] = now;
-            }
+          const cacheWrite: Record<string, number> = {};
+          if (cache.lastSync !== undefined)
+            cacheWrite[CS_LAST_SYNC] = cache.lastSync;
+          if (cache.lastSoftSync !== undefined)
+            cacheWrite[CS_LAST_SOFT_SYNC] = cache.lastSoftSync;
+          if (Object.keys(cacheWrite).length > 0) {
             await cacheStorage.set(cacheWrite);
+          }
+          if (cache.clearSoftNeeded) {
             await cacheStorage.remove(CS_SOFT_SYNC_NEEDED);
-          } else if (status === "timeout") {
-            await cacheStorage.set({ [CS_LAST_SYNC]: now });
           }
         } catch (err) {
           // Non-fatal: orchestrator state is already persisted, and the

--- a/src/stores/__tests__/runtime-store.test.ts
+++ b/src/stores/__tests__/runtime-store.test.ts
@@ -722,7 +722,7 @@ describe("runtime-store auth flows", () => {
     // Allow sync but make fetchBookmarkPage throw NO_AUTH
     mocks.reserveSyncRun.mockResolvedValue({
       allow: true,
-      mode: "quick",
+      mode: "incremental",
       reason: "manual",
       leaseId: "lease-auth-err",
       accountKey: "acct-1",
@@ -760,7 +760,7 @@ describe("runtime-store auth flows", () => {
     // First sync: allow but fail with network error
     mocks.reserveSyncRun.mockResolvedValue({
       allow: true,
-      mode: "quick",
+      mode: "incremental",
       reason: "manual",
       leaseId: "lease-err-1",
       accountKey: "acct-1",
@@ -773,7 +773,7 @@ describe("runtime-store auth flows", () => {
     // Retry: allow sync with successful fetch
     mocks.reserveSyncRun.mockResolvedValue({
       allow: true,
-      mode: "quick",
+      mode: "incremental",
       reason: "manual",
       leaseId: "lease-ok-2",
       accountKey: "acct-1",

--- a/src/stores/runtime-store.ts
+++ b/src/stores/runtime-store.ts
@@ -42,8 +42,6 @@ import {
   SYNC_ABORT_TIMEOUT_INCREMENTAL_MS,
   SYNC_ABORT_TIMEOUT_MAX_MS,
   SYNC_ABORT_TIMEOUT_PER_1K_MS,
-  SYNC_MAX_BOOKMARKS_PER_JOB,
-  SYNC_MAX_PAGES_PER_JOB,
 } from "../lib/constants/sync-policy";
 import { CS_DB_CLEANUP_AT } from "../lib/storage-keys";
 import type {
@@ -932,10 +930,7 @@ export function createRuntimeStore() {
       };
 
       try {
-        const firstPass = await runReconcilePass({
-          maxPages: mode === "quick" ? SYNC_MAX_PAGES_PER_JOB : undefined,
-          maxBookmarks: mode === "quick" ? SYNC_MAX_BOOKMARKS_PER_JOB : undefined,
-        });
+        const firstPass = await runReconcilePass({});
 
         let reconcileResult = firstPass;
         if (

--- a/src/types/sync.ts
+++ b/src/types/sync.ts
@@ -5,7 +5,7 @@
 
 export type SyncTrigger = "auto" | "manual";
 export type SyncCompletionStatus = "success" | "failure" | "timeout" | "skipped";
-export type SyncMode = "full" | "incremental" | "quick";
+export type SyncMode = "full" | "incremental";
 
 export type SyncBlockedReason =
   | "in_flight"


### PR DESCRIPTION
## What

Extracts a pure `decideCompletion({ account, leaseId, status, errorCode, now })` from the service worker's `handleSyncPolicyComplete`, and sources the completion's `mode` and `trigger` from the **reserved lease** (`account.inFlight`) rather than the `COMPLETE_SYNC` message payload. Also removes the dead `"quick"` `SyncMode` member and the now-unreachable `SYNC_MAX_PAGES_PER_JOB` / `SYNC_MAX_BOOKMARKS_PER_JOB` constants.

## Why

`handleSyncPolicyComplete` mixed three concerns inline: the next-state machine, the cache-summary mirror writes, and the orchestration shell (read → write → snapshot). The state machine had no test surface of its own — bugs hid in how it was *called*. Pulling it behind a small pure interface makes the completion decision the test surface: `decideCompletion` returns `{ next, mode, trigger, cache }`, and the shell keeps `Date.now()`, persistence, and the actual `chrome.storage` writes.

## Behavior — note on the payload→lease shift

**Behavior-preserving for every honest client.** The reserve handler writes the same `mode`/`trigger` into the lease that it returns to the client; both `completeSyncRun` senders echo the lease's values verbatim (`runtime-store.ts:443`, `:837`), and the client never requests a mode — so `msg.mode === inFlight.mode` and `msg.trigger === inFlight.trigger` always hold.

The change is observable **only** for a spoofing or buggy tab that sends a `mode`/`trigger` differing from the lease it owns (e.g. claiming `full` on an incremental lease to stamp `lastFullSyncAt`, or `manual` to alter the cooldown). Such a tab can no longer relabel a run it doesn't own. This is intentional integrity hardening, not a regression.

The `"quick"` removal is pure dead-code deletion: the reserve state machine only ever emitted `full`/`incremental`, so no released version could persist a `quick` lease; the `runReconcilePass` cap ternary always resolved to `undefined` (≡ the new `{}`); and the old code already treated `quick` as `incremental` for stamps and cache writes.

## Cache-write contract (preserved exactly)

| status | storage writes |
| --- | --- |
| success (incremental) | set `lastSync` + `lastSoftSync`, then remove `softSyncNeeded` |
| success (full) | set `lastSync`, then remove `softSyncNeeded` |
| timeout | set `lastSync` only |
| failure / skipped | none |

## Tests

- New `decide-completion.test.ts` (13 cases): lease-identity guards, lease-owned mode/trigger, `RATE_LIMITED` backoff math, the full cache descriptor per status, and a compile-time `@ts-expect-error` guard proving `"quick"` is gone from `SyncMode`.
- `tsc --noEmit` clean; full suite 652 green.

## Verification

Adversarially verified for behavioral equivalence across three independent lenses (next-state, side-effects/cache, payload-vs-lease) plus a judge: no real-client divergence, byte-identical `next` state and storage calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
