### PR TITLE
Deep-review follow-ups: #61–#64 (synced-preference + Today's Read tests + polish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@vitejs/plugin-react": "^4.7.0",
     "fake-indexeddb": "^6.2.5",
     "fflate": "^0.8.2",
+    "jsdom": "29.1.1",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       fflate:
         specifier: ^0.8.2
         version: 0.8.2
+      jsdom:
+        specifier: 29.1.1
+        version: 29.1.1(@noble/hashes@2.2.0)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
@@ -94,7 +97,7 @@ importers:
         version: 6.4.3(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.3)
+        version: 4.0.18(@types/node@24.12.2)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(yaml@2.8.3)
 
   apps/site:
     dependencies:
@@ -140,6 +143,21 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    resolution: {integrity: sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@astrojs/check@0.9.9':
     resolution: {integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==}
@@ -302,6 +320,10 @@ packages:
       '@types/react':
         optional: true
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
@@ -313,6 +335,42 @@ packages:
   '@clack/prompts@1.6.0':
     resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
     engines: {node: '>= 20.12.0'}
+
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.8':
+    resolution: {integrity: sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5':
+    resolution: {integrity: sha512-oNjBvzLq2GPZtJphCjLqXow/cHySHSgtxvKZb7OqSZ/xHgw6NWNhfad+6AB9cLeVm6eA9d/qMll3JdEHjy6M+A==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emmetio/abbreviation@2.3.3':
     resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
@@ -649,6 +707,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.4':
     resolution: {integrity: sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==}
@@ -1305,6 +1372,9 @@ packages:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1413,6 +1483,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1421,6 +1495,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1490,6 +1567,10 @@ packages:
   entities@7.0.1:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -1632,6 +1713,10 @@ packages:
   html-dom-parser@5.1.8:
     resolution: {integrity: sha512-MCIUng//mF2qTtGHXJWr6OLfHWmg3Pm8ezpfiltF83tizPWY17JxT4dRLE8lykJ5bChJELoY3onQKPbufJHxYA==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
@@ -1685,6 +1770,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
@@ -1699,6 +1787,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.1.1:
+    resolution: {integrity: sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -2018,6 +2115,9 @@ packages:
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -2053,6 +2153,10 @@ packages:
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
@@ -2169,6 +2273,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -2245,6 +2353,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
@@ -2291,6 +2402,21 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.4:
+    resolution: {integrity: sha512-vwVLJVvvpslm7vqAH7+XNj/neA/Ynq7DT2EEcMuwc5YzN5XaMyRAqxwU+uX3azZ1FQtB2gvrvnLnAEkvYlVdfg==}
+
+  tldts@7.4.4:
+    resolution: {integrity: sha512-kFXFK7O4WPextIUAOk8qtnw9dxR9UIXP9CjuH1cTBVBZMDeQcUPgr/IazGiw1B0Yiw5L75gHLWeW4iD793r90g==}
+    hasBin: true
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
@@ -2322,6 +2448,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -2655,8 +2785,24 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -2670,6 +2816,13 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -2736,6 +2889,26 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.1':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
@@ -2995,6 +3168,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@capsizecss/unpack@4.0.0':
     dependencies:
       fontkitten: 1.0.3
@@ -3010,6 +3187,30 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@csstools/color-helpers@6.0.2': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.5(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emmetio/abbreviation@2.3.3':
     dependencies:
@@ -3194,6 +3395,10 @@ snapshots:
 
   '@esbuild/win32-x64@0.27.7':
     optional: true
+
+  '@exodus/bytes@1.15.1(@noble/hashes@2.2.0)':
+    optionalDependencies:
+      '@noble/hashes': 2.2.0
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -3881,6 +4086,10 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
   boolbase@1.0.0: {}
 
   browserslist@4.28.1:
@@ -3973,9 +4182,18 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-urls@7.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -4036,6 +4254,8 @@ snapshots:
   entities@6.0.1: {}
 
   entities@7.0.1: {}
+
+  entities@8.0.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -4266,6 +4486,12 @@ snapshots:
       domhandler: 5.0.3
       htmlparser2: 10.1.0
 
+  html-encoding-sniffer@6.0.0(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@3.0.3: {}
 
   html-react-parser@5.2.17(@types/react@19.2.14)(react@19.2.4):
@@ -4307,6 +4533,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
@@ -4318,6 +4546,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.1.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.1
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.5(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      css-tree: 3.2.1
+      data-urls: 7.0.0(@noble/hashes@2.2.0)
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0(@noble/hashes@2.2.0)
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.28.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1(@noble/hashes@2.2.0)
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -4787,6 +5041,10 @@ snapshots:
     dependencies:
       entities: 6.0.1
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-browserify@1.0.1: {}
 
   pathe@2.0.3: {}
@@ -4813,6 +5071,8 @@ snapshots:
   prismjs@1.30.0: {}
 
   property-information@7.1.0: {}
+
+  punycode@2.3.1: {}
 
   radix3@1.1.2: {}
 
@@ -4984,6 +5244,10 @@ snapshots:
 
   sax@1.6.0: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -5091,6 +5355,8 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  symbol-tree@3.2.4: {}
+
   tabbable@6.4.0: {}
 
   tailwind-merge@3.5.0: {}
@@ -5123,6 +5389,20 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@7.4.4: {}
+
+  tldts@7.4.4:
+    dependencies:
+      tldts-core: 7.4.4
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.4.4
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
@@ -5145,6 +5425,8 @@ snapshots:
   uncrypto@0.1.3: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.28.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -5276,7 +5558,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.5(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.3)
 
-  vitest@4.0.18(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.3):
+  vitest@4.0.18(@types/node@24.12.2)(jiti@2.7.0)(jsdom@29.1.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.18
       '@vitest/mocker': 4.0.18(vite@6.4.3(@types/node@24.12.2)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.3))
@@ -5300,6 +5582,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
+      jsdom: 29.1.1(@noble/hashes@2.2.0)
     transitivePeerDependencies:
       - jiti
       - less
@@ -5410,7 +5693,23 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1(@noble/hashes@2.2.0):
+    dependencies:
+      '@exodus/bytes': 1.15.1(@noble/hashes@2.2.0)
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which-pm-runs@1.1.0: {}
 
@@ -5424,6 +5723,10 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
 

--- a/src/components/BookmarksList.tsx
+++ b/src/components/BookmarksList.tsx
@@ -41,6 +41,7 @@ import {
   TODAY_QUEUE_DONE_TITLE,
   TODAY_QUEUE_TWO_MORE_EXHAUSTED,
   TODAY_QUEUE_TWO_MORE_LABEL,
+  TODAY_QUEUE_TWO_MORE_PENDING,
 } from "../lib/constants/ui";
 import {
   getPinnedTweetIds,
@@ -915,9 +916,13 @@ function useBookmarksListModel({
               <Button
                 variant="ghost"
                 onClick={handleAddTwoMore}
+                disabled={todayQueue?.isAddingMore}
+                aria-busy={todayQueue?.isAddingMore}
                 className="mt-5"
               >
-                {TODAY_QUEUE_TWO_MORE_LABEL}
+                {todayQueue?.isAddingMore
+                  ? TODAY_QUEUE_TWO_MORE_PENDING
+                  : TODAY_QUEUE_TWO_MORE_LABEL}
               </Button>
             ) : (
               <p className="mt-5 text-sm text-subtle/80">

--- a/src/components/NewTabHome.tsx
+++ b/src/components/NewTabHome.tsx
@@ -47,6 +47,7 @@ import {
   TODAY_QUEUE_DONE_TITLE,
   TODAY_QUEUE_TWO_MORE_EXHAUSTED,
   TODAY_QUEUE_TWO_MORE_LABEL,
+  TODAY_QUEUE_TWO_MORE_PENDING,
 } from "../lib/constants/ui";
 import {
   getTodayQueueProgress,
@@ -203,6 +204,7 @@ interface FooterCardProps {
   onOpenReading: (tab?: ReadingTab) => void;
   todayQueueDone: boolean;
   todayQueueCanAddMore: boolean;
+  todayQueueAddingMore: boolean;
   onAddTwoMore: () => void;
   todayQueueProgress: TodayQueueProgress | null;
   syncButton: SyncButtonState;
@@ -230,6 +232,7 @@ function FooterCard({
   onOpenReading,
   todayQueueDone,
   todayQueueCanAddMore,
+  todayQueueAddingMore,
   onAddTwoMore,
   todayQueueProgress,
   syncButton,
@@ -580,9 +583,13 @@ function FooterCard({
                 <Button
                   type="button"
                   onClick={onAddTwoMore}
+                  disabled={todayQueueAddingMore}
+                  aria-busy={todayQueueAddingMore}
                   className="border border-home-empty/25 bg-transparent text-home-fg-secondary hover:bg-white/5"
                 >
-                  {TODAY_QUEUE_TWO_MORE_LABEL}
+                  {todayQueueAddingMore
+                    ? TODAY_QUEUE_TWO_MORE_PENDING
+                    : TODAY_QUEUE_TWO_MORE_LABEL}
                 </Button>
               ) : (
                 <p className="text-sm text-home-empty/80">
@@ -858,6 +865,7 @@ function useNewTabHomeModel({
     recommendationSource === "today" && Boolean(todayQueue?.isDone);
   const todayQueueCanAddMore =
     todayQueueDone && Boolean(todayQueue?.canAddMore);
+  const todayQueueAddingMore = Boolean(todayQueue?.isAddingMore);
   const todayQueueProgress =
     recommendationSource === "today" ? getTodayQueueProgress(todayQueue) : null;
   const runtimeFooterState = useFooterState(
@@ -1091,6 +1099,7 @@ function useNewTabHomeModel({
     syncButton,
     todayQueueDone,
     todayQueueCanAddMore,
+    todayQueueAddingMore,
     onAddTwoMore: handleAddTwoMore,
     todayQueueProgress,
     topSites,
@@ -1149,6 +1158,7 @@ function renderNewTabHome({
   syncButton,
   todayQueueDone,
   todayQueueCanAddMore,
+  todayQueueAddingMore,
   onAddTwoMore,
   todayQueueProgress,
   topSites,
@@ -1359,6 +1369,7 @@ function renderNewTabHome({
                 onOpenReading={onOpenReading}
                 todayQueueDone={todayQueueDone}
                 todayQueueCanAddMore={todayQueueCanAddMore}
+                todayQueueAddingMore={todayQueueAddingMore}
                 onAddTwoMore={onAddTwoMore}
                 todayQueueProgress={todayQueueProgress}
                 syncButton={syncButton}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1046,15 +1046,22 @@ export async function getAllTodayQueueSnapshots(
 
 // Thin shell around the pure stale-key decision: drop any daily-set record left
 // behind by an earlier scoring version (including imported older-version
-// records). Safe to call with no records — it simply deletes nothing.
+// records). All stale keys are removed in a single readwrite transaction so the
+// sweep is one commit and one reader-activity emit, not one per key. Safe to
+// call with no records — it simply deletes nothing.
 export async function sweepStaleTodayQueueSnapshots(
   dbName: string = activeDbName,
 ): Promise<void> {
-  const records = await getAllTodayQueueSnapshots(dbName);
+  const db = await getDb(dbName);
+  const records = await db.getAll(TODAY_QUEUE_SNAPSHOTS_STORE_NAME);
   const staleKeys = selectStaleTodayQueueSnapshotKeys(records);
+  if (staleKeys.length === 0) return;
+  const tx = db.transaction(TODAY_QUEUE_SNAPSHOTS_STORE_NAME, "readwrite");
   for (const key of staleKeys) {
-    await deleteTodayQueueSnapshot(key, dbName);
+    if (key) tx.store.delete(key);
   }
+  await tx.done;
+  emitReaderActivity();
 }
 
 export async function getAllTodayQueueExposures(

--- a/src/hooks/__tests__/useSyncedPreference.test.ts
+++ b/src/hooks/__tests__/useSyncedPreference.test.ts
@@ -68,6 +68,26 @@ describe("useSyncedPreference", () => {
     expect(setSpy).not.toHaveBeenCalled();
   });
 
+  it("fires storage.sync.set exactly once per set, even under StrictMode", async () => {
+    const setSpy = vi.spyOn(fakeChrome.storage.sync, "set");
+    const { result } = await renderHook(
+      () => useSyncedPreference(KEY, normalize, "default"),
+      { strictMode: true },
+    );
+    await flushAsync();
+    setSpy.mockClear();
+
+    await act(async () => {
+      result.current[1]("chosen");
+    });
+    await flushAsync();
+
+    // The write lives outside the setState updater, so StrictMode's double
+    // invoke of the updater can't persist twice.
+    expect(setSpy).toHaveBeenCalledTimes(1);
+    expect(result.current[0]).toBe("chosen");
+  });
+
   it("drops the initial load when the hook unmounts before it resolves", async () => {
     const normalizeSpy = vi.fn(normalize);
     const resolveGet = deferGet();
@@ -116,23 +136,41 @@ describe("useSyncedPreference", () => {
   });
 
   it("ignores a sync change for a different key", async () => {
+    // Start from a non-default value so a spurious update would be observable:
+    // softening the changes[key] guard to change?.newValue would normalize
+    // undefined back to "default" and flip this.
+    await fakeChrome.storage.sync.set({ [KEY]: "real-value" });
+    const normalizeSpy = vi.fn(normalize);
     const { result } = await renderHook(() =>
-      useSyncedPreference(KEY, normalize, "default"),
+      useSyncedPreference(KEY, normalizeSpy, "default"),
     );
     await flushAsync();
+    expect(result.current[0]).toBe("real-value");
+    normalizeSpy.mockClear();
 
     await act(async () => {
       await fakeChrome.storage.sync.set({ "totem:other-pref": "unrelated" });
     });
     await flushAsync();
 
-    expect(result.current[0]).toBe("default");
+    expect(normalizeSpy).not.toHaveBeenCalled();
+    expect(result.current[0]).toBe("real-value");
   });
 
-  it("swallows a rejected storage.sync.set and keeps the optimistic value", async () => {
-    fakeChrome.storage.sync.set = vi
-      .fn()
-      .mockRejectedValue(new Error("quota exceeded"));
+  it("attaches a catch to a rejected storage.sync.set so it never leaks", async () => {
+    // Deterministic alternative to watching for an unhandled rejection (which
+    // surfaces non-deterministically): assert setSyncedValue actually attaches a
+    // rejection handler to the promise it gets back from set().
+    let catchHandlers = 0;
+    fakeChrome.storage.sync.set = vi.fn(() => {
+      const rejected = Promise.reject(new Error("quota exceeded"));
+      const realCatch = rejected.catch.bind(rejected);
+      rejected.catch = ((onRejected?: (reason: unknown) => unknown) => {
+        catchHandlers += 1;
+        return realCatch(onRejected);
+      }) as typeof rejected.catch;
+      return rejected;
+    });
 
     const { result } = await renderHook(() =>
       useSyncedPreference(KEY, normalize, "default"),
@@ -148,6 +186,7 @@ describe("useSyncedPreference", () => {
     expect(fakeChrome.storage.sync.set).toHaveBeenCalledWith({
       [KEY]: "optimistic",
     });
+    expect(catchHandlers).toBeGreaterThan(0);
   });
 
   it("is a no-op writer when storage.sync is unavailable", async () => {

--- a/src/hooks/__tests__/useSyncedPreference.test.ts
+++ b/src/hooks/__tests__/useSyncedPreference.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createFakeChrome, type FakeChrome } from "../../test-utils/fake-chrome";
+import { act, flushAsync, renderHook } from "../../test-utils/render-hook";
+import { hasChromeStorageSync } from "../../lib/chrome";
+import { SYNC_SETTINGS, SYNC_THEME } from "../../lib/storage-keys";
+import { useSyncedPreference } from "../useSyncedPreference";
+import { useSettings } from "../useSettings";
+import { useTheme } from "../useTheme";
+
+const KEY = "totem:test-pref";
+
+const normalize = (raw: unknown): string =>
+  typeof raw === "string" ? raw : "default";
+
+let fakeChrome: FakeChrome;
+
+beforeEach(() => {
+  fakeChrome = createFakeChrome();
+  vi.stubGlobal("chrome", fakeChrome);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+function deferGet(): (value: Record<string, unknown>) => void {
+  let resolveGet!: (value: Record<string, unknown>) => void;
+  fakeChrome.storage.sync.get = vi.fn(
+    () =>
+      new Promise<Record<string, unknown>>((resolve) => {
+        resolveGet = resolve;
+      }),
+  );
+  return (value) => resolveGet(value);
+}
+
+describe("useSyncedPreference", () => {
+  it("loads the stored value from storage.sync on mount", async () => {
+    await fakeChrome.storage.sync.set({ [KEY]: "stored-value" });
+
+    const { result } = await renderHook(() =>
+      useSyncedPreference(KEY, normalize, "default"),
+    );
+    await flushAsync();
+
+    expect(result.current[0]).toBe("stored-value");
+  });
+
+  it("keeps the default when storage.sync has no value", async () => {
+    const { result } = await renderHook(() =>
+      useSyncedPreference(KEY, normalize, "default"),
+    );
+    await flushAsync();
+
+    expect(result.current[0]).toBe("default");
+  });
+
+  it("does not write to storage.sync on mount, even under StrictMode", async () => {
+    const setSpy = vi.spyOn(fakeChrome.storage.sync, "set");
+
+    await renderHook(() => useSyncedPreference(KEY, normalize, "default"), {
+      strictMode: true,
+    });
+    await flushAsync();
+
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it("drops the initial load when the hook unmounts before it resolves", async () => {
+    const normalizeSpy = vi.fn(normalize);
+    const resolveGet = deferGet();
+
+    const { result, unmount } = await renderHook(() =>
+      useSyncedPreference(KEY, normalizeSpy, "default"),
+    );
+    expect(result.current[0]).toBe("default");
+    expect(normalizeSpy).not.toHaveBeenCalled();
+
+    await unmount();
+    resolveGet({ [KEY]: "late-value" });
+    await flushAsync();
+
+    // The cancelled guard short-circuits before normalize/setValue run.
+    expect(normalizeSpy).not.toHaveBeenCalled();
+  });
+
+  it("applies a cross-tab change from the sync area", async () => {
+    const { result } = await renderHook(() =>
+      useSyncedPreference(KEY, normalize, "default"),
+    );
+    await flushAsync();
+    expect(result.current[0]).toBe("default");
+
+    await act(async () => {
+      await fakeChrome.storage.sync.set({ [KEY]: "from-other-tab" });
+    });
+    await flushAsync();
+
+    expect(result.current[0]).toBe("from-other-tab");
+  });
+
+  it("ignores a change from a non-sync area", async () => {
+    const { result } = await renderHook(() =>
+      useSyncedPreference(KEY, normalize, "default"),
+    );
+    await flushAsync();
+
+    await act(async () => {
+      await fakeChrome.storage.local.set({ [KEY]: "local-only" });
+    });
+    await flushAsync();
+
+    expect(result.current[0]).toBe("default");
+  });
+
+  it("ignores a sync change for a different key", async () => {
+    const { result } = await renderHook(() =>
+      useSyncedPreference(KEY, normalize, "default"),
+    );
+    await flushAsync();
+
+    await act(async () => {
+      await fakeChrome.storage.sync.set({ "totem:other-pref": "unrelated" });
+    });
+    await flushAsync();
+
+    expect(result.current[0]).toBe("default");
+  });
+
+  it("swallows a rejected storage.sync.set and keeps the optimistic value", async () => {
+    fakeChrome.storage.sync.set = vi
+      .fn()
+      .mockRejectedValue(new Error("quota exceeded"));
+
+    const { result } = await renderHook(() =>
+      useSyncedPreference(KEY, normalize, "default"),
+    );
+    await flushAsync();
+
+    await act(async () => {
+      result.current[1]("optimistic");
+    });
+    await flushAsync();
+
+    expect(result.current[0]).toBe("optimistic");
+    expect(fakeChrome.storage.sync.set).toHaveBeenCalledWith({
+      [KEY]: "optimistic",
+    });
+  });
+
+  it("is a no-op writer when storage.sync is unavailable", async () => {
+    vi.stubGlobal("chrome", { storage: {} });
+    expect(hasChromeStorageSync()).toBe(false);
+
+    const { result } = await renderHook(() =>
+      useSyncedPreference(KEY, normalize, "default"),
+    );
+    await flushAsync();
+    expect(result.current[0]).toBe("default");
+
+    // Setting still updates local state without throwing on the missing area.
+    await act(async () => {
+      result.current[1]("local-only");
+    });
+    await flushAsync();
+
+    expect(result.current[0]).toBe("local-only");
+  });
+});
+
+describe("useSyncedPreference consumers — skipInitialLoad", () => {
+  it("useSettings keeps a user patch made before the initial load resolves", async () => {
+    const resolveGet = deferGet();
+
+    const { result } = await renderHook(() => useSettings());
+    await act(async () => {
+      result.current.updateSettings({ showSearchBar: false });
+    });
+
+    resolveGet({ [SYNC_SETTINGS]: { showSearchBar: true } });
+    await flushAsync();
+
+    expect(result.current.settings.showSearchBar).toBe(false);
+  });
+
+  it("useTheme keeps a theme chosen before the initial load resolves", async () => {
+    const resolveGet = deferGet();
+
+    const { result } = await renderHook(() => useTheme());
+    await act(async () => {
+      result.current.setThemePreference("dark");
+    });
+
+    resolveGet({ [SYNC_THEME]: "light" });
+    await flushAsync();
+
+    expect(result.current.themePreference).toBe("dark");
+  });
+});

--- a/src/hooks/__tests__/useTodayQueue-sweep.test.ts
+++ b/src/hooks/__tests__/useTodayQueue-sweep.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AccountDb } from "../../db";
+import type { TodayQueueBudgetMinutes } from "../../types";
+import { flushAsync, renderHook } from "../../test-utils/render-hook";
+
+// useTodayQueue resolves its DB handle through useAccountDb(); the per-account
+// sweep dedup (module-scoped sweptAccountIds) and the account-switch behaviour
+// can only be exercised by driving that handle. hoisted() keeps the registry
+// reachable from the (hoisted) vi.mock factory.
+const harness = vi.hoisted(() => {
+  type FakeDb = {
+    getTodayQueueSnapshot: ReturnType<typeof vi.fn>;
+    getAllQueueBookmarkMetadata: ReturnType<typeof vi.fn>;
+    getTodayQueueExposuresSince: ReturnType<typeof vi.fn>;
+    sweepStaleTodayQueueSnapshots: ReturnType<typeof vi.fn>;
+  };
+  const dbHandles = new Map<string, FakeDb>();
+  const state: { activeAccount: string | null } = { activeAccount: null };
+
+  function getFakeDb(accountId: string | null): FakeDb {
+    const key = accountId ?? "local";
+    let handle = dbHandles.get(key);
+    if (!handle) {
+      handle = {
+        getTodayQueueSnapshot: vi.fn(async () => null),
+        getAllQueueBookmarkMetadata: vi.fn(async () => []),
+        getTodayQueueExposuresSince: vi.fn(async () => []),
+        sweepStaleTodayQueueSnapshots: vi.fn(async () => undefined),
+      };
+      dbHandles.set(key, handle);
+    }
+    return handle;
+  }
+
+  return { getFakeDb, state };
+});
+
+vi.mock("../../stores/selectors", () => ({
+  useAccountDb: () =>
+    harness.getFakeDb(harness.state.activeAccount) as unknown as AccountDb,
+}));
+
+import { useTodayQueue } from "../useTodayQueue";
+
+// Empty bookmarks short-circuit refresh() before any queue build, so the four
+// stubbed methods above are all the hook touches besides the sweep.
+function input(accountId: string | null) {
+  return {
+    enabled: true,
+    accountId,
+    bookmarks: [],
+    readingProgress: [],
+    detailedTweetIds: new Set<string>(),
+    budgetMinutes: 15 as TodayQueueBudgetMinutes,
+    restrictToCachedDetails: false,
+  };
+}
+
+function activate(accountId: string | null) {
+  harness.state.activeAccount = accountId;
+}
+
+function sweepSpy(accountId: string | null) {
+  return harness.getFakeDb(accountId).sweepStaleTodayQueueSnapshots;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// sweptAccountIds in the hook module is page-load-scoped and never reset across
+// tests, so every case uses a distinct accountId to stay independent.
+describe("useTodayQueue stale-snapshot sweep wiring", () => {
+  it("sweeps an account's per-account DB exactly once per page load", async () => {
+    const account = "acc-62-dedup";
+    activate(account);
+
+    const { rerender, unmount } = await renderHook(
+      (props: ReturnType<typeof input>) => useTodayQueue(props),
+      { initialProps: input(account) },
+    );
+    await flushAsync();
+    expect(sweepSpy(account)).toHaveBeenCalledTimes(1);
+
+    // A re-render with the same account must not sweep again.
+    await rerender(input(account));
+    await flushAsync();
+    expect(sweepSpy(account)).toHaveBeenCalledTimes(1);
+
+    // Nor a fresh mount of the hook for the same account in the same page load.
+    await unmount();
+    activate(account);
+    await renderHook(
+      (props: ReturnType<typeof input>) => useTodayQueue(props),
+      { initialProps: input(account) },
+    );
+    await flushAsync();
+    expect(sweepSpy(account)).toHaveBeenCalledTimes(1);
+  });
+
+  it("sweeps the newly-active account's DB after an in-session account switch", async () => {
+    const first = "acc-62-switch-1";
+    const second = "acc-62-switch-2";
+
+    activate(first);
+    const { rerender } = await renderHook(
+      (props: ReturnType<typeof input>) => useTodayQueue(props),
+      { initialProps: input(first) },
+    );
+    await flushAsync();
+    expect(sweepSpy(first)).toHaveBeenCalledTimes(1);
+    expect(sweepSpy(second)).not.toHaveBeenCalled();
+
+    activate(second);
+    await rerender(input(second));
+    await flushAsync();
+    // The switch sweeps the second account's distinct handle, not the first's.
+    expect(sweepSpy(second)).toHaveBeenCalledTimes(1);
+    expect(sweepSpy(first)).toHaveBeenCalledTimes(1);
+  });
+
+  it("sweeps the local DB when accountId is null", async () => {
+    activate(null);
+    await renderHook(
+      (props: ReturnType<typeof input>) => useTodayQueue(props),
+      { initialProps: input(null) },
+    );
+    await flushAsync();
+    expect(sweepSpy(null)).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not sweep while the queue is disabled", async () => {
+    const account = "acc-62-disabled";
+    activate(account);
+    await renderHook(
+      (props: ReturnType<typeof input>) => useTodayQueue(props),
+      { initialProps: { ...input(account), enabled: false } },
+    );
+    await flushAsync();
+    expect(sweepSpy(account)).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useSyncedPreference.ts
+++ b/src/hooks/useSyncedPreference.ts
@@ -17,6 +17,16 @@ export function useSyncedPreference<T>(
 ): [T, SetSyncedValue<T>] {
   const [value, setValue] = useState<T>(defaultValue);
 
+  // Mirrors the latest value so setSyncedValue can resolve a functional update
+  // and persist OUTSIDE the setState updater. Keeping the updater pure (a plain
+  // value, no side effect) stops React's StrictMode / concurrent double-invoke
+  // from firing chrome.storage.sync.set twice for a single set.
+  const valueRef = useRef(value);
+  const applyValue = (next: T) => {
+    valueRef.current = next;
+    setValue(next);
+  };
+
   const normalizeRef = useRef(normalize);
   normalizeRef.current = normalize;
   const skipInitialLoadRef = useRef(options.skipInitialLoad);
@@ -31,7 +41,7 @@ export function useSyncedPreference<T>(
       try {
         const stored = await chrome.storage.sync.get({ [key]: defaultValue });
         if (!cancelled && !skipInitialLoadRef.current?.()) {
-          setValue(normalizeRef.current(stored[key]));
+          applyValue(normalizeRef.current(stored[key]));
         }
       } catch {}
     };
@@ -53,7 +63,7 @@ export function useSyncedPreference<T>(
       if (areaName !== "sync") return;
       const change = changes[key];
       if (!change) return;
-      setValue(normalizeRef.current(change.newValue));
+      applyValue(normalizeRef.current(change.newValue));
     };
 
     chrome.storage.onChanged.addListener(onStorageChange);
@@ -61,14 +71,14 @@ export function useSyncedPreference<T>(
   }, [key]);
 
   const setSyncedValue: SetSyncedValue<T> = (next) => {
-    setValue((prev) => {
-      const resolved =
-        typeof next === "function" ? (next as (prev: T) => T)(prev) : next;
-      if (hasChromeStorageSync()) {
-        chrome.storage.sync.set({ [key]: resolved }).catch(() => {});
-      }
-      return resolved;
-    });
+    const resolved =
+      typeof next === "function"
+        ? (next as (prev: T) => T)(valueRef.current)
+        : next;
+    applyValue(resolved);
+    if (hasChromeStorageSync()) {
+      chrome.storage.sync.set({ [key]: resolved }).catch(() => {});
+    }
   };
 
   return [value, setSyncedValue];

--- a/src/hooks/useTheme.ts
+++ b/src/hooks/useTheme.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { SYNC_THEME } from "../lib/storage-keys";
 import { useSyncedPreference } from "./useSyncedPreference";
 
@@ -21,12 +21,22 @@ function normalizeThemePreference(value: unknown): ThemePreference {
 }
 
 export function useTheme() {
-  const [themePreference, setThemePreference] =
+  // Mirrors useSettings: once the user picks a theme, a slower initial
+  // storage.sync load must not clobber that choice when it resolves.
+  const userPatchedRef = useRef(false);
+  const [themePreference, setSyncedThemePreference] =
     useSyncedPreference<ThemePreference>(
       SYNC_THEME,
       normalizeThemePreference,
       "system",
+      { skipInitialLoad: () => userPatchedRef.current },
     );
+  const setThemePreference = (
+    next: ThemePreference | ((prev: ThemePreference) => ThemePreference),
+  ) => {
+    userPatchedRef.current = true;
+    setSyncedThemePreference(next);
+  };
   const [systemTheme, setSystemTheme] = useState<ResolvedTheme>(() => getSystemTheme());
   const resolvedTheme: ResolvedTheme =
     themePreference === "system" ? systemTheme : themePreference;

--- a/src/hooks/useTodayQueue.ts
+++ b/src/hooks/useTodayQueue.ts
@@ -70,6 +70,8 @@ export interface UseTodayQueueResult {
   // True only in the done-state: at least one eligible saved post remains for a
   // calm "Two more". When false in the done-state the archive is exhausted today.
   canAddMore: boolean;
+  // True while addTwoMore is appending, so the button can show a pending state.
+  isAddingMore: boolean;
   refresh: () => void;
   addToTodayQueue: (tweetId: string) => Promise<void>;
   addTwoMore: () => Promise<void>;
@@ -150,6 +152,10 @@ export function useTodayQueue({
   // and each rolls the RNG independently — appending up to four items instead of
   // two and rolling randomness twice.
   const addingMoreRef = useRef(false);
+  // Reactive mirror of addingMoreRef so the done-state can disable the "Two more"
+  // button and show a pending label while the append runs (the ref alone can't
+  // drive a re-render).
+  const [isAddingMore, setIsAddingMore] = useState(false);
 
   const refresh = useCallback(() => {
     const requestId = ++refreshSeqRef.current;
@@ -528,6 +534,7 @@ export function useTodayQueue({
   const addTwoMore = useCallback(async () => {
     if (!state.snapshot || addingMoreRef.current) return;
     addingMoreRef.current = true;
+    setIsAddingMore(true);
     try {
       const localDate = state.localDate || formatLocalDate();
       const ids = pickAdditionalTodayReadItems({
@@ -549,6 +556,7 @@ export function useTodayQueue({
       }
     } finally {
       addingMoreRef.current = false;
+      setIsAddingMore(false);
     }
   }, [
     accountId,
@@ -577,6 +585,7 @@ export function useTodayQueue({
     completedCount,
     isDone,
     canAddMore,
+    isAddingMore,
     refresh,
     addToTodayQueue,
     addTwoMore,

--- a/src/lib/constants/ui.ts
+++ b/src/lib/constants/ui.ts
@@ -19,4 +19,5 @@ export const TODAY_QUEUE_DONE_MESSAGE =
 // repeatable; no streak, counter, or momentum language (done is always the
 // headline). When the safe pool is empty the control retires for the day.
 export const TODAY_QUEUE_TWO_MORE_LABEL = "Two more";
+export const TODAY_QUEUE_TWO_MORE_PENDING = "Adding…";
 export const TODAY_QUEUE_TWO_MORE_EXHAUSTED = "Nothing else to add today.";

--- a/src/lib/export/__tests__/article-render-golden.test.ts
+++ b/src/lib/export/__tests__/article-render-golden.test.ts
@@ -99,7 +99,60 @@ const headingChunksArticle: ArticleContent = {
   coverImageUrl: "",
 };
 
+function videoBlockArticle(
+  title: string,
+  data: Record<string, unknown>,
+): ArticleContent {
+  return {
+    title,
+    plainText: "ignored when blocks present",
+    coverImageUrl: "",
+    entityMap: { "0": { type: "MEDIA", data } },
+    contentBlocks: [
+      {
+        type: "atomic",
+        text: " ",
+        inlineStyleRanges: [],
+        entityRanges: [{ offset: 0, length: 1, key: 0 }],
+        depth: 0,
+      },
+    ],
+  };
+}
+
+const VIDEO_NO_SOURCE_FALLBACK =
+  "*Video — open the source URL in the front matter on X.*";
+
 describe("article render golden", () => {
+  // The blocks-path golden above always supplies a postUrl, so the markdown
+  // emitter's video-without-source fallback (the else branch of mediaVideo) is
+  // only covered here. C9 — see issue #63.
+  it("markdown — video block without a source URL emits the front-matter fallback", () => {
+    expect(
+      articleToMarkdown(
+        videoBlockArticle("Video Without Source", {
+          videoUrl: "https://video.example.com/clip.mp4",
+        }),
+        { includeCoverImage: false },
+      ),
+    ).toBe(`# Video Without Source\n\n${VIDEO_NO_SOURCE_FALLBACK}\n`);
+  });
+
+  it("markdown — video without a source keeps the poster preview above the fallback", () => {
+    const markdown = articleToMarkdown(
+      videoBlockArticle("Video With Poster", {
+        videoUrl: "https://video.example.com/clip.mp4",
+        imageUrl: "https://img.example.com/poster.jpg",
+      }),
+      { includeCoverImage: false },
+    );
+    expect(markdown).toContain(
+      "![Video preview](https://img.example.com/poster.jpg)",
+    );
+    expect(markdown).toContain(VIDEO_NO_SOURCE_FALLBACK);
+    expect(markdown).not.toContain("Watch on X");
+  });
+
   it("markdown — blocks path (all block types + title skip + metadata + cover)", () => {
     expect(
       articleToMarkdown(blocksArticle, { metadata: blocksMetadata }),

--- a/src/test-utils/fake-chrome.ts
+++ b/src/test-utils/fake-chrome.ts
@@ -14,6 +14,13 @@ type StorageChangeCallback = (
   changes: Record<string, StorageChange>,
 ) => void;
 
+type GlobalStorageChangeCallback = (
+  changes: Record<string, StorageChange>,
+  areaName: string,
+) => void;
+
+type GetKeys = string | string[] | Record<string, unknown> | null | undefined;
+
 type MessageCallback = (
   message: unknown,
   sender: { id?: string },
@@ -21,20 +28,46 @@ type MessageCallback = (
 ) => boolean | void;
 
 export function createFakeChrome() {
-  // Storage
-  let storageData: StorageData = {};
-  const storageChangeListeners: StorageChangeCallback[] = [];
+  // Storage. Each area is independent; mutations notify the area's own
+  // onChanged listeners (single-arg) and the global chrome.storage.onChanged
+  // listeners (with areaName), matching the real extension API.
+  const globalStorageChangeListeners: GlobalStorageChangeCallback[] = [];
 
-  const storage = {
-    local: {
-      async get(keys?: string | string[] | null): Promise<StorageData> {
-        if (!keys) return { ...storageData };
-        const keyList = typeof keys === "string" ? [keys] : keys;
-        const result: StorageData = {};
-        for (const key of keyList) {
-          if (key in storageData) {
-            result[key] = storageData[key];
+  function notifyGlobal(
+    changes: Record<string, StorageChange>,
+    areaName: string,
+  ) {
+    for (const listener of globalStorageChangeListeners) {
+      listener(changes, areaName);
+    }
+  }
+
+  function createStorageArea(areaName: string) {
+    let data: StorageData = {};
+    const areaListeners: StorageChangeCallback[] = [];
+
+    function emit(changes: Record<string, StorageChange>) {
+      for (const listener of areaListeners) listener(changes);
+      notifyGlobal(changes, areaName);
+    }
+
+    const area = {
+      async get(keys?: GetKeys): Promise<StorageData> {
+        if (keys === undefined || keys === null) return { ...data };
+        if (typeof keys === "string") {
+          return keys in data ? { [keys]: data[keys] } : {};
+        }
+        if (Array.isArray(keys)) {
+          const result: StorageData = {};
+          for (const key of keys) {
+            if (key in data) result[key] = data[key];
           }
+          return result;
+        }
+        // Object form: each value is the default returned when the key is absent.
+        const result: StorageData = {};
+        for (const [key, fallback] of Object.entries(keys)) {
+          result[key] = key in data ? data[key] : fallback;
         }
         return result;
       },
@@ -42,38 +75,56 @@ export function createFakeChrome() {
       async set(items: StorageData): Promise<void> {
         const changes: Record<string, StorageChange> = {};
         for (const [key, value] of Object.entries(items)) {
-          changes[key] = { oldValue: storageData[key], newValue: value };
-          storageData[key] = value;
+          changes[key] = { oldValue: data[key], newValue: value };
+          data[key] = value;
         }
-        for (const listener of storageChangeListeners) {
-          listener(changes);
-        }
+        emit(changes);
       },
 
       async remove(keys: string | string[]): Promise<void> {
         const keyList = typeof keys === "string" ? [keys] : keys;
         const changes: Record<string, StorageChange> = {};
         for (const key of keyList) {
-          if (key in storageData) {
-            changes[key] = { oldValue: storageData[key], newValue: undefined };
-            delete storageData[key];
+          if (key in data) {
+            changes[key] = { oldValue: data[key], newValue: undefined };
+            delete data[key];
           }
         }
-        if (Object.keys(changes).length > 0) {
-          for (const listener of storageChangeListeners) {
-            listener(changes);
-          }
-        }
+        if (Object.keys(changes).length > 0) emit(changes);
       },
 
       onChanged: {
         addListener(fn: StorageChangeCallback) {
-          storageChangeListeners.push(fn);
+          areaListeners.push(fn);
         },
         removeListener(fn: StorageChangeCallback) {
-          const idx = storageChangeListeners.indexOf(fn);
-          if (idx >= 0) storageChangeListeners.splice(idx, 1);
+          const idx = areaListeners.indexOf(fn);
+          if (idx >= 0) areaListeners.splice(idx, 1);
         },
+      },
+    };
+
+    function reset() {
+      data = {};
+      areaListeners.length = 0;
+    }
+
+    return { area, reset };
+  }
+
+  const local = createStorageArea("local");
+  const sync = createStorageArea("sync");
+
+  const storage = {
+    local: local.area,
+    sync: sync.area,
+    onChanged: {
+      addListener(fn: GlobalStorageChangeCallback) {
+        globalStorageChangeListeners.push(fn);
+      },
+      removeListener(fn: GlobalStorageChangeCallback) {
+        const idx = globalStorageChangeListeners.indexOf(fn);
+        if (idx >= 0) globalStorageChangeListeners.splice(idx, 1);
       },
     },
   };
@@ -148,8 +199,9 @@ export function createFakeChrome() {
 
   // Reset all state for test isolation
   function reset() {
-    storageData = {};
-    storageChangeListeners.length = 0;
+    local.reset();
+    sync.reset();
+    globalStorageChangeListeners.length = 0;
     messageListeners.length = 0;
     tabIdCounter = 1;
     tabRemoveListeners.length = 0;

--- a/src/test-utils/render-hook.ts
+++ b/src/test-utils/render-hook.ts
@@ -1,0 +1,78 @@
+/**
+ * Minimal hook renderer for jsdom-environment tests — drives a hook through a
+ * throwaway component with React's own act(), no external testing library.
+ * Use under `// @vitest-environment jsdom`.
+ */
+import { act, createElement, StrictMode, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+export { act };
+
+// React's act() refuses to run unless the environment opts in.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+export interface RenderHookOptions<TProps> {
+  initialProps?: TProps;
+  // Wrap the harness in <StrictMode> to surface double-invoked effects.
+  strictMode?: boolean;
+}
+
+export interface RenderHookResult<TResult, TProps> {
+  result: { current: TResult };
+  rerender: (props?: TProps) => Promise<void>;
+  unmount: () => Promise<void>;
+}
+
+export async function renderHook<TResult, TProps = void>(
+  callback: (props: TProps) => TResult,
+  options: RenderHookOptions<TProps> = {},
+): Promise<RenderHookResult<TResult, TProps>> {
+  const container = document.createElement("div");
+  const result = { current: undefined as unknown as TResult };
+  let currentProps = options.initialProps as TProps;
+  let root!: Root;
+
+  function Harness({ hookProps }: { hookProps: TProps }): ReactNode {
+    result.current = callback(hookProps);
+    return null;
+  }
+
+  const renderTree = () => {
+    const element = createElement(Harness, { hookProps: currentProps });
+    root.render(
+      options.strictMode ? createElement(StrictMode, null, element) : element,
+    );
+  };
+
+  await act(async () => {
+    root = createRoot(container);
+    renderTree();
+  });
+
+  return {
+    result,
+    async rerender(props?: TProps) {
+      if (arguments.length > 0) currentProps = props as TProps;
+      await act(async () => {
+        renderTree();
+      });
+    },
+    async unmount() {
+      await act(async () => {
+        root.unmount();
+      });
+    },
+  };
+}
+
+/**
+ * Flush pending promise microtasks and any React work they schedule (e.g. an
+ * async effect that resolves and then calls setState). Wrapped in act() so the
+ * resulting re-render is applied before assertions run.
+ */
+export async function flushAsync(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}


### PR DESCRIPTION
Closes #64. Closes #63. Closes #62. Closes #61.

The deferred low-severity nits surfaced by the #58/#59 deep review, done one issue at a time. Each commit maps to one issue; a final commit addresses an adversarial self-review of the branch.

## #64 — polish: minor nits
- **`useTheme` `skipInitialLoad` parity** — `useTheme` now passes `skipInitialLoad` to `useSyncedPreference` and flags `userPatchedRef` on set, mirroring `useSettings`, so a slower initial `storage.sync` load can't clobber a theme the user just chose.
- **"Two more" in-flight feedback** — `useTodayQueue` exposes a reactive `isAddingMore`; the done-state button in both `BookmarksList` and `NewTabHome` now disables, sets `aria-busy`, and shows an "Adding…" label while the append runs.
- **Single-cursor sweep** — `sweepStaleTodayQueueSnapshots` deletes every stale key in one readwrite transaction (one commit, one reader-activity emit) instead of one transaction per key.
- **`useTheme` StrictMode double-write** — the *mount-time* write was already removed by the C10 refactor (`32f5b86b`). The adversarial review then found a **still-live** manifestation: `setSyncedValue` wrote `chrome.storage.sync.set` *inside* the `setValue` updater, which React double-invokes under StrictMode — so a single set persisted twice. Fixed by moving the write out of the (now pure) updater and resolving functional updates from a `valueRef`. Locked by a new test.

## #63 — test: markdown video-without-source fallback (C9)
The blocks-path golden always supplied a `postUrl`, so the markdown emitter's `mediaVideo` else branch (the `*Video — open the source URL in the front matter on X.*` fallback) was never asserted. Added two golden cases: a bare video block (fallback only) and a video with a poster but no source (poster preview kept above the fallback, no "Watch on X" link).

## #61 — test: synced-preference hooks lifecycle (C10)
First hook-lifecycle coverage for `useSyncedPreference` and its consumers: platform guard, cancelled-flag race on unmount mid-load, the `onChanged` (sync-area + key) listener, swallow-on-fail set, no write on mount, and `skipInitialLoad` for both `useSettings` and `useTheme`.

Every behavioural assertion is **mutation-verified** — each fails when its guard is regressed. (The first cut of three of these tests was tautological; the final commit reworks them after an adversarial review caught that.)

**Test infrastructure introduced here:**
- `fake-chrome` extended with a `sync` storage area and a global `chrome.storage.onChanged` that fires `(changes, areaName)`, matching the real API (the `local` area keeps its existing single-arg `onChanged`).
- a minimal `renderHook`/`act`/`flushAsync` helper using React's own `act` under jsdom — no new testing framework.
- `jsdom` added as the DOM environment, opted into per-file via `// @vitest-environment jsdom`, so the default node environment (and the existing `vi.stubGlobal` tests) is unchanged.

## #62 — test: per-account stale-snapshot sweep dedup wiring
Exercises the riskiest, previously-untested sweep behaviour: swept exactly once per account per page load (re-render + remount dedup via the module-scoped `sweptAccountIds`), an in-session account switch sweeps the newly-active account's distinct DB handle, null `accountId` sweeps the `local` DB, and a disabled queue doesn't sweep.

## Verification
- `pnpm typecheck` — clean
- `pnpm test` — 735 passing (62 files; +22 new tests), full suite re-run after each issue
- `pnpm build:extension` — builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
