### PR TITLE
refactor(reader): extract pure shouldFetchExternalDetail + selectReaderDisplayBookmark seams

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,11 @@ import {
   isReaderRoute,
   type ReturnSurface,
 } from "./lib/reader-navigation";
-import { resolveReaderRouteBookmarks } from "./lib/reader-route";
+import {
+  resolveReaderRouteBookmarks,
+  selectReaderDisplayBookmark,
+  shouldFetchExternalDetail,
+} from "./lib/reader-route";
 import type { ReadingTab } from "./lib/reading-list";
 import { LS_READING_TAB } from "./lib/storage-keys";
 import { NewTabHome } from "./components/NewTabHome";
@@ -776,8 +780,11 @@ function ReaderRouteApp() {
     [allBookmarks, displayBookmarks, readTweetId],
   );
 
-  const fetchExternalDetail =
-    Boolean(readTweetId) && !localBookmark && !hiddenBookmark;
+  const fetchExternalDetail = shouldFetchExternalDetail({
+    tweetId: readTweetId,
+    localBookmark,
+    hiddenBookmark,
+  });
   const { state: readerDetail, refetch: refetchReaderDetail } = useReaderDetail(
     fetchExternalDetail ? readTweetId : null,
   );
@@ -822,16 +829,27 @@ function ReaderRouteApp() {
     }
   }, [localBookmark?.tweetId]); // eslint-disable-line react-hooks/exhaustive-deps -- sync snapshot when ID changes, not on every bookmark object update
 
-  const externalBookmark = useMemo(() => {
-    if (readerDetail.status !== "success") return null;
-    if (externalUnbookmarkedTweetId === readerDetail.tweetId) {
-      return { ...readerDetail.data.focalTweet, bookmarked: false };
-    }
-    return readerDetail.data.focalTweet;
-  }, [readerDetail, externalUnbookmarkedTweetId]);
-
-  const displayBookmark =
-    localBookmark || localBookmarkSnapshot || externalBookmark;
+  const displayBookmark = useMemo(
+    () =>
+      selectReaderDisplayBookmark({
+        localBookmark,
+        localBookmarkSnapshot,
+        externalDetail:
+          readerDetail.status === "success"
+            ? {
+                tweetId: readerDetail.tweetId,
+                focalTweet: readerDetail.data.focalTweet,
+              }
+            : null,
+        externalUnbookmarkedTweetId,
+      }),
+    [
+      localBookmark,
+      localBookmarkSnapshot,
+      readerDetail,
+      externalUnbookmarkedTweetId,
+    ],
+  );
 
   const relatedBookmarks = useMemo(
     () => pickRelatedBookmarks(displayBookmark, displayBookmarks, 3, shuffleSeed > 0),

--- a/src/lib/__tests__/reader-route.test.ts
+++ b/src/lib/__tests__/reader-route.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
-import { resolveReaderRouteBookmarks } from "../reader-route";
+import {
+  resolveReaderRouteBookmarks,
+  selectReaderDisplayBookmark,
+  shouldFetchExternalDetail,
+} from "../reader-route";
 import type { Bookmark } from "../../types";
 
-function makeBookmark(tweetId: string): Bookmark {
+function makeBookmark(
+  tweetId: string,
+  overrides: Partial<Bookmark> = {},
+): Bookmark {
   return {
     id: `bookmark-${tweetId}`,
     tweetId,
@@ -30,13 +37,14 @@ function makeBookmark(tweetId: string): Bookmark {
     hasVideo: false,
     hasLink: false,
     quotedTweet: null,
+    ...overrides,
   };
 }
 
 describe("resolveReaderRouteBookmarks", () => {
   it("keeps prev and next inside the readable bookmark set", () => {
-    const allBookmarks = ["1", "2", "3", "4"].map(makeBookmark);
-    const readableBookmarks = ["1", "3", "4"].map(makeBookmark);
+    const allBookmarks = ["1", "2", "3", "4"].map((id) => makeBookmark(id));
+    const readableBookmarks = ["1", "3", "4"].map((id) => makeBookmark(id));
 
     expect(
       resolveReaderRouteBookmarks("3", readableBookmarks, allBookmarks),
@@ -49,8 +57,8 @@ describe("resolveReaderRouteBookmarks", () => {
   });
 
   it("treats non-readable local bookmarks as hidden", () => {
-    const allBookmarks = ["1", "2", "3"].map(makeBookmark);
-    const readableBookmarks = ["1", "3"].map(makeBookmark);
+    const allBookmarks = ["1", "2", "3"].map((id) => makeBookmark(id));
+    const readableBookmarks = ["1", "3"].map((id) => makeBookmark(id));
 
     expect(
       resolveReaderRouteBookmarks("2", readableBookmarks, allBookmarks),
@@ -60,5 +68,145 @@ describe("resolveReaderRouteBookmarks", () => {
       prevBookmark: null,
       nextBookmark: null,
     });
+  });
+});
+
+describe("shouldFetchExternalDetail", () => {
+  it("fetches when a tweetId has no local or hidden bookmark", () => {
+    expect(
+      shouldFetchExternalDetail({
+        tweetId: "1",
+        localBookmark: null,
+        hiddenBookmark: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("stays idle without a tweetId", () => {
+    expect(
+      shouldFetchExternalDetail({
+        tweetId: null,
+        localBookmark: null,
+        hiddenBookmark: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("does not fetch when a local or hidden bookmark already exists", () => {
+    expect(
+      shouldFetchExternalDetail({
+        tweetId: "1",
+        localBookmark: makeBookmark("1"),
+        hiddenBookmark: null,
+      }),
+    ).toBe(false);
+    expect(
+      shouldFetchExternalDetail({
+        tweetId: "1",
+        localBookmark: null,
+        hiddenBookmark: makeBookmark("1"),
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores the bookmarked flag — un-bookmarking a local row never retriggers a fetch", () => {
+    const base = { tweetId: "1", hiddenBookmark: null } as const;
+    const bookmarked = shouldFetchExternalDetail({
+      ...base,
+      localBookmark: makeBookmark("1", { bookmarked: true }),
+    });
+    const unbookmarked = shouldFetchExternalDetail({
+      ...base,
+      localBookmark: makeBookmark("1", { bookmarked: false }),
+    });
+    expect(bookmarked).toBe(false);
+    expect(unbookmarked).toBe(false);
+    expect(unbookmarked).toBe(bookmarked);
+  });
+});
+
+describe("selectReaderDisplayBookmark", () => {
+  const external = (tweetId: string, overrides: Partial<Bookmark> = {}) => ({
+    tweetId,
+    focalTweet: makeBookmark(tweetId, overrides),
+  });
+
+  it("prefers the live local row over snapshot and external", () => {
+    const result = selectReaderDisplayBookmark({
+      localBookmark: makeBookmark("1", { text: "local" }),
+      localBookmarkSnapshot: makeBookmark("1", { text: "snapshot" }),
+      externalDetail: external("1", { text: "external" }),
+      externalUnbookmarkedTweetId: null,
+    });
+    expect(result?.text).toBe("local");
+  });
+
+  it("falls back to the snapshot when there is no live local row", () => {
+    const result = selectReaderDisplayBookmark({
+      localBookmark: null,
+      localBookmarkSnapshot: makeBookmark("1", { text: "snapshot" }),
+      externalDetail: external("1", { text: "external" }),
+      externalUnbookmarkedTweetId: null,
+    });
+    expect(result?.text).toBe("snapshot");
+  });
+
+  it("uses external detail when no local row or snapshot exists", () => {
+    const detail = external("1");
+    const result = selectReaderDisplayBookmark({
+      localBookmark: null,
+      localBookmarkSnapshot: null,
+      externalDetail: detail,
+      externalUnbookmarkedTweetId: null,
+    });
+    expect(result).toBe(detail.focalTweet);
+  });
+
+  it("returns null when nothing is available", () => {
+    expect(
+      selectReaderDisplayBookmark({
+        localBookmark: null,
+        localBookmarkSnapshot: null,
+        externalDetail: null,
+        externalUnbookmarkedTweetId: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("overlays bookmarked:false on the external copy when its id was un-bookmarked", () => {
+    const detail = external("1", { bookmarked: true });
+    const result = selectReaderDisplayBookmark({
+      localBookmark: null,
+      localBookmarkSnapshot: null,
+      externalDetail: detail,
+      externalUnbookmarkedTweetId: "1",
+    });
+    expect(result).toMatchObject({ tweetId: "1", bookmarked: false });
+    // overlay is applied in place, not by mutating the fetched copy
+    expect(result).not.toBe(detail.focalTweet);
+    expect(detail.focalTweet.bookmarked).toBe(true);
+  });
+
+  it("does not overlay when the un-bookmarked id is a different tweet", () => {
+    const detail = external("1", { bookmarked: true });
+    const result = selectReaderDisplayBookmark({
+      localBookmark: null,
+      localBookmarkSnapshot: null,
+      externalDetail: detail,
+      externalUnbookmarkedTweetId: "2",
+    });
+    expect(result).toBe(detail.focalTweet);
+  });
+
+  it("never overlays the local branch — the overlay is external-only", () => {
+    const local = makeBookmark("1", { bookmarked: true });
+    const result = selectReaderDisplayBookmark({
+      localBookmark: local,
+      localBookmarkSnapshot: null,
+      externalDetail: null,
+      externalUnbookmarkedTweetId: "1",
+    });
+    expect(result).toBe(local);
+    expect(result?.bookmarked).toBe(true);
   });
 });

--- a/src/lib/reader-route.ts
+++ b/src/lib/reader-route.ts
@@ -41,3 +41,58 @@ export function resolveReaderRouteBookmarks(
         : null,
   };
 }
+
+/**
+ * Whether the reader route must fetch a tweet's detail from the network.
+ *
+ * Gated purely on the *existence* of a usable local row — a real tweetId with
+ * no local or hidden bookmark. It deliberately does NOT look at the bookmark's
+ * `bookmarked` flag: un-bookmarking an item must not retrigger a detail fetch.
+ * That state is applied as an overlay on already-fetched data (see
+ * `selectReaderDisplayBookmark`), so `bookmarked` never belongs in the fetch
+ * effect's dependency set.
+ */
+export function shouldFetchExternalDetail(input: {
+  tweetId: string | null;
+  localBookmark: Bookmark | null;
+  hiddenBookmark: Bookmark | null;
+}): boolean {
+  return (
+    Boolean(input.tweetId) && !input.localBookmark && !input.hiddenBookmark
+  );
+}
+
+export interface ReaderExternalDetail {
+  tweetId: string;
+  focalTweet: Bookmark;
+}
+
+/**
+ * The bookmark the reader route should display, by precedence:
+ * live local row → its last snapshot → externally-fetched detail.
+ *
+ * The un-bookmark overlay applies only to the external branch: when the user
+ * removes a bookmark we don't own a local row for, we mark the fetched copy
+ * `bookmarked: false` in place rather than refetching. Local rows carry their
+ * own `bookmarked` state through the store, so they need no overlay.
+ */
+export function selectReaderDisplayBookmark(input: {
+  localBookmark: Bookmark | null;
+  localBookmarkSnapshot: Bookmark | null;
+  externalDetail: ReaderExternalDetail | null;
+  externalUnbookmarkedTweetId: string | null;
+}): Bookmark | null {
+  const {
+    localBookmark,
+    localBookmarkSnapshot,
+    externalDetail,
+    externalUnbookmarkedTweetId,
+  } = input;
+  if (localBookmark) return localBookmark;
+  if (localBookmarkSnapshot) return localBookmarkSnapshot;
+  if (!externalDetail) return null;
+  if (externalUnbookmarkedTweetId === externalDetail.tweetId) {
+    return { ...externalDetail.focalTweet, bookmarked: false };
+  }
+  return externalDetail.focalTweet;
+}


### PR DESCRIPTION
## What

Extracts two pure functions into `src/lib/reader-route.ts` and rewires the reader route in `App.tsx` to use them:

- `shouldFetchExternalDetail({ tweetId, localBookmark, hiddenBookmark })` — the gate that decides whether the reader must fetch a tweet's detail from the network.
- `selectReaderDisplayBookmark({ localBookmark, localBookmarkSnapshot, externalDetail, externalUnbookmarkedTweetId })` — the `local → snapshot → external` display precedence plus the un-bookmark overlay.

This replaces an inline `externalBookmark` `useMemo`, a `localBookmark || localBookmarkSnapshot || externalBookmark` expression, and an inline `fetchExternalDetail` boolean — none of which had a test surface inside the 1000-line `App.tsx`.

## Why

The reader route's "which bookmark do we show, and is it un-bookmarked?" decision carried a subtle business rule — local row beats its snapshot beats externally-fetched detail, and the un-bookmark overlay applies **only** to the external branch — with no test guarding it. Pulling it behind a small pure interface makes that rule the test surface.

## Fix-first invariant: `bookmarked` stays out of the fetch path

The fetch gate is keyed purely on the **existence** of a usable local row, never on its `bookmarked` flag. Un-bookmarking an item must not retrigger a detail fetch: that state flows through `externalUnbookmarkedTweetId` as an **overlay on already-fetched data** (`{ ...focalTweet, bookmarked: false }`), applied in place. `shouldFetchExternalDetail` is therefore deliberately `bookmarked`-agnostic, and `useReaderDetail`'s effect deps are unchanged. A dedicated test asserts toggling `bookmarked` on a local row never flips the fetch decision.

No change to the `not_found` / error rendering path (`ExternalReaderShell`, `detail-error.ts`, `reader-error-view.ts`) — those seams already exist and are untouched.

## Behavior

Behavior-preserving. `selectReaderDisplayBookmark` reproduces the old `||` chain exactly (all three sources are `… | null`, so `||` short-circuit ≡ `if (x) return x`), and the overlay applies only on the external branch when the un-bookmarked id matches. `displayBookmark` is now a `useMemo` keyed on all of its inputs — strictly more referentially stable than the old per-render expression, so no downstream regression.

## Tests

`reader-route.test.ts` gains 11 cases: fetch-gate truth table incl. the `bookmarked`-independence invariant; display precedence (local > snapshot > external); the in-place (non-mutating) external overlay; id-mismatch no-overlay; and the local-branch-never-overlaid rule.

`tsc --noEmit` clean; full suite 650 green.

## Verification

Adversarially reviewed for behavioral equivalence (value + memo-identity of `displayBookmark`, fetch-gate equality, fix-first `bookmarked`-out-of-fetch-deps, not_found untouched): EQUIVALENT, no real user path diverges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
